### PR TITLE
Allow http:// requests to controller

### DIFF
--- a/projects/ziti-console-lib/src/lib/services/settings.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/settings.service.ts
@@ -89,7 +89,7 @@ export class SettingsService extends SettingsServiceClass {
     override controllerSave(name: string, url: string) {
         url = url.split('#').join('').split('?').join('');
         if (url.endsWith('/')) url = url.substr(0, url.length - 1);
-        if (!url.startsWith('https://')) url = 'https://' + url;
+        if (!url.startsWith('https://') && !url.startsWith('http://')) url = 'https://' + url;
         const callUrl = url + "/edge/management/v1/version?rejectUnauthorized=" + this.rejectUnauthorized;
         firstValueFrom(this.httpClient.get(callUrl).pipe(catchError((err: any) => {
             throw "Edge Controller not Online: " + err?.message;
@@ -139,7 +139,7 @@ export class SettingsService extends SettingsServiceClass {
     public initApiVersions(url: string) {
         url = url.split('#').join('').split('?').join('');
         if (url.endsWith('/')) url = url.substr(0, url.length - 1);
-        if (!url.startsWith('https://')) url = 'https://' + url;
+        if (!url.startsWith('https://') && !url.startsWith('http://')) url = 'https://' + url;
         const callUrl = url + "/edge/management/v1/version?rejectUnauthorized=false";
         return firstValueFrom(this.httpClient.get(callUrl)
             .pipe(

--- a/server-edge.js
+++ b/server-edge.js
@@ -4,7 +4,7 @@ import cors from 'cors';
 import bodyParser from 'body-parser';
 
 const app = express();
-const startupPort = process.env.PORT || 1408;
+const port = process.env.PORT || 1408;
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended:false}));
@@ -37,15 +37,20 @@ app.use(helmet(helmetOptions));
 app.use('/', express.static('dist/app-ziti-console'));
 app.use('/:name', express.static('dist/app-ziti-console'));
 
-app.listen(startupPort, function() {
-    console.log("Ziti Admin Console is now listening on port "+startupPort);
-}).on('error', function(err) {
-    if (err.code=="EADDRINUSE") {
-        maxAttempts--;
-        console.log("Port "+startupPort+" In Use, Attempting new port "+(startupPort+1));
-        startupPort++;
-        if (maxAttempts>0) StartServer(startupPort);
-    } else {
-        console.log("All Ports in use "+port+" to "+startupPort);
-    }
-});
+let maxAttempts = 100;
+StartServer(port);
+
+function StartServer(startupPort) {
+    app.listen(startupPort, function() {
+        console.log("Ziti Admin Console is now listening on port "+startupPort);
+    }).on('error', function(err) {
+        if (err.code=="EADDRINUSE") {
+            maxAttempts--;
+            console.log("Port "+startupPort+" In Use, Attempting new port "+(startupPort+1));
+            startupPort++;
+            if (maxAttempts>0) StartServer(startupPort);
+        } else {
+            console.log("All Ports in use "+port+" to "+startupPort);
+        }
+    });
+}


### PR DESCRIPTION
Allow users to specify `http://` protocol for an edge controller on login page