### PR TITLE
New Services List Page & Create/Edit Screen

### DIFF
--- a/projects/app-ziti-console/src/app/app.module.ts
+++ b/projects/app-ziti-console/src/app/app.module.ts
@@ -46,6 +46,7 @@ import {
     DEACTIVATE_GUARD,
     ZAC_LOGIN_SERVICE,
     EDGE_ROUTER_EXTENSION_SERVICE,
+    SERVICE_EXTENSION_SERVICE,
     ExtensionsNoopService
 } from "ziti-console-lib";
 
@@ -111,6 +112,7 @@ if (environment.nodeIntegration) {
         {provide: ZAC_LOGIN_SERVICE, useClass: loginService},
         {provide: SETTINGS_SERVICE, useClass: settingsService},
         {provide: EDGE_ROUTER_EXTENSION_SERVICE, useClass: ExtensionsNoopService},
+        {provide: SERVICE_EXTENSION_SERVICE, useClass: ExtensionsNoopService},
     ],
     bootstrap: [AppComponent]
 })

--- a/projects/ziti-console-lib/src/lib/assets/html/config-types.htm
+++ b/projects/ziti-console-lib/src/lib/assets/html/config-types.htm
@@ -146,6 +146,7 @@
                     page.apiParams.autoFormatRange({line:0, ch:0}, {line:page.apiParams.lineCount()});
                     page.apiParams.scrollTo(null, 0);
                     $("#AddModal").scrollTop(stayAt);
+                    return obj;
                 } catch (e) {
                     console.log(e);
                 }

--- a/projects/ziti-console-lib/src/lib/assets/styles/ziti.css
+++ b/projects/ziti-console-lib/src/lib/assets/styles/ziti.css
@@ -2,7 +2,7 @@
  ** Main Application Styles
 ***/
 body {
-    --highlighted: #f5a93d;;
+    --highlighted: #f5a93d;
     --red: #ff104b;
     --green: #00db48;
     --white: #FFF;

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/checkbox-list/checkbox-list-input.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/checkbox-list/checkbox-list-input.component.ts
@@ -1,6 +1,22 @@
+/*
+    Copyright NetFoundry Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {Subject} from "rxjs";
-import {debounce} from "lodash";
+import {defer, isEmpty} from "lodash";
 
 @Component({
   selector: 'lib-checkbox-list-input',
@@ -11,7 +27,7 @@ import {debounce} from "lodash";
           <input type="checkbox"
               class="jsonEntry"
                  [ngClass]="{'error': error}"
-              [checked]="item.checked" (click)="item.checked=!item.checked;update();"/>
+              [checked]="item.checked" (click)="item.checked=!item.checked;updateFieldVal();"/>
           <span class="boxlabel">{{item.name}}</span>
       </div>
       <div *ngIf="error" class="error">{{error}}</div>
@@ -29,31 +45,58 @@ export class CheckboxListInputComponent {
   @Input() set fieldName(name: string) {
     this._fieldName = name;
     this._idName = name.replace(/\s/g, '').toLowerCase();
-  }  @Input() fieldValue: string[] = [];
+  }
+  _fieldValue: string[] = [];
+  @Input() set fieldValue(vals) {
+    this._fieldValue = vals;
+    this.updateCheckedItems();
+  }
+  get fieldValue():string [] {
+    return this._fieldValue;
+  }
   @Input() placeholder = '';
   @Input() parentage: string[] = [];
   @Input() set valueList(list: string[]) {
-    const items: any[] = [];
-    list.forEach(v => {
-      items.push ({name: v, checked: false});
-    });
-    this.items = items;
-}
+    this.updateCheckboxItems(list);
+  }
   @Input() labelColor = '#000000';
   @Input() fieldClass = '';
   @Input() error = '';
   @Output() fieldValueChange = new EventEmitter<string[]>();
   valueChange = new Subject<string[]> ();
 
-  update() {
-    debounce(() => {
-      this.fieldValue = [];
-      this.items.forEach(item => {
-        if(item.checked) this.fieldValue.push(item.name);
+  updateCheckedItems() {
+    if (isEmpty(this._fieldValue)) {
+      return;
+    }
+    this.items?.forEach((item) => {
+      let checked = false;
+      this._fieldValue?.forEach((val) => {
+        if (item.name === val) {
+          checked = true;
+        }
       });
-      this.fieldValueChange.emit(this.fieldValue);
-      this.valueChange.next(this.fieldValue);
-    }, 500)();
+      item.checked = checked;
+    });
+  }
+
+  updateCheckboxItems(list: string[]) {
+    const items: any[] = [];
+    list.forEach(v => {
+      items.push ({name: v, checked: false});
+    });
+    this.items = items;
+  }
+
+  updateFieldVal() {
+    defer(() => {
+      this._fieldValue = [];
+      this.items.forEach(item => {
+        if(item.checked) this._fieldValue.push(item.name);
+      });
+      this.fieldValueChange.emit(this._fieldValue);
+      this.valueChange.next(this._fieldValue);
+    });
   }
 }
 

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.component.html
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.component.html
@@ -1,0 +1,61 @@
+<div class="forwarding-config-container">
+    <lib-protocol-address-port-input
+        [showProtocol]="true"
+        [showAddress]="true"
+        [showHostName]="false"
+        [showPort]="true"
+        [disableProtocol]="disableProtocol"
+        [disableAddress]="disableAddress"
+        [disablePort]="disablePort"
+        [(protocol)]="protocol"
+        [(address)]="address"
+        [(port)]="port"
+    ></lib-protocol-address-port-input>
+    <div class="forwarding-config-toggles">
+        <lib-boolean-toggle-input
+                [fieldName]="'FORWARD PROTOCOL'"
+                [(fieldValue)]="forwardProtocol"
+                (fieldValueChange)="forwardProtocolToggled($event)"
+        >
+        </lib-boolean-toggle-input>
+        <lib-boolean-toggle-input
+                [fieldName]="'FORWARD ADDRESS'"
+                [(fieldValue)]="forwardAddress"
+                (fieldValueChange)="forwardAddressToggled($event)"
+        >
+        </lib-boolean-toggle-input>
+        <lib-boolean-toggle-input
+                [fieldName]="'FORWARD PORT'"
+                [(fieldValue)]="forwardPort"
+                (fieldValueChange)="forwardPortToggled($event)"
+        >
+        </lib-boolean-toggle-input>
+    </div>
+    <div class="forwarding-config-allowed-inputs">
+        <lib-checkbox-list-input
+            *ngIf="forwardProtocol"
+            [fieldName]="'ALLOWED PROTOCOLS'"
+            [valueList]="['tcp', 'udp']"
+            [(fieldValue)]="allowedProtocols"
+        >
+        </lib-checkbox-list-input>
+        <lib-text-list-input
+            *ngIf="forwardAddress"
+            [fieldName]="'ALLOWED ADDRESSES'"
+            [placeholder]="'10.10.0.0/24 domain.com'"
+            [(fieldValue)]="allowedAddresses"
+            [labelColor]="'#000000'"
+        >
+        </lib-text-list-input>
+        <lib-text-list-input
+            *ngIf="forwardPort"
+            [fieldName]="'ALLOWED PORT RANGES'"
+            [placeholder]="'80 120-125 443 8080'"
+            [(fieldValue)]="allowedPortRanges"
+            [labelColor]="'#000000'"
+            [fieldClass]="errors['allowedPortRanges'] ? 'error' : ''"
+            (fieldValueChange)="validatePortRanges()"
+        >
+        </lib-text-list-input>
+    </div>
+</div>

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.component.scss
@@ -1,0 +1,25 @@
+.forwarding-config-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+
+  .forwarding-config-toggles {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .forwarding-config-allowed-inputs {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  & * {
+    width: 100%;
+  }
+}

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.component.ts
@@ -1,0 +1,105 @@
+/*
+    Copyright NetFoundry Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {ForwardingConfigService} from "./forwarding-config.service";
+import {SchemaService} from "../../../services/schema.service";
+
+@Component({
+  selector: 'lib-forwarding-config',
+  templateUrl: './forwarding-config.component.html',
+  styleUrls: ['./forwarding-config.component.scss']
+})
+export class ForwardingConfigComponent {
+
+  @Input() protocol: string = 'tcp';
+  @Input() address: string = undefined;
+  @Input() port: number = undefined;
+  @Input() forwardProtocol = false;
+  @Input() forwardAddress = false;
+  @Input() forwardPort = false;
+  @Input() allowedAddresses: any = undefined;
+  @Input() allowedPortRanges: any = undefined;
+  @Input() allowedProtocols: any = undefined;
+  @Output() protocolChange: EventEmitter<string> = new EventEmitter<string>();
+  @Output() addressChange: EventEmitter<string> = new EventEmitter<string>();
+  @Output() portChange: EventEmitter<number> = new EventEmitter<number>();
+  @Output() forwardProtocolChange: EventEmitter<any> = new EventEmitter<any>();
+  @Output() forwardAddressChange: EventEmitter<any> = new EventEmitter<any>();
+  @Output() forwardPortChange: EventEmitter<any> = new EventEmitter<any>();
+  @Output() allowedAddressesChange: EventEmitter<any> = new EventEmitter<any>();
+  @Output() allowedPortRangesChange: EventEmitter<any> = new EventEmitter<any>();
+  @Output() allowedProtocolsChange: EventEmitter<any> = new EventEmitter<any>();
+
+  errors = {};
+  disableProtocol = false;
+  disableAddress = false;
+  disablePort = false;
+
+  constructor(private svc: ForwardingConfigService, private schemaSvc: SchemaService) {}
+
+  forwardProtocolToggled(event) {
+    if (!this.forwardProtocol) {
+      this.allowedProtocols = undefined;
+    } else {
+      this.protocol = undefined;
+    }
+    this.disableProtocol = this.forwardProtocol;
+  }
+
+  forwardAddressToggled(event) {
+    if (!this.forwardAddress) {
+      this.allowedAddresses = undefined;
+    } else {
+      this.address = undefined;
+    }
+    this.disableAddress = this.forwardAddress;
+  }
+
+  forwardPortToggled(event) {
+    if (!this.forwardPort) {
+      this.allowedPortRanges = undefined;
+    } else {
+      this.port = undefined;
+    }
+    this.disablePort = this.forwardPort;
+  }
+
+  setProperties(data: any) {
+    this.forwardPort = data.forwardPort;
+    this.forwardProtocol = data.forwardProtocol;
+    this.forwardAddress = data.forwardAddress;
+    this.protocol = data.protocol ? data.protocol : 'tcp';
+    this.address = data.address;
+    this.port = data.port;
+    this.allowedProtocols = data.allowedProtocols;
+    this.allowedAddresses = data.allowedAddresses;
+    this.setAllowedPortRanges(data.allowedPortRanges);
+    this.svc.validate(this.allowedPortRanges);
+  }
+
+  getProperties() {
+    return this.svc.getProperties(this.protocol, this.address, this.port, this.forwardProtocol, this.forwardAddress, this.forwardPort, this.allowedProtocols, this.allowedAddresses, this.allowedPortRanges);
+  }
+
+  validatePortRanges() {
+    this.errors['allowedPortRanges'] = this.schemaSvc.validatePortRanges(this.allowedPortRanges);
+  }
+
+  setAllowedPortRanges(ranges) {
+    this.allowedPortRanges = this.schemaSvc.parseAllowedPortRanges(ranges);
+  }
+}

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.service.ts
@@ -1,0 +1,46 @@
+/*
+    Copyright NetFoundry Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import {Injectable} from "@angular/core";
+import {SchemaService} from "../../../services/schema.service";
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ForwardingConfigService {
+
+    constructor(private schemaSvc: SchemaService) {}
+
+    getProperties(protocol, address, port, forwardProtocol, forwardAddress, forwardPort, allowedProtocols, allowedAddresses, allowedPortRanges) {
+        const props = [
+            {key: 'protocol', value: protocol},
+            {key: 'address', value: address},
+            {key: 'port', value: port},
+            {key: 'forwardProtocol', value: forwardProtocol ? forwardProtocol : undefined},
+            {key: 'forwardAddress', value: forwardAddress ? forwardAddress : undefined},
+            {key: 'forwardPort', value: forwardPort ? forwardPort : undefined},
+            {key: 'allowedAddresses', value: allowedAddresses},
+            {key: 'allowedPortRanges', value: this.schemaSvc.getPortRanges(allowedPortRanges)},
+            {key: 'allowedProtocols', value: allowedProtocols},
+        ];
+        return props;
+    }
+
+    validate(allowedPortRanges) {
+        const errors: any = {};
+        errors.allowedPortRanges = this.schemaSvc.validatePortRanges(allowedPortRanges);
+    }
+}

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/port-ranges/port-ranges.component.html
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/port-ranges/port-ranges.component.html
@@ -1,0 +1,13 @@
+<label>PORT RANGES</label>
+<p-chips
+        (onAdd)="validateConfig()"
+        (onRemove)="validateConfig()"
+        (keyup)="onKeyup($event)"
+        [(ngModel)]="fieldValue"
+        [allowDuplicate]="false"
+        [ngClass]="{ error: invalid }"
+        [placeholder]="'80 120-125 443 8080'"
+        [addOnBlur]="true"
+        separator=","
+>
+</p-chips>

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/port-ranges/port-ranges.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/port-ranges/port-ranges.component.ts
@@ -1,0 +1,91 @@
+/*
+    Copyright NetFoundry Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {isNumber} from 'lodash';
+import {SchemaService} from "../../../services/schema.service";
+
+@Component({
+  selector: 'lib-port-ranges',
+  templateUrl: './port-ranges.component.html',
+  styleUrls: ['./port-ranges.component.scss']
+})
+export class PortRangesComponent {
+
+  @Input() fieldValue: any = '';
+  @Output() fieldValueChanged: EventEmitter<any> = new EventEmitter<any>();
+  errors: any = {};
+  invalid: boolean = false;
+
+  constructor(private schemaSvc: SchemaService) {}
+
+  getProperties() {
+    if (!this.fieldValue) {
+      return [];
+    }
+    const ranges = this.schemaSvc.getPortRanges(this.fieldValue);
+    return [{key: 'portRanges', value: ranges}];
+  }
+
+  setProperties(ranges) {
+    if (!ranges) {
+      this.fieldValue = [];
+      return;
+    }
+
+    this.fieldValue = this.schemaSvc.parseAllowedPortRanges(ranges);
+  }
+
+  onKeyup(event: any) {
+    if (event.key === " ") {
+      event.preventDefault();
+      const element = event.target as HTMLElement;
+      element.blur();
+      element.focus();
+    }
+  }
+
+  validateConfig() {
+    if (!this.fieldValue) {
+      this.invalid = false;
+      return;
+    }
+    let invalid = false;
+    this.fieldValue.forEach((val: string) => {
+      const vals = val.split('-');
+      if (vals.length === 1) {
+        const port = parseInt(val);
+        if (isNaN(port)) {
+          invalid = true;
+          return;
+        }
+      } else if (vals.length === 2) {
+        const port1 = parseInt(vals[0]);
+        const port2 = parseInt(vals[1]);
+        if (isNaN(port1) || isNaN(port2)) {
+          invalid = true;
+          return;
+        } else if (port1 > port2) {
+          invalid = true;
+          return;
+        }
+      } else {
+        invalid = true;
+      }
+    });
+    this.invalid = invalid;
+  }
+}

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/protocol-address-port/protocol-address-port-input.component.html
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/protocol-address-port/protocol-address-port-input.component.html
@@ -1,20 +1,35 @@
-<div class="grid addressFull">
-    <div>
-        <lib-selector-input *ngIf="showProtocol" [fieldName]="protocolFieldName"
-                      [fieldValue]="protocolValue"
+<div class="grid {{className}}">
+    <div *ngIf="showProtocol" [ngClass]="{disabled: disableProtocol}">
+        <lib-selector-input [fieldName]="protocolFieldName"
+                      [(fieldValue)]="protocol"
                       [labelColor]="labelColor"
-                      (fieldValueChange)="protocolChange($event)"></lib-selector-input>
+                      [placeholder]="undefined"
+                      [valueList]="['tcp', 'udp']"
+                      (fieldValueChange)="update()"
+        ></lib-selector-input>
     </div>
-    <div>
-        <lib-string-input *ngIf="showAddress" [fieldName]="addressFieldName"
-                    [fieldValue]="addressValue"
+    <div *ngIf="showAddress" [ngClass]="{disabled: disableAddress}">
+        <lib-string-input [fieldName]="addressFieldName"
+                    [(fieldValue)]="address"
                     [labelColor]="labelColor"
-                    (fieldValueChange)="addressChange($event)"></lib-string-input>
+                    [placeholder]="'host.name'"
+                          (fieldValueChange)="update()"
+        ></lib-string-input>
     </div>
-    <div>
-        <lib-number-input *ngIf="showPort" [fieldName]="portFieldName"
-                    [fieldValue]="portValue"
+    <div *ngIf="showHostName" [ngClass]="{disabled: disableHostName}">
+        <lib-string-input [fieldName]="hostNameFieldName"
+                          [(fieldValue)]="hostName"
+                          [labelColor]="labelColor"
+                          [placeholder]="'host.name'"
+                          (fieldValueChange)="update()"
+        ></lib-string-input>
+    </div>
+    <div *ngIf="showPort" [ngClass]="{disabled: disablePort}">
+        <lib-number-input [fieldName]="portFieldName"
+                    [(fieldValue)]="port"
                     [labelColor]="labelColor"
-                    (fieldValueChange)="portChange($event)"></lib-number-input>
+                    [placeholder]="'0'"
+                    (fieldValueChange)="update()"
+        ></lib-number-input>
     </div>
 </div>

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/protocol-address-port/protocol-address-port-input.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/protocol-address-port/protocol-address-port-input.component.scss
@@ -2,9 +2,18 @@
 .grid {
     display: grid;
     grid-template-columns: auto;
-    grid-gap: 3px;
+    grid-gap: 10px;
 }
 
 .grid.addressFull {
     grid-template-columns: 75px auto 75px;
+
+    .disabled {
+        opacity: .5;
+        pointer-events: none;
+    }
+}
+
+.host-name-port {
+    grid-template-columns: auto 75px;
 }

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/protocol-address-port/protocol-address-port-input.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/protocol-address-port/protocol-address-port-input.component.ts
@@ -1,55 +1,102 @@
-import {Component, EventEmitter, Input, Output, ViewChild, ViewContainerRef} from '@angular/core';
+/*
+    Copyright NetFoundry Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import {Component, DoCheck, EventEmitter, Input, OnInit, Output, ViewChild, ViewContainerRef} from '@angular/core';
 import {Subject} from "rxjs";
-import {debounce} from "lodash";
+import _, {debounce, isEmpty, isNumber} from "lodash";
 
 @Component({
   selector: 'lib-protocol-address-port-input',
   templateUrl: './protocol-address-port-input.component.html',
   styleUrls: ['./protocol-address-port-input.component.scss']
 })
-export class ProtocolAddressPortInputComponent {
+export class ProtocolAddressPortInputComponent implements OnInit, DoCheck {
   @Input() protocolList: any;
   @Input() showProtocol = true;
   @Input() showAddress = true;
+  @Input() showHostName = true;
   @Input() showPort = true;
-  @Input() protocolValue: any;
-  @Input() addressValue: any;
-  @Input() portValue: any;
+  @Input() disableProtocol = false;
+  @Input() disableAddress = false;
+  @Input() disableHostName = false;
+  @Input() disablePort = false;
+  @Input() protocol: string;
+  @Input() address: string;
+  @Input() hostName: string;
+  @Input() port: number;
   @Input() parentage: string[] = [];
   @Input() labelColor = '#000000';
   @Input() labelPrefix = '';
   @Input() fieldClass = '';
   @Input() error = '';
-  @Output() fieldValueChange = new EventEmitter<any>();
+  @Output() fieldValueChange: EventEmitter<any> = new EventEmitter<any>();
+  @Output() portChange: EventEmitter<number> = new EventEmitter<number>();
+  @Output() addressChange: EventEmitter<string> = new EventEmitter<string>();
+  @Output() hostNameChange: EventEmitter<string> = new EventEmitter<string>();
+  @Output() protocolChange: EventEmitter<string> = new EventEmitter<string>();
   valueChange = new Subject<any> ();
 
   protocolFieldName = 'Protocol';
   addressFieldName = 'Address';
+  hostNameFieldName = 'Host Name';
   portFieldName = 'Port';
 
+  checkAddressDebounced = debounce(this.checkAddress, 100, {maxWait: 100, leading: true});
+  ngOnInit() {
+
+  }
+
+  ngDoCheck() {
+    this.checkAddressDebounced();
+  }
+
+  _addressChanged = false;
+  _prevAddress;
+  checkAddress() {
+    this._addressChanged = !_.isEqual(this._prevAddress, this.address);
+    this.addressChange.emit(this.address);
+  }
+
   update() {
-    debounce(() => {
-      const data: any = {};
-      if(this.showProtocol) data.protocol = this.protocolValue;
-      if(this.showAddress) data.protocol = this.addressValue;
-      if(this.showPort) data.protocol = this.portValue;
-      this.fieldValueChange.emit(data);
-      this.valueChange.next(data);
-    }, 500)();
+    this.portChange.emit(this.port);
+    this.addressChange.emit(this.address);
+    this.hostNameChange.emit(this.hostName);
+    this.protocolChange.emit(this.protocol);
   }
 
-  protocolChange(value: string) {
-    this.protocolValue = value;
-    this.update();
+  get className() {
+    let className = 'addressFull'
+    if (!this.showProtocol && (this.showHostName || this.showHostName) && (this.showPort)) {
+      className = 'host-name-port';
+    }
+    return className;
   }
 
-  addressChange(value: string) {
-    this.addressValue = value;
-    this.update();
-  }
+  getProperties() {
+    const protocol = isEmpty(this.protocol) ? undefined : this.protocol;
+    const address = isEmpty(this.address) ? undefined : this.address;
+    const hostname = isEmpty(this.hostName) ? undefined : this.hostName;
+    const port = !isNumber(this.port) ? undefined : this.port;
 
-  portChange(value: number | undefined) {
-    this.portValue = value;
-    this.update();
+    const props = [
+      {key: 'protocol', value: protocol},
+      {key: 'address', value: address},
+      {key: 'hostname', value: hostname},
+      {key: 'port', value: port}
+    ];
+    return props;
   }
 }

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/selector/selector-input.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/selector/selector-input.component.ts
@@ -11,7 +11,7 @@ import {debounce} from "lodash";
              class="jsonEntry"
               [ngClass]="{'error': error}"
              [(ngModel)]="fieldValue" (change)="selected()">
-          <option value="">{{placeholder}}</option>
+          <option value="" *ngIf="placeholder">{{placeholder}}</option>
         <ng-container *ngIf="!listIsObject">
           <option *ngFor="let name of _valueList" [value]="name">{{name}}</option>
         </ng-container>

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/text-list/text-list-input.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/text-list/text-list-input.component.ts
@@ -1,6 +1,22 @@
+/*
+    Copyright NetFoundry Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {Subject} from "rxjs";
-import {debounce} from "lodash";
+import {debounce, isEmpty} from "lodash";
 
 @Component({
   selector: 'lib-text-list-input',
@@ -8,11 +24,13 @@ import {debounce} from "lodash";
     <div [ngClass]="fieldClass">
       <label for="schema_{{parentage?parentage+'_':''}}{{_idName}}"  [ngStyle]="{'color': labelColor}">{{_fieldName}}</label>
       <p-chips id="schema_{{parentage?parentage+'_':''}}{{_idName}}"
-          (keyup)="onKeyup()"
+          (keyup)="onKeyup($event)"
           [(ngModel)]="fieldValue"
           [allowDuplicate]="false"
           [placeholder]="placeholder"
           [addOnBlur]="true"
+          [ngClass]="fieldClass" 
+          (onBlur)="emitEvents()"
           separator=",">
       </p-chips>
       <div *ngIf="error" class="error">{{error}}</div>
@@ -27,7 +45,18 @@ export class TextListInputComponent {
     this._fieldName = name;
     this._idName = name.replace(/\s/g, '').toLowerCase();
   }
-  @Input() fieldValue = '';
+
+  _fieldValue: any = '';
+  @Input('fieldValue')
+  set fieldValue(val) {
+    this._fieldValue = val;
+  }
+
+  get fieldValue() {
+    const val = isEmpty(this._fieldValue) ? undefined : this._fieldValue;
+    return val;
+  }
+
   @Input() placeholder = '';
   @Input() parentage: string[] = [];
   @Input() labelColor = '#000000';
@@ -36,7 +65,17 @@ export class TextListInputComponent {
   @Output() fieldValueChange = new EventEmitter<string>();
   valueChange = new Subject<string> ();
 
-  onKeyup() {
+  onKeyup(event: any) {
+    if (event.key === " ") {
+      event.preventDefault();
+      const element = event.target as HTMLElement;
+      element.blur();
+      element.focus();
+    }
+    this.emitEvents();
+  }
+
+  emitEvents() {
     debounce(() => {
       this.fieldValueChange.emit(this.fieldValue);
       this.valueChange.next(this.fieldValue);

--- a/projects/ziti-console-lib/src/lib/features/preview-list/preview-list.component.html
+++ b/projects/ziti-console-lib/src/lib/features/preview-list/preview-list.component.html
@@ -4,6 +4,7 @@
 
     <div class="text row">
         <div (click)="selected(name)" *ngFor="let name of names" [ngClass]="{ clickable: clickable }" class="listText">
+            <div *ngIf="allowRemove" class="icon-clear" (click)="remove(name)"></div>
             {{ name }}
         </div>
     </div>

--- a/projects/ziti-console-lib/src/lib/features/preview-list/preview-list.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/preview-list/preview-list.component.scss
@@ -47,7 +47,18 @@
     padding-left: 10px;
     padding-right: 10px;
     margin-bottom: 2px;
-    color: var(--primary)
+    color: var(--primary);
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 5px;
+
+    .icon-clear {
+        margin-top: 2px;
+        &:hover {
+            color: var(--background);
+        }
+    }
 }
 
 ::-webkit-scrollbar-thumb {

--- a/projects/ziti-console-lib/src/lib/features/preview-list/preview-list.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/preview-list/preview-list.component.ts
@@ -27,7 +27,9 @@ export class PreviewListComponent {
   @Input() public clickable = false;
   @Input() isLoading = false;
   @Input() allNames = [];
+  @Input() allowRemove = false
   @Output() itemSelected = new EventEmitter<string>();
+  @Output() itemRemoved = new EventEmitter<string>();
   public names = [];
   filterFor = '';
 
@@ -61,5 +63,9 @@ export class PreviewListComponent {
 
   selected(name: string) {
     if (this.clickable) this.itemSelected.emit(name);
+  }
+
+  remove(name) {
+    this.itemRemoved.emit(name);
   }
 }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.ts
@@ -36,10 +36,8 @@ export class EdgeRouterFormComponent extends ProjectableForm implements OnInit, 
   @Input() formData: any = {};
   @Input() edgeRouterRoleAttributes: any[] = [];
   @Output() close: EventEmitter<any> = new EventEmitter<any>();
-  @Output() dataChange: EventEmitter<any> = new EventEmitter<any>();
 
   formView = 'simple';
-  initData: any = {};
   isEditing = false;
   isLoading = false;
   servicesLoading = false;
@@ -75,7 +73,6 @@ export class EdgeRouterFormComponent extends ProjectableForm implements OnInit, 
       this.authPolicies = result;
     });
     this.initData = cloneDeep(this.formData);
-    this.watchData();
     this.extService.updateFormData(this.formData);
     this.subscription.add(
       this.extService.formDataChanged.subscribe((data) => {
@@ -85,6 +82,7 @@ export class EdgeRouterFormComponent extends ProjectableForm implements OnInit, 
         this.formData = data;
       })
     );
+    this.initData = cloneDeep(this.formData);
   }
 
   ngOnDestroy() {
@@ -178,28 +176,6 @@ export class EdgeRouterFormComponent extends ProjectableForm implements OnInit, 
     this.formData.noTraversal = !this.formData.noTraversal;
   }
 
-  closeModal(refresh = true, ignoreChanges = false): void {
-    if (!ignoreChanges && this._dataChange) {
-      const confirmed = confirm('You have unsaved changes. Do you want to leave this page and discard your changes or stay on this page?');
-      if (!confirmed) {
-        return;
-      }
-    }
-    this.close.emit({refresh: refresh});
-  }
-
   clear(): void {
-  }
-
-  _dataChange = false;
-  watchData() {
-    delay(() => {
-      const dataChange = !isEqual(this.initData, this.formData);
-      if (dataChange !== this._dataChange) {
-        this.dataChange.emit(dataChange);
-      }
-      this._dataChange = dataChange;
-      this.watchData();
-    }, 100);
   }
 }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/form-field-container/form-field-container.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/form-field-container/form-field-container.component.html
@@ -11,6 +11,7 @@
         </div>
         <span class="form-field-label" *ngIf="label">{{label}}</span>
         <span class="form-field-count" *ngIf="count || count === 0">{{count}}</span>
+        <div class="form-field-action save-button" *ngIf="action" (click)="actionClicked()">{{actionLabel}}</div>
         <div class="form-field-title-container title-container-2" *ngIf="title2">
             <span class="form-field-title title2">{{title2}}</span>
             <div

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/form-field-container/form-field-container.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/form-field-container/form-field-container.component.scss
@@ -88,4 +88,8 @@
             font-weight: 600;
         }
     }
+
+    .save-button {
+        text-wrap: nowrap;
+    }
 }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/form-field-container/form-field-container.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/form-field-container/form-field-container.component.ts
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-import {Component, Input} from '@angular/core';
+import {Component, Input, Output, EventEmitter} from '@angular/core';
 
 @Component({
   selector: 'lib-form-field-container',
@@ -30,9 +30,16 @@ export class FormFieldContainerComponent {
   @Input() helpText2: any = undefined;
   @Input() label: any = undefined;
   @Input() count: any = undefined;
+  @Input() action: any = undefined;
+  @Input() actionLabel: string;
   @Input() class = '';
   @Input() contentStyle: any = '';
   @Input() showHeader: any = true;
 
+  @Output() actionRequested: EventEmitter<any> = new EventEmitter<any>();
   constructor() {}
+
+  actionClicked() {
+    this.actionRequested.emit({action: this.action});
+  }
 }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
@@ -53,11 +53,9 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
   @Input() formData: any = {};
   @Input() identityRoleAttributes: any[] = [];
   @Output() close: EventEmitter<any> = new EventEmitter<any>();
-  @Output() dataChange: EventEmitter<any> = new EventEmitter<any>();
 
   override entityType = 'identity';
 
-  initData: any = {};
   isEditing = false;
   enrollmentExpiration: any;
   jwt: any;
@@ -101,7 +99,6 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
     this.getAssociatedServicePolicies();
     this.getAuthPolicies();
     this.initData = cloneDeep(this.formData);
-    this.watchData();
     this.loadTags();
   }
 
@@ -144,7 +141,7 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
       total: 100
     }
     this.zitiService.get('auth-policies', paging, []).then((result: any) => {
-      this.authPolicies = [{id: 'default', name: 'Default'}, ...result.data];
+      this.authPolicies = [...result.data];
     });
   }
 
@@ -286,28 +283,6 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
     this.growlerService.show(growlerData);
   }
 
-  closeModal(refresh = false, ignoreChanges = false): void {
-    if (!ignoreChanges && this._dataChange) {
-      const confirmed = confirm('You have unsaved changes. Do you want to leave this page and discard your changes or stay on this page?');
-      if (!confirmed) {
-        return;
-      }
-    }
-    this.close.emit({refresh: refresh});
-  }
-
   clear(): void {
-  }
-
-  _dataChange = false;
-  watchData() {
-    delay(() => {
-      const dataChange = !isEqual(this.initData, this.formData);
-      if (dataChange !== this._dataChange) {
-        this.dataChange.emit(dataChange);
-      }
-      this._dataChange = dataChange;
-      this.watchData();
-    }, 100);
   }
 }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.html
@@ -1,0 +1,288 @@
+<div class="projectable-form-wrapper"
+     (keyup.enter)="save($event)"
+     (keyup.escape)="closeModal(false)"
+>
+    <lib-form-header
+        [data]="formData"
+        [title]="(formData.id ? 'Edit Service' : 'Create Service')"
+        [moreActions]="formData.moreActions"
+        (actionRequested)="headerActionRequested($event)"
+        [(formView)]="formView"
+    ></lib-form-header>
+    <div class="edge-router-form-container projectable-form-container">
+        <div class="projectable-form-main-column form-group-row" *ngIf="formView === 'simple'">
+            <div class="form-group-column three-fifths">
+                <lib-form-field-container [title]="'Service Name'" [label]="'Required'">
+                    <input
+                        class="form-field-input"
+                        placeholder="Name this Service"
+                        [ngClass]="{error: svc.errors['name']}"
+                        [(ngModel)]="formData.name"
+                        autofocus
+                        #nameFieldInput
+                    />
+                </lib-form-field-container>
+                <lib-form-field-container
+                        [title]="'Select or create Service attributes'"
+                        [label]="'Optional'"
+                        [contentStyle]="'z-index: 99999999'"
+                        [helpText]="'Attributes are tags applied to a resource. Apply the same tag to other Services to form a group of Services.'"
+                >
+                    <lib-tag-selector
+                            [(selectedRoleAttributes)]="formData.roleAttributes"
+                            [availableRoleAttributes]="serviceRoleAttributes"
+                            [placeholder]="'Add attributes to group Services'"
+                    ></lib-tag-selector>
+                </lib-form-field-container>
+                <lib-form-field-container
+                        [title]="'Add Configurations'"
+                        [action]="false"
+                        [actionLabel]="svc.attachLabel"
+                        (actionRequested)="svc.attachConfig(svc.selectedConfigId)"
+                >
+                    <div class="form-field-input-group">
+                        <div class="config-title-row">
+                            <span class="form-field-title">Select a Config</span>
+                        </div>
+                        <select
+                                [(ngModel)]="svc.selectedConfigTypeId"
+                                (change)="configTypeChanged($event)"
+                                id="SelectedConfigType"
+                                class="form-field-dropdown"
+                        >
+                            <option value="">Select configuration type...</option>
+                            <option
+                                    *ngFor="let type of svc.configTypes"
+                                    [value]="type.id"
+                            >
+                                {{ type.name }}
+                            </option>
+                        </select>
+                        <select
+                                [(ngModel)]="svc.selectedConfigId"
+                                (change)="configChanged($event)"
+                                id="SelectedConfig"
+                                class="form-field-dropdown"
+                                [ngClass]="{'disabled': !svc.selectedConfigTypeId || svc.selectedConfigTypeId === ''}"
+                        >
+                            <option value="">Select configuration...</option>
+                            <option value="add-new">Add a New  Config</option>
+                            <option
+                                    *ngFor="let config of svc.filteredConfigs"
+                                    [value]="config.id"
+                            >
+                                {{ config.name }}
+                            </option>
+                        </select>
+                        <div *ngIf="!showConfigData && svc.selectedConfigId && svc.selectedConfigId !== ''" class="button-row-right" >
+                            <div class="save-button" (click)="svc.attachConfig(svc.selectedConfigId)">
+                                {{svc.attachLabel}}
+                            </div>
+                        </div>
+                        <div [hidden]="!showConfigData" class="form-field-extended-fields">
+                            <div *ngIf="showConfigData" class="config-title-row" style="margin-bottom: 10px;">
+                                <span class="form-field-title">Config Name</span>
+                                <div
+                                        class="save-button"
+                                        (click)="svc.attachConfig(svc.selectedConfigId)"
+                                >{{svc.attachLabel}}
+                                </div>
+                            </div>
+                            <input
+                                    *ngIf="showConfigData"
+                                    [(ngModel)]="svc.newConfigName"
+                                    class="form-field-input"
+                                    [placeholder]="'New Config Name'"
+                                    [ngClass]="{error: svc.configErrors['name']}"
+                                    style="margin-bottom: 20px;"
+                            />
+                            <div class="config-title-row" style="margin-bottom: 10px;">
+                                <span class="form-field-title">Configuration Form</span>
+                                <div
+                                        id="OnOffButton"
+                                        class="onoff jsonButton configsForm save-button"
+                                        (click)="svc.toggleJSONView()"
+                                >
+                                    <span>{{svc.configJsonView ? 'Show Form' : 'Show JSON'}}</span>
+                                </div>
+                            </div>
+
+                            <!--<span class="form-field-title" [innerHTML]="configDataLabel"></span>-->
+                            <lib-json-view *ngIf="svc.configJsonView && !svc.hideConfigJSON" [(data)]="svc.configData"></lib-json-view>
+                            <lib-json-view *ngIf="svc.configJsonView && svc.hideConfigJSON" [(data)]="svc.configData"></lib-json-view>
+                            <div class="config-form-container" [hidden]="svc.configJsonView">
+                                <ng-container #dynamicform></ng-container>
+                            </div>
+                        </div>
+                    </div>
+                </lib-form-field-container>
+                <lib-form-field-toggle [(toggleOn)]="showMore" style="margin: 0px 10px"></lib-form-field-toggle>
+                <div *ngIf="showMore" class="form-group-column">
+                    <lib-form-field-container
+                        [title]="'Terminator Strategy'"
+                        [title2]="'Encryption'"
+                        [layout]="'row'"
+                        class="form-field-advanced"
+                    >
+                        <select
+                                [(ngModel)]="formData.terminatorStrategy"
+                                id="authPolicyId"
+                                class="form-field-dropdown"
+                        >
+                            <option value="">Select a Strategy....</option>
+                            <option
+                                    *ngFor="let strat of strategies"
+                                    [value]="strat.id"
+                            >
+                                {{ strat.label }}
+                            </option>
+                        </select>
+                        <div class="config-item">
+                            <div class="config-container toggle-container">
+                                <div class="config-container-label">Require Encryption</div>
+                                <div
+                                        (click)="toggleEncryptionRequired()"
+                                        [ngClass]="{ on: formData.encryptionRequired }"
+                                        class="toggle"
+                                >
+                                    <span [hidden]="!formData.encryptionRequired" class="on-label">YES</span>
+                                    <span [hidden]="formData.encryptionRequired" class="off-label">NO</span>
+                                    <div class="switch"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </lib-form-field-container>
+                    <lib-form-field-container
+                            [title]="'Custom Tags'"
+                            [label]="'OPTIONAL'"
+                            class="form-field-advanced"
+                    >
+                        <lib-custom-tags [(tags)]="formData.tags"></lib-custom-tags>
+                    </lib-form-field-container>
+                    <lib-form-field-container
+                            [title]="'App Data'"
+                            [label]="'OPTIONAL'"
+                            class="form-field-advanced"
+                    >
+                        <lib-json-view></lib-json-view>
+                    </lib-form-field-container>
+                </div>
+            </div>
+            <div class="form-group-column two-fifths">
+                <lib-form-field-container
+                    [title]="'Selected Configurations'"
+                    [count]="svc.addedConfigNames ? svc.addedConfigNames.length : 0"
+                >
+                    <lib-preview-list
+                        [allNames]="svc.addedConfigNames"
+                        [allowRemove]="true"
+                        (itemRemoved)="svc.removeConfig($event)"
+                    ></lib-preview-list>
+                </lib-form-field-container>
+                <lib-form-field-container
+                        [title]="'Terminators'"
+                >
+                    <div class="form-field-input-group" style="background-color: #344459">
+                        <span class="form-field-title">{{'Router'}}</span>
+                        <select
+                                [(ngModel)]="svc.selectedRouterId"
+                                (change)="svc.routerChanged($event)"
+                                id="SelectedRouter"
+                                class="form-field-dropdown"
+                        >
+                            <option value="">Select a Router...</option>
+                            <option
+                                    *ngFor="let router of svc.routers"
+                                    [value]="router.id"
+                            >
+                                {{ router.name }}
+                            </option>
+                        </select>
+                    </div>
+                    <div class="form-field-input-group" *ngIf="svc.selectedRouterId && svc.selectedRouterId !== ''" style="background-color: #344459">
+                        <div class="form-field-row">
+                            <div class="config-item">
+                                <div class="config-item-label-container">
+                                    <span class="config-label">BINDING</span>
+                                </div>
+                                <select
+                                        [(ngModel)]="svc.selectedBindingId"
+                                        id="SelectedBindingType"
+                                        class="form-field-dropdown"
+                                >
+                                    <option value="">Select Binding...</option>
+                                    <option
+                                            *ngFor="let binding of bindingTypes"
+                                            [value]="binding.id"
+                                    >
+                                        {{ binding.name }}
+                                    </option>
+                                </select>
+                            </div>
+                            <div class="config-item">
+                                <div class="config-item-label-container">
+                                    <span class="config-label">PROTOCOL</span>
+                                </div>
+                                <select
+                                        [(ngModel)]="svc.terminatorProtocol"
+                                        id="SelectedTerminatorProtocol"
+                                        class="form-field-dropdown"
+                                >
+                                    <option
+                                            *ngFor="let protocol of protocols"
+                                            [value]="protocol.id"
+                                    >
+                                        {{ protocol.name }}
+                                    </option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="form-field-row">
+                            <div class="config-item">
+                                <div class="config-item-label-container">
+                                    <span class="config-label">HOST</span>
+                                </div>
+                                <input
+                                        [(ngModel)]="svc.terminatorHost"
+                                        class="form-field-input"
+                                        [placeholder]="'example.com'"
+                                        [ngClass]="{error: svc.terminatorErrors['host']}"
+                                />
+                            </div>
+                            <div class="config-item">
+                                <div class="config-item-label-container">
+                                    <span class="config-label">PORT</span>
+                                </div>
+                                <input
+                                        [(ngModel)]="svc.terminatorPort"
+                                        class="form-field-input"
+                                        [placeholder]="'80, 443, etc...'"
+                                        [ngClass]="{error: svc.terminatorErrors['port']}"
+                                />
+                            </div>
+                        </div>
+                        <div class="button-row-right" >
+                            <div
+                                    class="save-button"
+                                    (click)="svc.addTerminator()"
+                            >Add
+                            </div>
+                        </div>
+                    </div>
+                </lib-form-field-container>
+                <lib-form-field-container
+                        [title]="'Terminating Routers'"
+                        [count]="svc.addedTerminatorNames ? svc.addedTerminatorNames.length : 0"
+                >
+                    <lib-preview-list
+                            [allNames]="svc.addedTerminatorNames"
+                    ></lib-preview-list>
+                </lib-form-field-container>
+            </div>
+        </div>
+        <div class="form-group-column" *ngIf="formView === 'raw'">
+            <lib-json-view *ngIf="formData" [(data)]="formData"></lib-json-view>
+        </div>
+    </div>
+</div>
+<lib-loading-indicator *ngIf="isLoading" [isLoading]="isLoading"></lib-loading-indicator>

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.html
@@ -10,7 +10,7 @@
         [(formView)]="formView"
     ></lib-form-header>
     <div class="edge-router-form-container projectable-form-container">
-        <div class="projectable-form-main-column form-group-row" *ngIf="formView === 'simple'">
+        <div class="projectable-form-main-column form-group-row" [hidden]="formView !== 'simple'">
             <div class="form-group-column three-fifths">
                 <lib-form-field-container [title]="'Service Name'" [label]="'Required'">
                     <input

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.scss
@@ -1,4 +1,4 @@
-.identity-form-container {
+.edge-router-form-container {
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -7,9 +7,87 @@
   gap: 15px;
 }
 
+.form-field-dropdown {
+  background-image: url(/assets/svgs/ArrowDown.svg);
+  background-position: center right 10px;
+  background-repeat: no-repeat;
+  background-size: 18px;
+  padding-right: 28px;
+}
+
+.form-field-extended-fields {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.jsonButton {
+  position: relative;
+  top: 0;
+  margin: 0;
+  padding: 10px;
+  height: 30px;
+}
+
 .disabled {
   opacity: .5;
   pointer-events: none;
+}
+
+::ng-deep .config-form-container {
+  label {
+    color: var(--white) !important;
+  }
+}
+
+.config-title-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+
+  .jsonButton {
+    color: var(--offWhite);
+    font-weight: 600;
+    opacity: 1;
+  }
+}
+
+.attach-config {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 14px;
+  background: var(--primary);
+  padding: 7px;
+  border-radius: 7px;
+  color: var(--white);
+  cursor: pointer;
+  box-shadow: 0 3px 9px 0 var(--primaryColorOpaque);
+  border: none;
+  width: fit-content;
+
+  &:active {
+    background: #648293;
+    box-shadow: none;
+    transform: translateY(1px);
+  }
+  &:hover {
+    outline: 0;
+    filter: brightness(90%);
+    box-shadow: 0 2px 3px 0 var(--primaryColorOpaque);
+  }
+}
+
+.form-field-input-group {
+  gap: 10px;
+  display: flex;
+  flex-direction: column;
+
+  .form-field-title {
+    color: var(--offWhite);
+  }
 }
 
 ::ng-deep .admin-toggle {
@@ -84,14 +162,6 @@
       .switch {
         top: 1px;
       }
-    }
-  }
-}
-
-::ng-deep .copy {
-  &.icon-copy {
-    &.url-copy {
-      background-color: var(--navigation);
     }
   }
 }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.scss
@@ -90,6 +90,14 @@
   }
 }
 
+.projectable-form-main-column {
+  &.form-group-row {
+    &[hidden] {
+      display: none;
+    }
+  }
+}
+
 ::ng-deep .admin-toggle {
   width: 100%;
   width: 35%;

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
@@ -1,0 +1,207 @@
+/*
+    Copyright NetFoundry Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  OnDestroy,
+  Output,
+  OnChanges,
+  SimpleChanges,
+  ViewChild,
+  ElementRef,
+  AfterViewInit,
+  Inject,
+  ViewContainerRef
+} from '@angular/core';
+import {Subscription} from 'rxjs';
+import {ProjectableForm} from "../projectable-form.class";
+import {SETTINGS_SERVICE, SettingsService} from "../../../services/settings.service";
+
+import {isEmpty, forEach, delay, unset, keys, defer, cloneDeep, isEqual, some, filter} from 'lodash';
+import {ZITI_DATA_SERVICE, ZitiDataService} from "../../../services/ziti-data.service";
+import {GrowlerService} from "../../messaging/growler.service";
+import {GrowlerModel} from "../../messaging/growler.model";
+import {SERVICE_EXTENSION_SERVICE, ServiceFormService} from './service-form.service';
+import {MatDialogRef} from "@angular/material/dialog";
+import {ExtensionService} from "../../extendable/extensions-noop.service";
+
+@Component({
+  selector: 'lib-service-form',
+  templateUrl: './service-form.component.html',
+  styleUrls: ['./service-form.component.scss'],
+  providers: [
+    {
+      provide: MatDialogRef,
+      useValue: {}
+    }
+  ]
+})
+export class ServiceFormComponent extends ProjectableForm implements OnInit, OnChanges, OnDestroy, AfterViewInit {
+  @Input() set formData(data) {
+    if (!data?.configs) {
+      data.configs = [];
+    }
+    this.svc.formData = data;
+  }
+
+  get formData(): any {
+    return this.svc.formData;
+  }
+
+  @Input() serviceRoleAttributes: any[] = [];
+  @Output() close: EventEmitter<any> = new EventEmitter<any>();
+
+  isEditing = false;
+  enrollmentExpiration: any;
+  jwt: any;
+  token: any;
+  isLoading = false;
+  strategies = [
+    {id: 'smartrouting', label: 'Smart Routing'},
+    {id: 'weighted', label: 'Weighted'},
+    {id: 'random', label: 'Random'},
+    {id: 'ha', label: 'High Availability'},
+  ];
+  bindingTypes = [
+    {id: 'udp', name: 'UDP'},
+    {id: 'transport', name: 'Transport'},
+    {id: 'edge', name: 'Edge'},
+  ];
+  protocols = [
+    {id: 'udp', name: 'UDP'},
+    {id: 'tcp', name: 'TCP'}
+  ];
+
+  showMore = false;
+  formView = 'simple';
+  settings: any = {};
+  errors: any = {};
+  subscription: Subscription = new Subscription();
+
+  @ViewChild("dynamicform", {read: ViewContainerRef}) dynamicForm!: ViewContainerRef;
+  constructor(
+      @Inject(SETTINGS_SERVICE) public settingsService: SettingsService,
+      public svc: ServiceFormService,
+      @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
+      private growlerService: GrowlerService,
+      @Inject(SERVICE_EXTENSION_SERVICE) private extService: ExtensionService
+  ) {
+    super();
+  }
+
+  ngOnInit(): void {
+    this.subscription.add(
+      this.settingsService.settingsChange.subscribe((results:any) => {
+        this.settings = results;
+      })
+    );
+    this.jwt = this.formData.enrollmentJwt;
+    this.token = this.formData.enrollmentToken;
+    this.enrollmentExpiration = this.formData?.enrollmentExpiresAt;
+    this.svc.getAssociatedConfigs();
+    this.svc.getAssociatedTerminators();
+    this.initData = cloneDeep(this.formData);
+    this.subscription.add(
+      this.extService.formDataChanged.subscribe((data) => {
+        if (data.isEmpty) {
+          return;
+        }
+      })
+    );
+  }
+
+  ngOnDestroy() {
+    this.extService.closed.emit({});
+    this.subscription.unsubscribe();
+  }
+
+  override ngAfterViewInit() {
+    super.ngAfterViewInit();
+    this.nameFieldInput.nativeElement.focus();
+    this.resetTags();
+    this.svc.getConfigTypes();
+    this.svc.getConfigs().then(() => {
+      this.svc.updatedAddedConfigs();
+    });
+    this.svc.getRouters();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    this.isEditing = !isEmpty(this.formData.id);
+  }
+
+  configChanged($event) {
+    this.svc.configChanged(this.dynamicForm);
+  }
+
+  configTypeChanged($event) {
+    this.svc.configTypeChanged(this.dynamicForm);
+  }
+
+  get showConfigData() {
+    return this.svc.selectedConfigId === 'add-new';
+  }
+
+  headerActionRequested(action) {
+    switch(action.name) {
+      case 'save':
+        this.save();
+        break;
+      case 'close':
+        this.closeModal(true);
+        break;
+      case 'toggle-view':
+        this.formView = action.data;
+        break;
+    }
+  }
+
+  async save(event?) {
+    const isValid = this.svc.validate();
+    const isExtValid = await this.extService.validateData();
+    const isEdit = !isEmpty(this.formData.id);
+    if(!isValid || !isExtValid) {
+      return;
+    }
+
+    this.isLoading = true;
+    const serviceId = await this.svc.save(this.formData).then((result) => {
+      if (!isEmpty(result?.id)) {
+        this.formData = result;
+        this.initData = this.formData;
+      }
+      return result?.id;
+    }).finally(() => {
+      this.isLoading = false;
+    });
+    if (serviceId && !isEdit) {
+      await this.svc.addTerminators(serviceId)
+    }
+    if (serviceId) {
+      this.closeModal(true, true);
+    }
+  }
+
+  toggleEncryptionRequired() {
+    this.formData.encryptionRequired = !this.formData.encryptionRequired;
+  }
+
+  clear(): void {
+  }
+}

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
@@ -1,0 +1,530 @@
+/*
+    Copyright NetFoundry Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import {Injectable, Inject, InjectionToken} from "@angular/core";
+import {isEmpty, unset, keys, some, defer, cloneDeep, filter} from 'lodash';
+import {ZITI_DATA_SERVICE, ZitiDataService} from "../../../services/ziti-data.service";
+import {GrowlerService} from "../../messaging/growler.service";
+import {GrowlerModel} from "../../messaging/growler.model";
+import {SETTINGS_SERVICE, SettingsService} from "../../../services/settings.service";
+import {ExtensionService} from "../../extendable/extensions-noop.service";
+import {Service} from "../../../models/service";
+import moment from 'moment';
+import dynamic from "ajv/dist/vocabularies/dynamic";
+import {SchemaService} from "../../../services/schema.service";
+import {Subscription} from "rxjs";
+
+export const SERVICE_EXTENSION_SERVICE = new InjectionToken<any>('SERVICE_EXTENSION_SERVICE');
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ServiceFormService {
+
+    paging = {
+        filter: "",
+        noSearch: true,
+        order: "asc",
+        page: 1,
+        searchOn: "name",
+        sort: "name",
+        total: 100
+    }
+
+    formData: any;
+    configData: any;
+    selectedConfigId: any = '';
+    configs: any = [];
+    configTypes: any = [];
+    filteredConfigs: any = [];
+    selectedConfigTypeId: any = '';
+    selectedConfigType: any = {};
+    addedConfigNames: any = [];
+    addedTerminatorNames: any = [];
+    addedTerminators: any = [];
+    configJsonView = false;
+    hideConfigJSON = false;
+    configErrors: any = {};
+    terminatorErrors: any = {};
+    newConfigName: string = '';
+    terminatorHost: string = '';
+    terminatorPort: string = '';
+    selectedSchema: any = {};
+    items: any = [];
+    routers: any = [];
+    configDataLabel = 'Configuration Form';
+    attachLabel = 'Create and Attach';
+    errors: any = {};
+    selectedRouterId: string = '';
+    selectedRouter: any;
+    selectedBindingId: string = '';
+    terminatorProtocol = 'udp';
+
+    associatedConfigs: any = [];
+    associatedTerminators: any = [];
+
+    lColorArray = [
+        'black',
+        'white',
+        'black',
+    ]
+
+    bColorArray = [
+        '#33aaff',
+        'var(--secondary)',
+        '#fafafa',
+    ]
+
+    subscription: Subscription = new Subscription();
+
+    constructor(
+        @Inject(SETTINGS_SERVICE) public settingsService: SettingsService,
+        @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
+        private growlerService: GrowlerService,
+        @Inject(SERVICE_EXTENSION_SERVICE)private extService: ExtensionService,
+        private schemaSvc: SchemaService
+    ) {}
+ 
+    save(formData): Promise<any> {
+        const isUpdate = !isEmpty(formData.id);
+        const data: any = this.getServiceDataModel(formData, isUpdate);
+        const svc = isUpdate ? this.zitiService.patch.bind(this.zitiService) : this.zitiService.post.bind(this.zitiService);
+        return svc('services', data, formData.id).then(async (result: any) => {
+            const id = result?.data?.id || formData.id;
+            let router = await this.zitiService.getSubdata('services', id, '').then((routerData) => {
+                return routerData.data;
+            });
+            return this.extService.formDataSaved(router).then((formSavedResult: any) => {
+                if (!formSavedResult) {
+                    return router;
+                }
+                const growlerData = new GrowlerModel(
+                    'success',
+                    'Success',
+                    `Services ${isUpdate ? 'Updated' : 'Created'}`,
+                    `Successfully ${isUpdate ? 'updated' : 'created'} Service: ${formData.name}`,
+                );
+                this.growlerService.show(growlerData);
+                return router;
+            }).catch((result) => {
+                return false;
+            });
+        }).catch((resp) => {
+            let errorMessage;
+            if (resp?.error?.error?.cause?.message) {
+                errorMessage = resp?.error?.error?.cause?.message;
+            } else if (resp?.error?.error?.cause?.reason) {
+                errorMessage = resp?.error?.error?.cause?.reason;
+            }else if (resp?.error?.message) {
+                errorMessage = resp?.error?.message;
+            } else {
+                errorMessage = 'An unknown error occurred';
+            }
+            const growlerData = new GrowlerModel(
+                'error',
+                'Error',
+                `Error Creating Service`,
+                errorMessage,
+            );
+            this.growlerService.show(growlerData);
+            throw resp;
+        })
+    }
+
+    addTerminators(serviceId) {
+        const promises = [];
+        this.addedTerminators.forEach((terminator) => {
+            terminator.service = serviceId
+            promises.push(this.zitiService.post('terminators', terminator));
+        });
+    }
+
+    getServiceDataModel(formData, isUpdate) {
+        const saveModel = new Service();
+        const modelProperties = keys(saveModel);
+        modelProperties.forEach((prop) => {
+            switch(prop) {
+                default:
+                    saveModel[prop] = formData[prop];
+            }
+        });
+        return saveModel;
+    }
+
+    getConfigTypes() {
+        this.zitiService.get('config-types', this.paging, []).then((result: any) => {
+            this.configTypes = result.data;
+        });
+    }
+
+    getConfigs() {
+        return this.zitiService.get('configs', this.paging, []).then((result: any) => {
+            this.configs = result.data;
+            this.configTypeChanged();
+        });
+    }
+
+    getRouters() {
+        this.zitiService.get('edge-routers', this.paging, []).then((result: any) => {
+            this.routers = result.data;
+        });
+    }
+
+    getAssociatedConfigs() {
+        this.zitiService.getSubdata('services', this.formData.id, 'configs').then((result: any) => {
+            this.associatedConfigs = result.data;
+            this.addedConfigNames = this.associatedConfigs.map((cfg) => {
+                return cfg.name;
+            });
+        });
+    }
+
+    getAssociatedTerminators() {
+        this.zitiService.getSubdata('services', this.formData.id, 'terminators').then((result: any) => {
+            this.associatedTerminators = result.data;
+            this.addedTerminatorNames = this.associatedTerminators.map((cfg) => {
+                return cfg.router?.name;
+            });
+        });
+    }
+
+    createConfig(configData) {
+        return this.zitiService.post('configs', configData).then((result) => {
+            return result;
+        }).catch((response) => {
+            const msg = response?.error?.error?.cause?.reason;
+            const growlerData = new GrowlerModel(
+                'error',
+                'Error',
+                `Error Creating New Config`,
+                msg,
+            );
+            this.growlerService.show(growlerData);
+        });
+    }
+
+    configTypeChanged(dynamicForm?) {
+        this.filteredConfigs = this.configs.filter((config) => {
+            return config.configTypeId === this.selectedConfigTypeId;
+        });
+        this.configTypes.forEach((configType) => {
+            if (this.selectedConfigTypeId === configType.id) {
+                this.selectedConfigType = configType;
+            }
+        });
+        this.selectedConfigId = !isEmpty(this.selectedConfigTypeId) ? 'add-new' : '';
+        this.configChanged(dynamicForm);
+    }
+
+    routerChanged(event?: any) {
+        let selectedRouter;
+        this.routers.forEach((router) => {
+            if (this.selectedRouterId === router.id) {
+                selectedRouter = router;
+            }
+        });
+        this.selectedRouter = selectedRouter;
+    }
+
+    updatedAddedConfigs() {
+        this.addedConfigNames = [];
+        this.configs.forEach((availableConfig) => {
+            const cfgExists = some(this.formData.configs, configId => {
+                return availableConfig.id == configId;
+            });
+            if (cfgExists) {
+                this.addedConfigNames.push(availableConfig.name);
+                this.addedConfigNames = [...this.addedConfigNames];
+            }
+        })
+    }
+
+    toggleJSONView() {
+        this.configJsonView = !this.configJsonView;
+        this.configDataLabel = this.configJsonView ? 'JSON Configuration' : 'Configuration Form';
+        this.updateConfigData();
+    }
+
+    async createForm(dynamicForm) {
+        this.clearForm();
+        if (this.selectedConfigType && dynamicForm) {
+            if (this.selectedSchema) {
+                this.renderSchmea(this.selectedSchema, dynamicForm);
+            }
+        }
+    }
+
+    clearForm() {
+        this.items.forEach((item: any) => {
+            if (item?.component) item.component.destroy();
+        });
+        this.items = [];
+        if (this.subscription) this.subscription.unsubscribe();
+    }
+
+    renderSchmea(schema: any, dynamicForm: any) {
+        if (schema.properties) {
+            this.items = this.schemaSvc.render(schema, dynamicForm, this.lColorArray, this.bColorArray);
+            for (let obj of this.items) {
+                const cRef = obj.component;
+                cRef.instance.errors = this.errors;
+                if (cRef?.instance.valueChange) {
+                    const pName: string[]  = cRef.instance.parentage;
+                    let parentKey;
+                    if(pName) parentKey = pName.join('.');
+                    if (parentKey && !this.formData[parentKey]) this.formData[parentKey] = {};
+                }
+            }
+        }
+    }
+
+    async attachConfig(addedConfigId) {
+        let configId;
+        if (this.selectedConfigId === 'add-new') {
+            if (!this.configJsonView) {
+                this.getConfigDataFromForm();
+            }
+            if (!this.validateConfig()) {
+                return;
+            }
+            const newConfig = {
+                configTypeId: this.selectedConfigTypeId,
+                data: this.configData,
+                name: this.newConfigName
+            }
+            configId = await this.createConfig(newConfig)
+                .then((result) => {
+                    return result?.data?.id;
+                })
+                .catch((result) => {
+                    const errorField = result?.error?.error?.cause?.field;
+                    if (!isEmpty(errorField)) {
+                        this.configErrors[errorField] = true;
+                    }
+                    const errorMessage = result?.error?.error?.cause?.reason;
+                    const growlerData = new GrowlerModel(
+                        'error',
+                        'Error',
+                        `Error Creating Config`,
+                        errorMessage,
+                    );
+                    this.growlerService.show(growlerData);
+                    return undefined;
+                });
+            if (!isEmpty(configId)) {
+                this.formData.configs.push(configId);
+                this.addedConfigNames.push(this.newConfigName);
+                this.addedConfigNames = [...this.addedConfigNames];
+                this.getConfigs();
+                const growlerData = new GrowlerModel(
+                    'success',
+                    'Success',
+                    `New Config Attached`,
+                    `New Config ${this.newConfigName} has been created and attached to the service`,
+                );
+                this.growlerService.show(growlerData);
+                this.newConfigName = '';
+                this.selectedConfigTypeId = '';
+                this.selectedConfigId = '';
+                return;
+            }
+        }
+        let configAdded = false;
+        this.formData.configs.forEach((configId) => {
+            if (configId === addedConfigId) {
+                configAdded = true;
+            }
+        });
+        if (!configAdded) {
+            let configName = '';
+            this.configs.forEach((config) => {
+                if (config.id === addedConfigId) {
+                    configName = config.name;
+                }
+            });
+            if (!isEmpty(configName)) {
+                this.addedConfigNames.push(configName);
+                this.addedConfigNames = [...this.addedConfigNames];
+            }
+            this.formData.configs.push(addedConfigId);
+            this.selectedConfigTypeId = '';
+            this.selectedConfigId = '';
+        } else {
+            const growlerData = new GrowlerModel(
+                'warning',
+                'Info',
+                `Config Already Attached`,
+                'Config has already been attached to this service',
+            );
+            this.growlerService.show(growlerData);
+        }
+    }
+
+    removeConfig(nameToRemove) {
+        let configIdToRemove;
+        this.configs.forEach((availableConfig) => {
+            if (availableConfig.name === nameToRemove) {
+                configIdToRemove = availableConfig.id;
+            }
+        });
+        if (configIdToRemove) {
+            const newConfigs = filter(this.formData.configs, configId => {
+                return configId !== configIdToRemove;
+            });
+            const newConfigNames = filter(this.addedConfigNames, (configName) => {
+                return configName !== nameToRemove;
+            });
+            this.formData.configs = newConfigs;
+            this.addedConfigNames = newConfigNames;
+        }
+    }
+
+    getConfigDataFromForm() {
+        const data = {};
+        this.addItemsToConfig(this.items, data);
+        this.configData = data;
+        this.hideConfigJSON = false;
+    }
+
+    addItemsToConfig(items, data) {
+        items.forEach((item) => {
+            let props = [];
+            if (item.items) {
+                data[item.key] = this.addItemsToConfig(item.items, {});
+            } else if (item?.component?.instance?.getProperties) {
+                props = item?.component?.instance?.getProperties();
+            } else if (item?.component?.instance) {
+                props = [{key: item.key, value: item.component.instance.fieldValue}];
+            }
+            props.forEach((prop) => {
+                data[prop.key] = prop.value;
+            });
+        });
+        return data;
+    }
+
+    async configChanged(dynamicForm) {
+        let selectedConfig: any = {};
+        this.configData = undefined;
+        let data;
+        let attachLabel = 'Attach to Service';
+        if (this.selectedConfigId === 'add-new') {
+            data = {};
+            this.selectedSchema = await this.zitiService.schema(this.selectedConfigType.schema);
+            attachLabel = 'Create and Attach';
+            this.createForm(dynamicForm);
+        } else if (this.selectedConfigId) {
+            this.filteredConfigs.forEach((config) => {
+                if (this.selectedConfigId === config.id) {
+                    selectedConfig = config;
+                }
+            });
+            data = selectedConfig?.data || {};
+        }
+        if (!this.configData) {
+            this.configData = data;
+        } else {
+            defer(() => {
+                this.configData = cloneDeep(data);
+            });
+        }
+        this.updateConfigData();
+        this.attachLabel = attachLabel;
+    }
+
+    updateConfigData() {
+        if (!this.configJsonView) {
+            this.updateFormView(this.items, this.configData);
+        } else {
+            this.hideConfigJSON = true;
+            defer(() => {
+                this.getConfigDataFromForm();
+            });
+        }
+    }
+
+    updateFormView(items, data) {
+        items.forEach((item) => {
+            if (item.items) {
+                this.updateFormView(item.items, data[item.key]);
+            } else if (item?.component?.instance?.setProperties) {
+                let val;
+                switch (item.key) {
+                    case 'forwardingconfig':
+                        val = {
+                            protocol: data.protocol,
+                            address: data.address,
+                            port: data.port,
+                            forwardProtocol: data.forwardProtocol,
+                            forwardAddress: data.forwardAddress,
+                            forwardPort: data.forwardPort,
+                            allowedProtocols: data.allowedProtocols,
+                            allowedAddresses: data.allowedAddresses,
+                            allowedPortRanges: data.allowedPortRanges
+                        }
+                        break;
+                    default:
+                        val = data[item.key];
+                        break;
+                }
+                item?.component?.instance?.setProperties(val);
+            } else if (item?.component?.setInput) {
+                item.component.setInput('fieldValue', data[item.key]);
+            }
+        });
+        return data;
+    }
+
+    addTerminator() {
+        let termAdded = false;
+        this.addedTerminators.forEach((termName) => {
+            if (this.selectedRouter.name === termName) {
+                termAdded = true;
+            }
+        });
+        if (!termAdded) {
+            const terminatorModel = {
+                address: this.terminatorProtocol + ':' + this.terminatorHost + ":" + this.terminatorPort,
+                binding: this.selectedBindingId,
+                router: this.selectedRouter.id,
+                service: undefined
+            }
+            this.addedTerminatorNames = [...this.addedTerminatorNames, this.selectedRouter.name];
+            this.addedTerminators.push(terminatorModel);
+            this.selectedRouterId = '';
+            this.selectedBindingId = '';
+            this.terminatorPort = '';
+            this.terminatorHost = '';
+            this.terminatorProtocol = '';
+        }
+    }
+
+    validate() {
+        this.errors = {};
+        if (isEmpty(this.formData.name)) {
+            this.errors['name'] = true;
+        }
+        return isEmpty(this.errors);
+    }
+
+    validateConfig() {
+        this.configErrors = {};
+        if (isEmpty(this.newConfigName)) {
+            this.configErrors['name'] = true;
+        }
+        return isEmpty(this.configErrors);
+    }
+}

--- a/projects/ziti-console-lib/src/lib/models/service.ts
+++ b/projects/ziti-console-lib/src/lib/models/service.ts
@@ -1,0 +1,8 @@
+export class Service {
+    name = '';
+    encryptionRequired = true;
+    terminatorStrategy = '';
+    roleAttributes: any[] = [];
+    tags: any = {};
+    configs: any[] = []
+};

--- a/projects/ziti-console-lib/src/lib/pages/services/services-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/services/services-page.component.html
@@ -1,0 +1,31 @@
+<div class="ziti-page-container ziti-services-container">
+    <lib-list-page-header [title]="'Services'"
+                          [tabs]="tabs"
+                          [showAdd]="!itemsSelected"
+                          (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
+
+    <lib-data-table [tableId]="'services'"
+                    [rowData]="rowData"
+                    [columnDefinitions]="columnDefs"
+                    (actionRequested)="tableAction($event)"
+                    [startCount]="startCount"
+                    [endCount]="endCount"
+                    [totalCount]="totalCount"
+                    [currentPage]="currentPage"
+                    [emptyMsg]="'No Services defined, Click the plus to add a service.'"
+                    [filterApplied]="filterApplied"
+                    [menuItems]="svc.menuItems"
+                    [headerActions]="svc.tableHeaderActions"
+    >
+    </lib-data-table>
+</div>
+<lib-side-modal [(open)]="svc.sideModalOpen" [showClose]="false">
+    <lib-service-form
+            *ngIf="svc.modalType === 'service' && svc.sideModalOpen"
+            [formData]="svc.selectedService"
+            [serviceRoleAttributes]="serviceRoleAttributes"
+            (close)="closeModal($event)"
+            (dataChange)="dataChanged($event)"
+    ></lib-service-form>
+</lib-side-modal>
+<lib-loading-indicator *ngIf="isLoading" [isLoading]="isLoading"></lib-loading-indicator>

--- a/projects/ziti-console-lib/src/lib/pages/services/services-page.component.scss
+++ b/projects/ziti-console-lib/src/lib/pages/services/services-page.component.scss
@@ -1,0 +1,210 @@
+.ziti-page-container {
+  .action {
+    line-height: 60px;
+    top: 25px;
+    right: 25px;
+    z-index: 999;
+  }
+}
+
+.ziti-services-container {
+  ::ng-deep {
+    .zac-wrapper-container {
+      height: 0px;
+      left: -999999px;
+      position: fixed;
+      .action {
+        display: none;
+      }
+    }
+  }
+}
+
+.ziti-ag-grid {
+  height: 100%;
+  position: relative;
+  width: 100%;
+
+  .ziti-ag-grid-table {
+    height: 100%;
+    width: 100%;
+
+    .ag-root-wrapper {
+      border-bottom-style: none;
+    }
+
+    .ag-cell {
+      align-items: center;
+      display: flex;
+    }
+  }
+}
+
+.system-policies-toggle,
+.hidden-results-container {
+  position: relative;
+  right: 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: flex-start;
+  margin-top: 10px;
+  padding-left: 20px;
+  border-radius: 7px;
+  padding-bottom: 0;
+  padding-right: 0;
+  padding-top: 0;
+  flex-wrap: nowrap;
+  flex: 1 0 auto;
+
+  .toggle-text {
+    font-weight: 600;
+    font-size: 12px;
+
+    a {
+      cursor: pointer;
+    }
+  }
+
+  .toggle {
+    width: 75px;
+    margin-left: 10px;
+
+    &.on {
+      .switch {
+        left: 52px;
+      }
+    }
+  }
+
+  .spinner {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: transparent;
+    border-top: 2px solid var(--tableText);
+    border-right: 2px solid var(--tableText);
+    border-bottom: 2px solid transparent;
+    border-left: 2px solid transparent;
+    animation: loading 0.5s infinite linear;
+    margin-left: 5px;
+  }
+}
+
+.hidden-results-container {
+  &.loading-results {
+    opacity: 0.7;
+  }
+}
+
+.nf-cell-vert-align {
+  align-items: center;
+  display: flex;
+}
+
+.ag-row .ag-cell {
+  align-items: center;
+  display: flex;
+}
+
+.hidden-columns-list {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  margin-left: 7px;
+  min-height: 30px;
+  flex-wrap: wrap;
+  flex: 0 1 auto;
+
+  &.hidden-results {
+    flex-wrap: nowrap;
+    overflow: auto;
+    .hidden-column-item {
+      flex: 1 0 auto;
+    }
+  }
+  &::-webkit-scrollbar {
+    height: 14px;
+  }
+
+  .hidden-column-item {
+    align-items: center;
+    background-color: var(--background);
+    border: 2px solid var(--background);
+    border-radius: 12px;
+    cursor: pointer;
+    color: var(----stroke);
+    font-weight: 600;
+    font-family: 'Open Sans', sans-serif;
+    display: flex;
+    flex: 0 1 auto;
+    height: 25px !important;
+    margin-left: 10px;
+    margin-top: 5px;
+    padding-left: 5px;
+    padding-right: 10px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    position: relative;
+    text-align: center;
+    box-shadow: unset;
+    transform: translateY(0);
+
+  }
+
+  .ag-dnd-ghost {
+    &:hover {
+      border: 2px solid var(--primaryColor) !important;
+
+      .ag-dnd-ghost-label {
+        color: var(--ag-alpine-active-color, var(--primaryColor));
+      }
+
+      .ag-dnd-ghost-icon {
+        .ag-icon-eye-slash {
+          color: var(--ag-alpine-active-color, var(--primaryColor));
+
+          &:before {
+            content: '\f113';
+          }
+        }
+      }
+    }
+  }
+
+  .ag-dnd-ghost-label {
+    line-height: initial;
+  }
+
+}
+
+::ng-deep .darkmode .ag-dnd-ghost-icon {
+  .ag-icon-eye-slash {
+    color: white !important;
+  }
+}
+
+.tMenu {
+  transition-property: opacity;
+  z-index: 99999999999;
+  height: fit-content;
+
+  &.action-menu {
+    position: fixed;
+
+    &.header-menu {
+    }
+
+    width: 175px;
+  }
+
+  .tActionRow {
+    transition-property: opacity;
+    &.has-icon {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+    }
+  }
+}

--- a/projects/ziti-console-lib/src/lib/pages/services/services-page.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/services/services-page.component.ts
@@ -1,0 +1,149 @@
+/*
+    Copyright NetFoundry Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import {Component, Inject, OnInit, OnDestroy} from '@angular/core';
+import {ServicesPageService} from "../services/services-page.service";
+import {DataTableFilterService} from "../../features/data-table/data-table-filter.service";
+import {TabNameService} from "../../services/tab-name.service";
+import {ConsoleEventsService} from "../../services/console-events.service";
+import {ZAC_WRAPPER_SERVICE, ZacWrapperServiceClass} from "../../features/wrappers/zac-wrapper-service.class";
+import {ListPageComponent} from "../../shared/list-page-component.class";
+import {MatDialog} from "@angular/material/dialog";
+import {ConfirmComponent} from "../../features/confirm/confirm.component";
+
+@Component({
+  selector: 'lib-services',
+  templateUrl: './services-page.component.html',
+  styleUrls: ['./services-page.component.scss']
+})
+export class ServicesPageComponent extends ListPageComponent implements OnInit, OnDestroy  {
+
+  dialogRef: any;
+  serviceRoleAttributes: any[] = [];
+  formDataChanged = false;
+  isLoading: boolean;
+  tabs: { url: string; label: string }[];
+  title = 'Manage Services';
+
+  constructor(
+      public override svc: ServicesPageService,
+      filterService: DataTableFilterService,
+      public dialogForm: MatDialog,
+      private tabNames: TabNameService,
+      consoleEvents: ConsoleEventsService,
+      @Inject(ZAC_WRAPPER_SERVICE)private zacWrapperService: ZacWrapperServiceClass,
+  ) {
+    super(filterService, svc, consoleEvents);
+    let userLang = navigator.language || 'en-us';
+    userLang = userLang.toLowerCase();
+  }
+
+  override ngOnInit() {
+    super.ngOnInit();
+    this.tabs = this.tabNames.getTabs('services');
+  }
+
+  headerActionClicked(action: string) {
+    switch(action) {
+      case 'add':
+        this.svc.openUpdate();
+        break;
+      case 'edit':
+        this.svc.openUpdate();
+        break;
+      case 'delete':
+        const selectedItems = this.rowData.filter((row) => {
+          return row.selected;
+        }).map((row) => {
+          return row.id;
+        });
+        this.openBulkDelete(selectedItems);
+        break;
+      default:
+    }
+  }
+
+  tableAction(event: any) {
+    switch(event?.action) {
+      case 'toggleAll':
+      case 'toggleItem':
+        this.itemToggled(event.item)
+        break;
+      case 'update':
+        this.svc.openUpdate(event.item);
+        break;
+      case 'create':
+        this.svc.openUpdate();
+        break;
+      case 'delete':
+        this.deleteItem(event.item)
+        break;
+      case 'download-all':
+        this.svc.downloadAllItems();
+        break;
+      case 'download-selected':
+        this.svc.downloadItems(this.selectedItems);
+        break;
+      default:
+        break;
+    }
+  }
+
+  deleteItem(item: any) {
+    this.openBulkDelete([item.id]);
+  }
+
+  private openBulkDelete(selectedItems: any[]) {
+    const data = {
+      appendId: 'DeleteServices',
+      title: 'Delete',
+      message: 'Are you sure you would like to delete the selected item(s)?"',
+      bulletList: [],
+      confirmLabel: 'Yes',
+      cancelLabel: 'Cancel'
+    };
+    this.dialogRef = this.dialogForm.open(ConfirmComponent, {
+      data: data,
+      autoFocus: false,
+    });
+    this.dialogRef.afterClosed().subscribe((result) => {
+      if (result) {
+        this.svc.removeItems('services', selectedItems).then(() => {
+          this.refreshData();
+        });
+      }
+    });
+  }
+
+  getServiceRoleAttributes() {
+    this.svc.getServiceRoleAttributes().then((result: any) => {
+      this.serviceRoleAttributes = result.data;
+    });
+  }
+
+  dataChanged(event) {
+    this.formDataChanged = event;
+  }
+
+  closeModal(event?) {
+    this.svc.sideModalOpen = false;
+    if(event?.refresh) {
+      this.refreshData();
+      this.getServiceRoleAttributes();
+    }
+  }
+
+}

--- a/projects/ziti-console-lib/src/lib/pages/services/services-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/services/services-page.service.ts
@@ -1,0 +1,217 @@
+/*
+    Copyright NetFoundry Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import {Injectable, Inject} from "@angular/core";
+import {cloneDeep, isEmpty} from 'lodash';
+import moment from 'moment';
+import {DataTableFilterService, FilterObj} from "../../features/data-table/data-table-filter.service";
+import {ListPageServiceClass} from "../../shared/list-page-service.class";
+import {
+    TableColumnDefaultComponent
+} from "../../features/data-table/column-headers/table-column-default/table-column-default.component";
+import {CallbackResults} from "../../features/list-page-features/list-page-form/list-page-form.component";
+import {SETTINGS_SERVICE, SettingsService} from "../../services/settings.service";
+import {ZITI_DATA_SERVICE, ZitiDataService} from "../../services/ziti-data.service";
+import {CsvDownloadService} from "../../services/csv-download.service";
+import {Service} from "../../models/service";
+import {unset} from "lodash";
+import {GrowlerModel} from "../../features/messaging/growler.model";
+import {GrowlerService} from "../../features/messaging/growler.service";
+import {MatDialog} from "@angular/material/dialog";
+import {SettingsServiceClass} from "../../services/settings-service.class";
+
+const CSV_COLUMNS = [
+    {label: 'Name', path: 'name'},
+    {label: 'Created At', path: 'createdAt'}
+];
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ServicesPageService extends ListPageServiceClass {
+
+    private paging = this.DEFAULT_PAGING;
+    public sideModalOpen = false;
+    public modalType = 'service';
+
+    selectedService: any = new Service();
+    columnFilters: any = {
+        name: '',
+        os: '',
+        createdAt: '',
+    };
+
+    override menuItems = [
+        {name: 'Edit', action: 'update'},
+        {name: 'Delete', action: 'delete'},
+    ]
+
+    override tableHeaderActions = [
+        {name: 'Download All', action: 'download-all'},
+        {name: 'Download Selected', action: 'download-selected'},
+    ]
+
+    constructor(
+        @Inject(SETTINGS_SERVICE) settings: SettingsServiceClass,
+        filterService: DataTableFilterService,
+        @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
+        override csvDownloadService: CsvDownloadService,
+        private growlerService: GrowlerService,
+        private dialogForm: MatDialog,
+    ) {
+        super(settings, filterService, csvDownloadService);
+    }
+
+    validate = (formData): Promise<CallbackResults> => {
+        return Promise.resolve({ passed: true});
+    }
+
+    initTableColumns(): any {
+        const nameRenderer = (row) => {
+            return `<div class="col cell-name-renderer" data-id="${row?.data?.id}">
+                <strong>${row?.data?.name}</strong>
+              </div>`
+        }
+
+        const rolesRenderer = (row) => {
+            let roles = '';
+            row?.data?.roleAttributes?.forEach((attr) => {
+                roles += '<div class="hashtag">'+attr+'</div>';
+            });
+            return roles;
+        }
+
+        const createdAtFormatter = (row) => {
+            return moment(row?.data?.createdAt).local().format('M/D/YYYY H:MM A');
+        }
+
+        return [
+            {
+                colId: 'name',
+                field: 'name',
+                headerName: 'Name',
+                headerComponent: TableColumnDefaultComponent,
+                headerComponentParams: this.headerComponentParams,
+                onCellClicked: (data) => {
+                    this.openUpdate(data.data);
+                },
+                resizable: true,
+                cellRenderer: nameRenderer,
+                cellClass: 'nf-cell-vert-align tCol',
+                sortable: true,
+                filter: true,
+                sortColumn: this.sort.bind(this),
+                sortDir: 'asc',
+                width: 300,
+            },
+            {
+                colId: 'roles',
+                field: 'roleAttributes',
+                headerName: 'Roles',
+                headerComponent: TableColumnDefaultComponent,
+                onCellClicked: (data) => {
+                    this.openUpdate(data.data);
+                },
+                resizable: true,
+                cellRenderer: rolesRenderer,
+                cellClass: 'nf-cell-vert-align tCol',
+                sortable: false,
+                filter: false,
+            },
+            {
+                colId: 'createdAt',
+                field: 'createdAt',
+                headerName: 'Created At',
+                headerComponent: TableColumnDefaultComponent,
+                valueFormatter: createdAtFormatter,
+                resizable: true,
+                sortable: true,
+                sortColumn: this.sort.bind(this),
+                cellClass: 'nf-cell-vert-align tCol',
+            }
+        ];
+    }
+
+    getData(filters?: FilterObj[], sort?: any, page?: any): Promise<any> {
+        // we can customize filters or sorting here before moving on...
+        this.paging.page = page || this.paging.page;
+        return super.getTableData('services', this.paging, filters, sort)
+            .then((results: any) => {
+                return this.processData(results);
+            });
+    }
+
+    private processData(results: any) {
+        if (!isEmpty(results?.data)) {
+            //pre-process data before rendering
+            results.data = this.addActionsPerRow(results);
+        }
+        if (!isEmpty(results?.meta?.pagination)) {
+            this.totalCount = results.meta?.pagination.totalCount;
+        }
+        return results;
+    }
+
+    private addActionsPerRow(results: any): any[] {
+        return results.data.map((row) => {
+            row.actionList = ['update', 'delete'];
+            return row;
+        });
+    }
+
+    public getServiceRoleAttributes() {
+        return this.zitiService.get('service-role-attributes', {}, []);
+    }
+
+    downloadAllItems() {
+        const paging = cloneDeep(this.paging);
+        paging.total = this.totalCount;
+        super.getTableData('services', paging, undefined, undefined)
+            .then((results: any) => {
+                return this.downloadItems(results?.data);
+            });
+    }
+
+    downloadItems(selectedItems) {
+        this.csvDownloadService.download(
+            'services',
+            selectedItems,
+            CSV_COLUMNS,
+            false,
+            false,
+            undefined,
+            false
+        );
+    }
+
+    public openUpdate(item?: any) {
+        this.modalType = 'service';
+        if (item) {
+            this.selectedService = item;
+            this.selectedService.badges = [];
+            // TODO: implement when metrics and dialog features are available
+            /*this.selectedService.moreActions = [
+                {name: 'open-metrics', label: 'Open Metrics'},
+                {name: 'dial-logs', label: 'Dial Logs'},
+                {name: 'dial-logs', label: 'View Events'},
+            ];*/
+            unset(this.selectedService, '_links');
+        } else {
+            this.selectedService = new Service();
+        }
+        this.sideModalOpen = true;
+    }
+}

--- a/projects/ziti-console-lib/src/lib/services/node-data.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/node-data.service.ts
@@ -25,6 +25,7 @@ import {HttpClient} from "@angular/common/http";
 import {FilterObj} from "../features/data-table/data-table-filter.service";
 import {isEmpty, get} from "lodash";
 import {ZitiDataService} from "./ziti-data.service";
+import {Resolver} from "@stoplight/json-ref-resolver";
 import moment from "moment";
 
 @Injectable({
@@ -265,6 +266,13 @@ export class NodeDataService extends ZitiDataService {
                 })
             )
         );
+    }
+
+    schema(data: any): Promise<any> {
+        const resolver = new Resolver();
+        return resolver.resolve(data).then((schema) => {
+            return schema.result
+        });
     }
 
     private getUrlFilter(paging: any) {

--- a/projects/ziti-console-lib/src/lib/services/schema.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/schema.service.ts
@@ -20,16 +20,19 @@ import {NumberInputComponent} from "../features/dynamic-widgets/number/number-in
 import {BooleanToggleInputComponent} from "../features/dynamic-widgets/boolean/boolean-toggle-input.component";
 import {StringInputComponent} from "../features/dynamic-widgets/string/string-input.component";
 import {SelectorInputComponent} from "../features/dynamic-widgets/selector/selector-input.component";
-import _ from "lodash";
+import _, {isNumber} from "lodash";
 import {TextListInputComponent} from "../features/dynamic-widgets/text-list/text-list-input.component";
 import {CheckboxListInputComponent} from "../features/dynamic-widgets/checkbox-list/checkbox-list-input.component";
 import {
     ProtocolAddressPortInputComponent
 } from "../features/dynamic-widgets/protocol-address-port/protocol-address-port-input.component";
+import {PortRangesComponent} from "../features/dynamic-widgets/port-ranges/port-ranges.component";
+import {ForwardingConfigComponent} from "../features/dynamic-widgets/forwarding-config/forwarding-config.component";
 
 export type ProtocolAddressPort = {
     protocol: any;
     address: any;
+    hostName: any;
     port: any;
 }
 
@@ -46,135 +49,20 @@ export class SchemaService {
     suggestId: any = null;
     suggestingField = "";
     propertyExcludes = [
-        "portchecks", 'httpchecks',
-        'protocol', 'address', 'port',
-        'forwardprotocol', 'forwardaddress', 'forwardport'
+        "portChecks", 'httpChecks',
     ]
+    reservedProperties = [];
+    reservedPropertiesMap: any = {
+        protocolAddressPort: undefined,
+        forwardProtocalAddressPort: undefined,
+        allowedAddresses: undefined,
+        forwardAddress: undefined
+    };
     private items: any[] = [];
     private bColorArray: string[] = [];
     private lColorArray: string[] = [];
 
     constructor() {
-    }
-
-    init(formId: string, codeId: string) {
-        // schema.formId = formId;
-        // if (codeId) {
-        //     schema.codeView = CodeMirror.fromTextArea(document.getElementById(codeId), {
-        //         mode: "application/json",
-        //         lineNumbers: true,
-        //         extraKeys: {"Ctrl-Space": "autocomplete"}
-        //     });
-        //     schema.codeView.setSize(null, 260);
-        //     schema.codeView.on('keyup', () => {
-        //         if (schema.timeoutId) clearTimeout(schema.timeoutId);
-        //         schema.timeoutId = setTimeout(() => {
-        //             schema.updateForm(JSON.parse(schema.codeView.getValue()));
-        //         }, 1000);
-        //     });
-        // }
-    }
-
-    toggle(e: any) {
-        // let id = $(e.currentTarget).attr("id");
-        // if ($(e.currentTarget).hasClass("on")) {
-        //     $(e.currentTarget).removeClass("on");
-        //     if (id) {
-        //         $("." + id + "_area").hide();
-        //         $("#" + id.split("forward").join("").toLowerCase()).prop("disabled", false);
-        //     }
-        // } else {
-        //     $(e.currentTarget).addClass("on");
-        //     if (id) {
-        //         $("." + id + "_area").show();
-        //         $("#" + id.split("forward").join("").toLowerCase()).prop("disabled", true);
-        //         if ($("#" + id.split("forward").join("").toLowerCase()).prop('nodeName') == "INPUT") $("#" + id.split("forward").join("").toLowerCase()).val("");
-        //     }
-        // }
-    }
-
-    suggest(e: any) {
-        // let element = $(e.currentTarget);
-        // schema.suggestingField = element.attr("id");
-        // let suggestionSource = element.data("suggest");
-        // schema.suggesting = new Data(suggestionSource);
-        // schema.suggesting.closeModals = false;
-        // schema.suggesting.init(false, false, false);
-        // context.removeListener(suggestionSource);
-        // context.addListener(suggestionSource, schema.suggestLoaded);
-        //
-        // if (this.suggestId) clearTimeout(this.suggestId);
-        //
-        // schema.suggesting.paging.filter = element.val();
-        // if (e.keyCode == 13) {
-        //     schema.suggesting.get();
-        // } else {
-        //     this.suggestId = setTimeout(schema.suggesting.get.bind(schema.suggesting), 500);
-        // }
-    }
-
-    suggestLoaded(e: any) {
-        // let list = $("#" + schema.suggestingField + "_Suggestions");
-        // list.html("");
-        // if (e.data.length > 0) {
-        //     for (let i = 0; i < e.data.length; i++) {
-        //         list.append('<div class="suggestItem" data-field="' + schema.suggestingField + '">' + e.data[i].name + '</div>');
-        //     }
-        //     list.addClass("open");
-        //     $(".suggestItem").click((e: any) => {
-        //         let suggested = $(e.currentTarget);
-        //         $("#" + suggested.data("field")).val(suggested.html());
-        //         $("#" + schema.suggestingField + "_Suggestions").removeClass("open");
-        //         $("#" + schema.suggestingField + "_Suggestions").html("");
-        //     });
-        // } else {
-        //     list.removeClass("open");
-        // }
-    }
-
-    subobject(e: any) {
-        // let obj = $(e.currentTarget);
-        // let id = obj.data("id");
-        // let to = obj.data("to");
-        // let vals = obj.data("values").split(',');
-        // let val = "";
-        // let types = [];
-        // for (let i = 0; i < vals.length; i++) {
-        //     val += ((i > 0) ? "" : "") + vals[i] + ": " + $("#" + id + "_" + vals[i]).val();
-        //     $("#" + id + "_" + vals[i]).val("");
-        //     if ($("#" + id + "_" + vals[i]).attr('type') == "number") {
-        //         types.push("number");
-        //     } else {
-        //         types.push("string");
-        //     }
-        // }
-        // let element = $('<div class="tag obj" data-types="' + types.toString() + '">' + val + '</div>');
-        // element.click(schema.removeMe);
-        // $("#" + to).append(element);
-    }
-
-    addBlurArray(e: any) {
-        // let id = $(e.currentTarget).prop("id");
-        // let val = $(e.currentTarget).val().split('').join('').trim();
-        // if (val.length > 0) {
-        //     let element = $('<div class="tag">' + val + '</div>');
-        //     element.click(schema.removeMe);
-        //     $("#" + id + "_selected").append(element);
-        //     $(e.currentTarget).val("");
-        // }
-    }
-
-    addArray(e: any) {
-        // if (e.keyCode == 188 || e.keyCode == 13) {
-        //     let id = $(e.currentTarget).prop("id");
-        //     let val = $(e.currentTarget).val().split('').join('').trim();
-        //     if (val.length > 0) {
-        //         let element = $('<div class="tag">' + val + '</div>');
-        //         element.click(schema.removeMe);
-        //         $("#" + id + "_selected").append(element);
-        //         $(e.currentTarget).val("");
-        //     }
-        // }
     }
 
     getType(property: any) {
@@ -194,6 +82,22 @@ export class SchemaService {
         }
     }
 
+    renderSchema(schema, dynamicForm, lColorArray, bColorArray, formData) {
+        if (schema.properties) {
+            this.items = this.render(schema, dynamicForm, lColorArray, bColorArray);
+            for (let obj of this.items) {
+                const cRef = obj.component;
+                if (cRef?.instance.valueChange) {
+                    const pName: string[]  = cRef.instance.parentage;
+                    let parentKey;
+                    if(pName) parentKey = pName.join('.');
+                    if (parentKey && !formData[parentKey]) formData[parentKey] = {};
+                }
+            }
+        }
+        return this.items;
+    }
+
     render(schema: any, view: ViewContainerRef, lColorArray: string[], bColorArray: string[]) {
         this.items = [];
         this.bColorArray = bColorArray;
@@ -201,14 +105,16 @@ export class SchemaService {
         if (schema.properties) {
             const nestLevel = 0;
             this.addFields(schema, view, nestLevel, []);
-            // if (schema.codeView != null) {
-            //     setTimeout(() => {
-            //         let json = schema.val();
-            //         schema.codeView.setValue(JSON.stringify(json));
-            //         schema.codeView.autoFormatRange({line: 0, ch: 0}, {line: schema.codeView.lineCount()});
-            //     }, 500);
-            // }
         }
+        const itemsToAdd = [];
+        if (this.reservedPropertiesMap.protocolAddressPort) {
+            itemsToAdd.push(this.reservedPropertiesMap.protocolAddressPort);
+        }
+        if (this.reservedPropertiesMap.allowedAddresses && this.reservedPropertiesMap.forwardAddress) {
+            itemsToAdd.push(this.reservedPropertiesMap.forwardAddress);
+            itemsToAdd.push(this.reservedPropertiesMap.allowedAddresses);
+        }
+        this.items = [...itemsToAdd, ...this.items];
         return this.items;
     }
 
@@ -221,8 +127,7 @@ export class SchemaService {
     validateFields(schema, formData: any, parentage?: string): any {
         let errors = {};
         for (let key in schema.properties) {
-            const k = key.toLowerCase();
-            errors = {...errors, ...this.validateField(k, schema, formData, schema.properties[key], parentage)};
+            errors = {...errors, ...this.validateField(key, schema, formData, schema.properties[key], parentage)};
         }
         return errors;
     }
@@ -462,7 +367,7 @@ export class SchemaService {
         }
     }
 
-    private buildNestedContainer(view: ViewContainerRef, nestLevel: number, key: string, parentage: string[], property: any) {
+    private buildNestedContainer(view: ViewContainerRef, nestLevel: number, key: string, parentage: string[], property: any, parent?: any) {
         let componentRef = view.createComponent(ObjectComponent);
         componentRef.setInput('fieldName', this.getLabel(key));
         if (parentage && !_.isEmpty(parentage)) componentRef.setInput('parentage', parentage);
@@ -470,7 +375,7 @@ export class SchemaService {
         const embeddedView = componentRef.instance.wrapperContents;
         componentRef.setInput('labelColor', this.lColorArray[nestLevel]);
         const newParent = [...parentage, key]
-        this.addFields(property, embeddedView, ++nestLevel, newParent);
+        this.addFields(property, embeddedView, ++nestLevel, newParent, parent);
         return componentRef;
     }
 
@@ -478,8 +383,11 @@ export class SchemaService {
         let componentRef = view.createComponent(BooleanToggleInputComponent);
         componentRef.setInput('fieldName', this.getLabel(key));
         if (parentage && !_.isEmpty(parentage)) componentRef.setInput('parentage', parentage);
-        componentRef.setInput('fieldValue', '');
+        componentRef.setInput('fieldValue', false);
         componentRef.setInput('labelColor', this.lColorArray[nestLevel]);
+        componentRef.instance.fieldValueChange.subscribe((event) => {
+            this.checkBoxChanged(event, key, componentRef);
+        });
         return componentRef;
     }
 
@@ -503,19 +411,19 @@ export class SchemaService {
         let componentRef = view.createComponent(NumberInputComponent);
         componentRef.setInput('fieldName', this.getLabel(key));
         if (parentage && !_.isEmpty(parentage)) componentRef.setInput('parentage', parentage);
-        componentRef.setInput('fieldValue', false);
+        componentRef.setInput('fieldValue', undefined);
         componentRef.setInput('placeholder', placeholder);
         componentRef.setInput('labelColor', this.lColorArray[nestLevel]);
         return componentRef;
     }
 
     private buildSelectField(view: ViewContainerRef, nestLevel: number, key: string, list: string[], parentage: string[]) {
+        const val = list?.length > 0 ? list[0] : '';
         let componentRef = view.createComponent(SelectorInputComponent);
         componentRef.setInput('fieldName', this.getLabel(key));
         if (parentage && !_.isEmpty(parentage)) componentRef.setInput('parentage', parentage);
-        componentRef.setInput('fieldValue', '');
+        componentRef.setInput('fieldValue', val);
         componentRef.setInput('valueList', list);
-        componentRef.setInput('placeholder', `select a value`);
         componentRef.setInput('labelColor', this.lColorArray[nestLevel]);
         return componentRef;
     }
@@ -524,21 +432,51 @@ export class SchemaService {
         let componentRef = view.createComponent(CheckboxListInputComponent);
         componentRef.setInput('fieldName', this.getLabel(key));
         if (parentage && !_.isEmpty(parentage)) componentRef.setInput('parentage', parentage);
-        componentRef.setInput('fieldValue', '');
+        componentRef.setInput('fieldValue', []);
         componentRef.setInput('valueList', list);
         componentRef.setInput('placeholder', `select a value`);
         componentRef.setInput('labelColor', this.lColorArray[nestLevel]);
         return componentRef;
     }
 
+    checkBoxChanged(event, key, componentRef) {
+        this.items.forEach((ref: any) => {
+            if (key === 'forwardAddress' && ref.key === 'allowedAddresses') {
+                ref.component.location.nativeElement.hidden = !event;
+            }
+            if (key === 'forwardPort' && ref.key === 'allowedPortRanges') {
+                ref.component.location.nativeElement.hidden = !event;
+            }
+            if (key === 'forwardProtocol' && ref.key === 'allowedProtocols') {
+                ref.component.location.nativeElement.hidden = !event;
+            }
+        });
+    }
+
     private buildTextListField(view: ViewContainerRef, nestLevel: number, key: string, parentage: string[]) {
         let componentRef = view.createComponent(TextListInputComponent);
         componentRef.setInput('fieldName', this.getLabel(key));
         if (parentage && !_.isEmpty(parentage)) componentRef.setInput('parentage', parentage);
-        componentRef.setInput('fieldValue', ['test1', 'test2']);
+        componentRef.setInput('fieldValue', []);
         componentRef.setInput('placeholder', `enter values separated with a comma`);
         componentRef.setInput('labelColor', this.lColorArray[nestLevel]);
         return componentRef;
+    }
+
+    private buildPortRanges(view: ViewContainerRef, nestLevel: number, parentage: string[], properties: ProtocolAddressPort) {
+        let componentRef = view.createComponent(PortRangesComponent);
+        return {
+            key: 'portRanges',
+            component: componentRef
+        };
+    }
+
+    private buildForwardingConfig(view: ViewContainerRef, nestLevel: number, parentage: string[], properties: ProtocolAddressPort) {
+        let componentRef = view.createComponent(ForwardingConfigComponent);
+        return {
+            key: 'forwardingconfig',
+            component: componentRef
+        };
     }
 
     private buildProtocolAddressPort(view: ViewContainerRef, nestLevel: number, parentage: string[], properties: ProtocolAddressPort) {
@@ -546,28 +484,35 @@ export class SchemaService {
         let protocolList = undefined;
         let showProtocol = false;
         let showAddress = false;
+        let showHostName = false;
         let showPort = false;
         if (properties.protocol) {
             showProtocol = true;
-            protocolList = properties.protocol.items.enum.map(p => p.toUpperCase());
-            if (properties.protocol.key.startsWith('forward')) labelPrefix = 'Forward ';
+            protocolList = properties.protocol?.enum?.map(p => p.toUpperCase());
+            if (properties.protocol?.key?.startsWith('forward')) labelPrefix = 'Forward ';
         }
         if (properties.address) {
             showAddress = true;
-            if (properties.address.key.startsWith('forward')) labelPrefix = 'Forward ';
+            if (properties.address?.key?.startsWith('forward')) labelPrefix = 'Forward ';
+        }
+        if (properties.hostName) {
+            showHostName = true;
+            if (properties.hostName?.key?.startsWith('forward')) labelPrefix = 'Forward ';
         }
         if (properties.port) {
             showPort = true;
-            if (properties.port.key.startsWith('forward')) labelPrefix = 'Forward ';
+            if (properties.port?.key?.startsWith('forward')) labelPrefix = 'Forward ';
         }
         let componentRef = view.createComponent(ProtocolAddressPortInputComponent);
         if (parentage && !_.isEmpty(parentage)) componentRef.setInput('parentage', parentage);
         componentRef.setInput('showProtocol', showProtocol);
         componentRef.setInput('showAddress', showAddress);
+        componentRef.setInput('showHostName', showHostName);
         componentRef.setInput('showPort', showPort);
-        componentRef.setInput('protocolValue', '');
-        componentRef.setInput('addressValue', '');
-        componentRef.setInput('portValue', '');
+        componentRef.setInput('protocol', '');
+        componentRef.setInput('address', '');
+        componentRef.setInput('hostName', '');
+        componentRef.setInput('port', '');
         componentRef.setInput('protocolList', protocolList);
         if (labelPrefix) componentRef.setInput('labelPrefix', labelPrefix);
         componentRef.setInput('labelColor', this.lColorArray[nestLevel]);
@@ -581,17 +526,44 @@ export class SchemaService {
         return key.replace(/([A-Z])/g, (m, p) => ' ' + p).toUpperCase();
     }
 
-    private addFields(schema: any, view: ViewContainerRef, nestLevel: number, parentage: string[]) {
-        // this.addSpecialFields(schema, view, nestLevel, parentage);
+    private addFields(schema: any, view: ViewContainerRef, nestLevel: number, parentage: string[], parent?: any) {
+        const excludedProperites = this.addSpecialFields(schema, view, nestLevel, parentage);
         for (let key in schema.properties) {
-            const k = key.toLowerCase();
-            // if (this.propertyExcludes.indexOf(k) < 0) {
-            this.items.push({
-                key: k,
-                component: this.addField(view, nestLevel, key, schema.properties[key], parentage)
-            });
-            // }
+            if (excludedProperites.includes(key) || this.propertyExcludes.includes(key)) {
+                continue;
+            }
+            let item: any = {};
+            const component = this.addField(view, nestLevel, key, schema.properties[key], parentage, item);
+            item.key = key;
+            item.component = component;
+            if (this.reservedProperties.includes(key)) {
+                this.reservedPropertiesMap[key] = item;
+            } if (parentage.length > 0) {
+                if (parent?.items) {
+                    parent.items.push(item);
+                } else if (parent) {
+                    parent.items = [item];
+                }
+            } else {
+                this.items.push(item);
+            }
         }
+    }
+
+    private addFieldToParentItem(itemToAdd, parentage) {
+        let parentItem;
+        let items = this.items;
+        parentage.forEach((parent: any) => {
+            items.forEach((item: any) => {
+                if (item.key === parent) {
+                    parentItem = item;
+                    if (item.items) {
+                        items = item.items;
+                    }
+                }
+            })
+        });
+        parentItem.items = itemToAdd;
     }
 
     private addSpecialFields(schema: any, view: ViewContainerRef, nestLevel: number, parentage: string[]) {
@@ -602,35 +574,50 @@ export class SchemaService {
         let forwardProtocol = undefined;
         let forwardPort = undefined;
         let forwardAddress = undefined;
+        let portRanges = undefined;
+        let excludedProperties = [];
         for (let key in schema.properties) {
+            let exclude = true;
             if (key === "port") port = schema.properties[key];
             else if (key === "address") address = schema.properties[key];
             else if (key === "hostname") hostName = schema.properties[key];
             else if (key === "protocol") protocol = schema.properties[key];
-            else if (key === "forwardprotocol") forwardProtocol = schema.properties[key];
-            else if (key === "forwardport") forwardPort = schema.properties[key];
-            else if (key === "forwardaddress") forwardAddress = schema.properties[key];
+            else if (key === "forwardProtocol") forwardProtocol = schema.properties[key];
+            else if (key === "forwardPort") forwardPort = schema.properties[key];
+            else if (key === "forwardAddress") forwardAddress = schema.properties[key];
+            else if (key === "portRanges") portRanges = schema.properties[key];
+            else exclude = false;
+
+            if (exclude) {
+                excludedProperties.push(key);
+            }
         }
-        if (protocol || address || port) {
-            const properties: ProtocolAddressPort = {protocol, address, port};
+        if ((protocol || address || hostName || port) && !(forwardProtocol && forwardAddress && forwardPort)) {
+            const properties: ProtocolAddressPort = {protocol, address, hostName, port};
             this.items.push(this.buildProtocolAddressPort(view, nestLevel, parentage, properties));
         }
-        if (forwardProtocol || forwardAddress || forwardPort) {
+        if (forwardProtocol && forwardAddress && forwardPort) {
             const properties: ProtocolAddressPort = {
                 protocol: forwardProtocol,
                 address: forwardAddress,
+                hostName: undefined,
                 port: forwardPort
             };
-            this.items.push(this.buildProtocolAddressPort(view, nestLevel, parentage, properties));
+            this.items.push(this.buildForwardingConfig(view, nestLevel, parentage, properties));
+            excludedProperties = [...excludedProperties, ...['allowedAddresses', 'allowedPortRanges', 'allowedProtocols']];
         }
+        if (portRanges) {
+            this.items.push(this.buildPortRanges(view, nestLevel, parentage, portRanges));
+        }
+        return excludedProperties;
     }
 
-    private addField(view: ViewContainerRef, nestLevel: number, key: string, property: any, parentage: string[]) {
+    private addField(view: ViewContainerRef, nestLevel: number, key: string, property: any, parentage: string[], parent?: any) {
         const type = this.getType(property);
         let componentRef: ComponentRef<any> | null = null;
         if (type == "object") {
-            if (property.properties != null) {
-                componentRef = this.buildNestedContainer(view, nestLevel, key, parentage, property);
+            if (property.properties) {
+                componentRef = this.buildNestedContainer(view, nestLevel, key, parentage, property, parent);
             }
         } else if (type == "integer") {
             componentRef = this.buildNumericField(view, nestLevel, key, property, parentage);
@@ -641,35 +628,14 @@ export class SchemaService {
             if (items.items) items = items.items;
 
             if (items.type && items.type == "object" && items.properties != null) {
-                componentRef = this.buildNestedContainer(view, nestLevel, key, parentage, property);
-                // if (items.type && items.type == "object" && items.properties != null) {
-                //     let properties = items.properties;
-                //     html += '<div id="' + ((parentage != null) ? parentage + '_' : '') + 'schema_' + key + '_selected" class="selectedItems"></div>';
-                //     html += '<div class="subform">';
-                //     let values = [];
-                //     if (key == "portRanges" || key == "allowedPortRanges") html += '<div class="grid splitadd">';
-                //     let order = ['low', 'high'];
-                //     let subItems = [];
-                //     for (let subKey in properties) {
-                //         subItems.push({
-                //             key: key,
-                //             subKey: subKey,
-                //             value: properties[subKey]
-                //         });
-                //     }
-                //     subItems.sort(function (a, b) {
-                //         let aPort = a.subKey.replace(/[^A-Za-z]+/g, '').toLowerCase().replace(/\s/g, '');
-                //         let bPort = b.subKey.replace(/[^A-Za-z]+/g, '').toLowerCase().replace(/\s/g, '');
-                //         return order.indexOf(aPort) - order.indexOf(bPort);
-                //     });
-                //     for (let i = 0; i < subItems.length; i++) {
-                //         values.push(subItems[i].subKey);
-                //         html += this.getField(subItems[i].subKey, subItems[i].value, subItems[i].key);
-                //     }
-                //     html += '<div><div id="' + ((parentage != null) ? parentage + '_' : '') + 'schema_' + key + '_Button" class="button subobject" data-id="' + key + '_schema" data-to="' + ((parentage != null) ? parentage + '_' : '') + 'schema_' + key + '_selected" data-values="' + values.toString() + '">Add</div></div>'
-                //     if (key == "portRanges") html += '</div>';
-                //     html += '</div></div>';
-                // } else
+                const subItems = [];
+                for (var subKey in items.properties) {
+                    subItems.push({
+                        key: subKey,
+                        value: items.properties[subKey]
+                    });
+                }
+                componentRef = this.buildNestedContainer(view, nestLevel, key, parentage, items, parent);
             } else if (Array.isArray(items.enum)) {
                 componentRef = this.buildCheckBoxListField(view, nestLevel, key, items.enum, parentage);
 
@@ -679,36 +645,6 @@ export class SchemaService {
             }
         } else if (type == "boolean") {
             componentRef = this.buildBooleanField(view, nestLevel, key, parentage);
-
-            // html = '<div>' + html;
-            // html += '<div id="schema_' + key + '" class="toggle"><div class="switch"></div><div class="label"></div></div></div>';
-            // if (key == "dialInterceptedAddress") {
-            //     html += '<div class="schema_dialInterceptedAddress_area" style="display:none">';
-            //     html += '<label for="schema_' + key + '_allowedAddresses">Forward Addresses</label>';
-            //     html += '<div id="schema_' + key + '_allowedAddresses_selected" class="selectedItems"></div>';
-            //     html += '<input id="schema_' + key + '_allowedAddresses" type="text" class="jsonEntry arrayEntry" placeholder="enter values seperated with a comma"/></div>';
-            //     html += "</div>";
-            // }
-            // if (key == "dialInterceptedPort") {
-            //     html += '<div class="schema_dialInterceptedPort_area" style="display:none">';
-            //     html += '<label for="schema_' + key + '_allowedPorts">Forward Port Ranges</label>';
-            //     html += '<div id="schema_' + key + '_allowedPorts_selected" class="selectedItems"></div>';
-            //
-            //     html += '<div class="subform"><div class="grid splitadd">';
-            //     html += '<div><label for="">High</label>';
-            //     html += '<input id="schema_' + key + '_allowedPorts_high" type="text" class="jsonEntry" placeholder="enter the value"/></div>';
-            //     html += '<div><label for="">Low</label>';
-            //     html += '<input id="schema_' + key + '_allowedPorts_low" type="text" class="jsonEntry" placeholder="enter the value"/></div>';
-            //     html += '<lab><div id="' + key + '_Button" class="button subobject" data-id="schema_' + key + '_allowedPorts" data-to="schema_' + key + '_allowedPorts_selected" data-types="number,number" data-values="high,low">Add</div></label>'
-            //     html += '</div></div></div>';
-            // }
-            // if (key == "dialInterceptedProtocol") {
-            //     html += '<div class="schema_dialInterceptedProtocol_area" style="display:none">';
-            //     html += '<label for="schema_' + key + '_allowedProtocols">Forward Protocols</label>';
-            //     html += '<div id="schema_' + key + '_allowedProtocols_selected" class="selectedItems"></div>';
-            //     html += '<input id="schema_' + key + '_allowedProtocols" type="text" class="jsonEntry arrayEntry" placeholder="enter values seperated with a comma"/></div>';
-            //     html += "</div>";
-            // }
         } else if (property.enum && property.enum.length > 0) {
             componentRef = this.buildSelectField(view, nestLevel, key, property.enum, parentage);
 
@@ -718,90 +654,75 @@ export class SchemaService {
         return componentRef;
     }
 
-    // val(schema: any, value: any, bypass: boolean) {
-    //     if (value != null) {
-    //         if (schema.properties) {
-    //             for (let key in schema.properties) {
-    //                 let property = schema.properties[key];
-    //                 let type = this.getType(property);
-    //                 if (type == "object") {
-    //                     if (value[key] == null) value[key] = {};
-    //                     if (property.properties != null) {
-    //                         for (let subKey in property.properties) {
-    //                             value[key][subKey] = this.setValue(schema, subKey, type, value[key][subKey], key);
-    //                         }
-    //                     }
-    //                 } else value[key] = this.setValue(schema, key, type, value[key]);
-    //             }
-    //             // if (!bypass) {
-    //             //     schema.codeView.setValue(JSON.stringify(value));
-    //             //     schema.codeView.autoFormatRange({line: 0, ch: 0}, {line: schema.codeView.lineCount()});
-    //             //     schema.codeView.setSize(null, 260);
-    //             // }
-    //         }
-    //     } else {
-    //         let json: any = {};
-    //         if (schema.properties) {
-    //             for (let key in schema.properties) {
-    //                 let property = schema.properties[key];
-    //                 if (this.getType(property) == "object") {
-    //                     json[key] = {};
-    //                     if (property.properties != null) {
-    //                         for (let subKey in property.properties) {
-    //                             json[key] = this.getValue(schema, subKey, property.properties[subKey], json[key]);
-    //                         }
-    //                     }
-    //                 } else json = this.getValue(schema, key, property, json);
-    //             }
-    //             if (json.dialInterceptedAddress) {
-    //                 json.allowedAddresses = schema.getListValue('schema_dialInterceptedAddress_allowedAddresses');
-    //                 json.forwardAddress = true;
-    //                 delete json.address;
-    //                 delete json.dialInterceptedAddress;
-    //             } else {
-    //                 delete json.dialInterceptedAddress;
-    //             }
-    //             if (json.dialInterceptedProtocol) {
-    //                 json.allowedProtocols = schema.getListValue('schema_dialInterceptedProtocol_allowedProtocols');
-    //                 json.forwardProtocol = true;
-    //                 delete json.protocol;
-    //                 delete json.dialInterceptedProtocol;
-    //             } else {
-    //                 delete json.dialInterceptedProtocol;
-    //             }
-    //             if (json.dialInterceptedPort) {
-    //                 json.allowedPortRanges = schema.getListValue('schema_dialInterceptedPort_allowedPorts');
-    //                 json.forwardPort = true;
-    //                 delete json.port;
-    //                 delete json.dialInterceptedPort;
-    //             } else {
-    //                 delete json.dialInterceptedPort;
-    //             }
-    //             if (json.forwardProtocol) {
-    //                 delete json.protocol;
-    //             } else {
-    //                 delete json.forwardProtocol;
-    //                 delete json.allowedProtocols;
-    //             }
-    //             if (json.forwardPort) {
-    //                 delete json.port;
-    //             } else {
-    //                 delete json.forwardPort;
-    //                 delete json.allowedPortRanges;
-    //             }
-    //             if (json.forwardAddress) {
-    //                 delete json.address;
-    //             } else {
-    //                 delete json.forwardAddress;
-    //                 delete json.allowedAddresses;
-    //             }
-    //             // if (json.listenOptions) delete json.listenOptions;
-    //             if (json.httpChecks) delete json.httpChecks;
-    //             if (json.portChecks) delete json.portChecks;
-    //         }
-    //         return json;
-    //     }
-    // }
+    getPortRanges(allowedPortRanges) {
+        if (!allowedPortRanges) {
+            return [];
+        }
+        const ranges = [];
+        allowedPortRanges.forEach((val: string) => {
+            const vals = val.split('-');
+            if (vals.length === 1) {
+                const port = parseInt(val);
+                ranges.push({high: port, low: port});
+            } else if (vals.length === 2) {
+                const port1 = parseInt(vals[0]);
+                const port2 = parseInt(vals[1]);
+                ranges.push({low: port1, high: port2});
+            } else {
+                // do nothing, invalid range
+            }
+        });
+        return ranges;
+    }
+
+    parseAllowedPortRanges(allowedPortRanges) {
+        const val = [];
+        if (!allowedPortRanges) {
+            return val;
+        }
+        allowedPortRanges.forEach((range: any) => {
+            if (range.low === range.high) {
+                val.push(range.low + '');
+            } else {
+                val.push(range.low + '-' + range.high);
+            }
+        });
+        return val;
+    }
+
+    validatePortRanges(allowedPortRanges) {
+        let invalid = false;
+        if (!allowedPortRanges) {
+            return invalid;
+        }
+        allowedPortRanges.forEach((val: string) => {
+            const vals = val.split('-');
+            if (vals.length === 1) {
+                const port = parseInt(val);
+                if (!this.isValidPort(port)) {
+                    invalid = true;
+                    return;
+                }
+            } else if (vals.length === 2) {
+                const port1 = parseInt(vals[0]);
+                const port2 = parseInt(vals[1]);
+                if (!this.isValidPort(port1) || !this.isValidPort(port2)) {
+                    invalid = true;
+                    return;
+                } else if (port1 > port2) {
+                    invalid = true;
+                    return;
+                }
+            } else {
+                invalid = true;
+            }
+        });
+        return invalid;
+    }
+
+    isValidPort(port) {
+        return !isNaN(port) && isNumber(port) && port >= 1 && port <= 65535;
+    }
 
     private addError(errors: any, key: string, msg: string) {
         if (errors[key]) errors[key] = `${errors[key]}; ${msg}`;

--- a/projects/ziti-console-lib/src/lib/services/ziti-controller-data.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/ziti-controller-data.service.ts
@@ -25,6 +25,7 @@ import {HttpClient} from "@angular/common/http";
 import {FilterObj} from "../features/data-table/data-table-filter.service";
 import {ZitiDataService} from "./ziti-data.service";
 import {isEmpty, get} from "lodash";
+import {Resolver} from "@stoplight/json-ref-resolver";
 import moment from "moment";
 
 @Injectable({
@@ -244,4 +245,13 @@ export class ZitiControllerDataService extends ZitiDataService {
         return urlFilter;
     }
 
+    override schema(data): Promise<any> {
+        return Promise.resolve(this.dereferenceJSONSchema(data));
+    }
+
+    async dereferenceJSONSchema(data: any) {
+        const resolver = new Resolver();
+        const schema = await resolver.resolve(data);
+        return schema.result;
+    }
 }

--- a/projects/ziti-console-lib/src/lib/services/ziti-data.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/ziti-data.service.ts
@@ -46,4 +46,5 @@ export abstract class ZitiDataService {
   abstract delete(type: string, id: string): Promise<any>;
   abstract call(url: string): Promise<any>;
   abstract resetEnrollment(id: string, any: string): Promise<any>;
+  abstract schema(data: any): Promise<any>;
 }

--- a/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
+++ b/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
@@ -102,6 +102,60 @@ body {
   }
 }
 
+.form-field-row {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+}
+
+.form-field-dropdown {
+  background-image: url(/assets/svgs/ArrowDown.svg);
+  background-position: center right 10px;
+  background-repeat: no-repeat;
+  background-size: 18px;
+  padding-right: 28px;
+  min-height: 50px;
+}
+
+.form-field-input {
+  min-height: 50px;
+}
+
+.form-field-input-group {
+  padding: 15px;
+  background-color: var(--formGroup);
+  border-radius: 7px;
+
+  &[hidden] {
+    display: none !important;
+  }
+}
+
+.form-field-extended-fields {
+  padding: 15px;
+  background-color: var(--formSubGroup);
+  border-radius: 7px;
+  &[hidden] {
+    display: none !important;
+  }
+}
+
+.form-field-title {
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--tableText);
+  text-transform: uppercase;
+  height: 14px;
+}
+
+.button-row-right {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+}
+
 .save-button {
   display: flex;
   align-items: center;
@@ -538,6 +592,32 @@ lib-form-field-container {
     }
     .off-label {
       margin-left: 27px;
+    }
+  }
+}
+
+.page {
+  .p-element {
+    .p-chips.p-component {
+      .p-inputtext.p-chips-multiple-container {
+        box-shadow: none;
+      }
+      &.p-input-wrapper {
+        &.p-focus {
+          border-color: var(--primary);
+        }
+        .p-chips-token {
+          background: var(--primary);
+          color: var(--offWhite);
+        }
+      }
+    }
+    &.error {
+      .p-chips.p-component {
+        &.p-input-wrapper {
+          border-color: var(--red);
+        }
+      }
     }
   }
 }

--- a/projects/ziti-console-lib/src/lib/shared/list-page-service.class.ts
+++ b/projects/ziti-console-lib/src/lib/shared/list-page-service.class.ts
@@ -47,6 +47,7 @@ export abstract class ListPageServiceClass {
         sort: "name",
         total: 50
     }
+    totalCount = 0;
     dataService: ZitiDataService;
     refreshData: (sort?: {sortBy: string, ordering: string}) => void | undefined;
 

--- a/projects/ziti-console-lib/src/lib/ziti-console-lib.module.ts
+++ b/projects/ziti-console-lib/src/lib/ziti-console-lib.module.ts
@@ -17,7 +17,7 @@
 import {APP_INITIALIZER, InjectionToken, Injector, NgModule} from '@angular/core';
 import {ZacWrapperComponent} from "./features/wrappers/zac-wrapper.component";
 import {SafePipe} from "./safe.pipe";
-import {HttpClientModule} from "@angular/common/http";
+import {HttpClientModule, HttpClient} from "@angular/common/http";
 import {CommonModule} from "@angular/common";
 import {FormsModule} from "@angular/forms";
 import {ZacRoutingModule} from "./zac-routing.module";
@@ -57,6 +57,7 @@ import {FilterBarComponent} from "./features/data-table/table-filter-bar/filter-
 import {AgGridModule} from "ag-grid-angular";
 import {IdentitiesPageComponent} from "./pages/identities/identities-page.component";
 import {EdgeRoutersPageComponent} from "./pages/edge-routers/edge-routers-page.component";
+import {ServicesPageComponent} from "./pages/services/services-page.component";
 import {ZITI_NAVIGATOR} from "./ziti-console.constants";
 import { GrowlerComponent } from './features/messaging/growler.component';
 import { ConfirmComponent } from './features/confirm/confirm.component';
@@ -84,6 +85,10 @@ import { OverridesComponent } from './features/overrides/overrides.component';
 import { ResetEnrollmentComponent } from './features/reset-enrollment/reset-enrollment.component';
 import { CustomTagsComponent } from './features/custom-tags/custom-tags.component';
 import {EdgeRouterFormComponent} from "./features/projectable-forms/edge-router/edge-router-form.component";
+
+import {ServiceFormComponent} from "./features/projectable-forms/service/service-form.component";
+import { PortRangesComponent } from './features/dynamic-widgets/port-ranges/port-ranges.component';
+import { ForwardingConfigComponent } from './features/dynamic-widgets/forwarding-config/forwarding-config.component';
 
 export function playerFactory() {
     return import(/* webpackChunkName: 'lottie-web' */ 'lottie-web');
@@ -142,6 +147,10 @@ export function playerFactory() {
         OverridesComponent,
         ResetEnrollmentComponent,
         CustomTagsComponent,
+        ServicesPageComponent,
+        ServiceFormComponent,
+        PortRangesComponent,
+        ForwardingConfigComponent,
     ],
     imports: [
         CommonModule,
@@ -178,13 +187,15 @@ export function playerFactory() {
         EdgeRouterFormComponent,
         IdentitiesPageComponent,
         EdgeRoutersPageComponent,
+        ServicesPageComponent,
         ZacRoutingModule,
         SideModalComponent,
         IdentityFormComponent,
         LoadingIndicatorComponent,
         GrowlerModule,
         FormFieldContainerComponent,
-        FormFieldToggleComponent
+        FormFieldToggleComponent,
+        ServiceFormComponent
     ],
     providers: [
         {provide: SHAREDZ_EXTENSION, useClass: ExtensionsNoopService},

--- a/projects/ziti-console-lib/src/public-api.ts
+++ b/projects/ziti-console-lib/src/public-api.ts
@@ -12,6 +12,8 @@ export * from './lib/pages/identities/identities-page.component';
 export * from './lib/pages/identities/identities-page.service';
 export * from './lib/pages/edge-routers/edge-routers-page.component';
 export * from './lib/pages/edge-routers/edge-routers-page.service';
+export * from './lib/pages/services/services-page.component';
+export * from './lib/pages/services/services-page.service';
 export * from './lib/services/login-service.class';
 export * from './lib/services/noop-login.service';
 export * from './lib/services/settings-service.class';
@@ -49,6 +51,8 @@ export * from './lib/features/projectable-forms/identity/identity-form.component
 export * from './lib/features/projectable-forms/identity/identity-form.service';
 export * from './lib/features/projectable-forms/edge-router/edge-router-form.component';
 export * from './lib/features/projectable-forms/edge-router/edge-router-form.service';
+export * from './lib/features/projectable-forms/service/service-form.component';
+export * from './lib/features/projectable-forms/service/service-form.service';
 export * from './lib/features/extendable/extensions-noop.service';
 export * from './lib/features/projectable-forms/form-header/form-header.component';
 export * from './lib/features/loading-indicator/loading-indicator.component';


### PR DESCRIPTION
* List page with ag-grid for displaying services
* Create/Edit screen for defining services
* Generation of inputs/form fields when adding Configs to a service based on selected Config Type schema
* Toggle between Form View and JSON View when editing a config
<img width="1438" alt="Screen Shot 2024-01-16 at 7 56 58 AM" src="https://github.com/openziti/ziti-console/assets/102923745/158b07c0-01ff-4114-a2d8-8327dbd36c70">
