### PR TITLE
Added options to identities page list menu & QR Code component to support "re-issue" action for enrollment tokens

### DIFF
--- a/projects/ziti-console-lib/src/lib/assets/languages/en-us.json
+++ b/projects/ziti-console-lib/src/lib/assets/languages/en-us.json
@@ -58,7 +58,8 @@
     "ZitiWizard": "Ziti Wizard",
     "WizardService": "Follow these steps to create a ziti service configuration",
     "ServiceName": "Service Name",
-
+    "ConfigName": "Config Name",
+    "NewConfigName": "New Config Name",
     "EnterName": "enter a name...",
     "EnterNameConfig": "enter a name for the config...",
     "EnterEMail": "enter your email address...",
@@ -109,8 +110,11 @@
     "ConfigurationTypes": "Configuration Types",
     "Configuration": "Configuration",
     "Configurations": "Configurations",
+    "AddConfigurations": "Add Configurations",
     "JSONConfiguration": "JSON Configuration",
+    "ConfigurationForm": "Configuration Form",
     "Schema": "Schema",
+    "CreateAndAttach": "Create and Attach",
     "AttachService": "Attach to Service",
     "ManageFields": "Manage Custom Fields",
     "ManageServers": "Manage Servers",
@@ -253,6 +257,11 @@
     "ExternalId": "External ID",
     "EnterExternal": "Enter external identifier",
     "SelectAuthPolicy": "Select an Auth Policy...",
+    "SelectAConfig": "Select a Config",
+    "SelectConfiguration": "Select configuration...",
+    "SelectConfigurationType": "Select configuration type...",
+    "SelectedConfigurations": "Selected Configurations",
+    "SelectARouter": "Select a Router...",
     "MinPasswordLength": "Minimum Length",
     "SelectJwtSigners": "Search and Selact Associated JWT Signers",
     "TypeToFilter": "Type to filter or enter to add value",
@@ -272,6 +281,7 @@
     "Cancel": "Cancel",
     "Done": "Done",
     "EgHost": "e.g. myservice.ziti",
+    "TerminatingRouters": "Terminating Routers",
 
 
 
@@ -306,8 +316,15 @@
     "RequireEncryption": "Require Encryption",
     "IdentityNameFormat": "Identity Name Format",
     "EnterIdentityNameFormat": "Enter a format for the identity name or leave blank for any",
-
-
+    "EditService": "Edit Service",
+    "CreateService": "Create Service",
     "ErrorInvalidFile": "Unable to read file, try opening in a text editor and pasting into the text field.",
-    "ConfirmClose": "The form has unsaved data, are you sure you want to close?"
+    "ConfirmClose": "The form has unsaved data, are you sure you want to close?",
+    "ConfirmDelete": "Are you sure you would like to delete the selected item(s)?",
+    "ServiceName": "Service Name",
+    "ServiceAttributesTitle": "Select or create Service attributes",
+    "ServiceNamePlaceholder": "Name this Service",
+    "ServiceAttributesPlaceholder": "Add attributes to group Services",
+    "ServiceAttributesHelp": "Attributes are tags applied to a resource. Apply the same tag to other Services to form a group of Services.",
+    "Encryption": "Encryption"
 }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.html
@@ -168,6 +168,7 @@
                         [expiration]="enrollmentExpiration"
                         [authenticators]="formData.authenticators"
                         [type]="'identity'"
+                        (doRefresh)="refreshIdentity()"
                     ></lib-qr-code>
                 </lib-form-field-container>
                 <lib-form-field-container

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
@@ -112,6 +112,14 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
     this.isEditing = !isEmpty(this.formData.id);
   }
 
+  refreshIdentity() {
+    this.svc.refreshIdentity(this.formData.id).then(result => {
+      this.formData = result.data;
+      this.enrollmentExpiration = this.identitiesService.getEnrollmentExpiration(this.formData);
+      this.jwt = this.identitiesService.getJWT(this.formData);
+    })
+  }
+
   getAssociatedServices() {
     this.zitiService.getSubdata('identities', this.formData.id, 'services').then((result: any) => {
       this.associatedServices = result.data;

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.service.ts
@@ -122,4 +122,9 @@ export class IdentityFormService {
             return status;
         });
     }
+
+    refreshIdentity(id) {
+        const url: any = `/identities/${id}`
+        return this.zitiService.call(url);
+    }
 }

--- a/projects/ziti-console-lib/src/lib/features/qr-code/qr-code.component.html
+++ b/projects/ziti-console-lib/src/lib/features/qr-code/qr-code.component.html
@@ -11,9 +11,14 @@
         <div>COPY ENROLLMENT TOKEN</div>
         <div class="download-key"></div>
     </div>
-    <div (click)="identitiesSvc.reissueJWT(identity)" *ngIf="showResetToken" class="download-button" >
+    <div (click)="identitiesSvc.resetJWT(identity)" *ngIf="showResetToken" class="download-button" >
         <div class="download-key"></div>
         <div>RESET ENROLLMENT</div>
+        <div class="tap-to-download"></div>
+    </div>
+    <div (click)="reissue()" *ngIf="showReissueToken" class="download-button" >
+        <div class="download-key"></div>
+        <div>REISSUE ENROLLMENT</div>
         <div class="tap-to-download"></div>
     </div>
     <span class="info-text" *ngIf="!jwtExpired && type !== 'router'">OR SCAN QR CODE</span>

--- a/projects/ziti-console-lib/src/lib/features/qr-code/qr-code.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/qr-code/qr-code.component.ts
@@ -19,6 +19,7 @@ import moment from 'moment';
 import {isEmpty} from 'lodash';
 import {MAT_DIALOG_DATA, MatDialogRef} from "@angular/material/dialog";
 import {IdentitiesPageService} from "../../pages/identities/identities-page.service";
+import {DialogRef} from "@angular/cdk/dialog";
 
 @Component({
   selector: 'lib-qr-code',
@@ -33,6 +34,7 @@ export class QrCodeComponent implements OnChanges {
   @Input() identity: any = {};
   @Input() type: string = 'identity';
   @Input() authenticators: any;
+  @Output() doRefresh: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   jwtExpired;
   expirationDate;
@@ -66,12 +68,34 @@ export class QrCodeComponent implements OnChanges {
     return this.authenticators?.cert?.id || this.authenticators?.updb?.id;
   }
 
+  get showReissueToken() {
+    return (this.identity?.enrollment?.ott?.id || this.identity?.enrollment?.updb?.id) && moment(this.expiration).isBefore();
+  }
+
   getJwtExpired() {
     return moment(this.expiration).isBefore();
   }
 
   getExpirationDate() {
     return moment(this.expiration).local().format('M/D/YY h:mm a');
+  }
+
+  reissue() {
+    const dialogRef: MatDialogRef<any> = this.identitiesSvc.reissueJWT(this.identity);
+    dialogRef.afterClosed().subscribe((result) => {
+        if (result) {
+          this.doRefresh.emit(true);
+        }
+    });
+  }
+
+  reset() {
+    const dialogRef: MatDialogRef<any> = this.identitiesSvc.resetJWT(this.identity);
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result) {
+        this.doRefresh.emit(true);
+      }
+    });
   }
 
   ngOnChanges() {

--- a/projects/ziti-console-lib/src/lib/features/reset-enrollment/reset-enrollment.component.html
+++ b/projects/ziti-console-lib/src/lib/features/reset-enrollment/reset-enrollment.component.html
@@ -1,8 +1,8 @@
 <div id="ResetModal" class="reset-enrollment-container modal" style="height: fit-content;">
     <div class="close icon-close" (click)="cancel()"></div>
     <div class="reset-title-container">
-        <div class="title">Reset Enrollment</div>
-        <div class="subtitle">Select a Date to reset the enrollment token</div>
+        <div class="title">{{type === 'reset' ? 'Reset' : 'Reissue'}} Enrollment</div>
+        <div class="subtitle">Select a date to {{type === 'reset' ? 'reset' : 'reissue'}} the enrollment token</div>
     </div>
     <div class="reset-content-container">
         <label>Date Enrollment Expires</label>
@@ -12,11 +12,12 @@
                 selectionMode="single"
                 [showIcon]="showIcon"
                 [showTime]="true"
+                [minDate]="minDate"
                 placeholder="Select Time Range"
                 #calendar
         ></p-calendar>
     </div>
     <div class="reset-buttons-container">
-        <div id="ResetEnrollButton" class="button" (click)="resetEnrollment()">Reset Enrollment</div>
+        <div id="ResetEnrollButton" class="button" (click)="handleAction()">{{type === 'reset' ? 'Reset' : 'Reissue'}} Enrollment</div>
     </div>
 </div>

--- a/projects/ziti-console-lib/src/lib/features/reset-enrollment/reset-enrollment.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/reset-enrollment/reset-enrollment.component.ts
@@ -19,8 +19,9 @@ import {MAT_DIALOG_DATA, MatDialogRef} from "@angular/material/dialog";
 import {GrowlerModel} from "../messaging/growler.model";
 import {ZITI_DATA_SERVICE, ZitiDataService} from "../../services/ziti-data.service";
 import {GrowlerService} from "../messaging/growler.service";
-import {isEmpty} from "lodash";
+import {isEmpty, result} from "lodash";
 import moment from "moment";
+import {ResetEnrollmentService} from "./reset-enrollment.service";
 
 @Component({
   selector: 'lib-reset-enrollment',
@@ -29,17 +30,20 @@ import moment from "moment";
 })
 export class ResetEnrollmentComponent implements OnInit {
 
+  minDate = moment().add(1, 'minutes').toDate();
+  type = 'reset';
   identity: any;
   dateValue = moment().add(2, 'days').toDate();
   showIcon: boolean = true;
   @ViewChild('calendar', { static: false }) calendar: any;
   constructor(
+      private svc: ResetEnrollmentService,
       private dialogRef: MatDialogRef<ResetEnrollmentComponent>,
       @Inject(MAT_DIALOG_DATA) public data: any,
-      @Inject(ZITI_DATA_SERVICE) private dataService: ZitiDataService,
-      private growlerService: GrowlerService
+      @Inject(ZITI_DATA_SERVICE) private dataService: ZitiDataService
   ) {
-    this.identity = data;
+    this.identity = data.identity;
+    this.type = data.type || 'reset';
   }
 
   ngOnInit() {
@@ -54,35 +58,27 @@ export class ResetEnrollmentComponent implements OnInit {
     this.dialogRef.close(false);
   }
 
-  resetEnrollment() {
-    let id = this.identity?.authenticators?.cert?.id || this.identity?.authenticators?.updb?.id;
-    if (!id) {
-      if(!isEmpty(this.identity?.enrollment?.ott)) {
-        id = this.identity?.enrollment?.ott.id;
-      } else if(!isEmpty(this.identity?.enrollment?.ottca)) {
-        id = this.identity?.enrollment?.ottca.id;
-      } else if (!isEmpty(this.identity?.enrollment?.updb)) {
-        id = this.identity?.enrollment?.updb.id;
-      }
+  handleAction() {
+    if (this.type === 'reset'){
+      this.reset();
+    } else {
+      this.reissue();
     }
-    const dateObj: any = moment(this.dateValue);
-    return this.dataService.resetEnrollment(id, dateObj).then(() => {
-      const growlerData = new GrowlerModel(
-          'success',
-          'Success',
-          `Enrollment Reset`,
-          `Successfully reissued enrollment token`,
-      );
-      this.growlerService.show(growlerData);
-      this.confirm();
-    }).catch((error) => {
-      const growlerData = new GrowlerModel(
-          'error',
-          'Error',
-          `Reset Failed`,
-          `Failed to reissues enrollment token`,
-      );
-      this.growlerService.show(growlerData);
-    });
+  }
+
+  reset() {
+      this.svc.resetEnrollment(this.identity, this.dateValue).then((result) => {
+          if (result) {
+              this.confirm();
+          }
+      });
+  }
+
+  reissue() {
+      this.svc.reissueEnrollment(this.identity, this.dateValue).then((result) => {
+          if (result) {
+              this.confirm();
+          }
+      });
   }
 }

--- a/projects/ziti-console-lib/src/lib/features/reset-enrollment/reset-enrollment.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/reset-enrollment/reset-enrollment.service.ts
@@ -1,0 +1,73 @@
+import {Inject, Injectable} from "@angular/core";
+import {isEmpty} from "lodash";
+import moment from "moment/moment";
+import {GrowlerModel} from "../messaging/growler.model";
+import {GrowlerService} from "../messaging/growler.service";
+import {ZITI_DATA_SERVICE, ZitiDataService} from "../../services/ziti-data.service";
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ResetEnrollmentService {
+
+    constructor(
+        private growlerService: GrowlerService,
+        @Inject(ZITI_DATA_SERVICE) private dataService: ZitiDataService,
+    ) {
+    }
+
+    resetEnrollment(identity, dateVal) {
+        let id = identity?.authenticators?.cert?.id || identity?.authenticators?.updb?.id;
+        const dateObj: any = moment(dateVal);
+        return this.dataService.resetEnrollment(id, dateObj).then(() => {
+            const growlerData = new GrowlerModel(
+                'success',
+                'Success',
+                `Enrollment Reset`,
+                `Successfully reset enrollment token`,
+            );
+            this.growlerService.show(growlerData);
+            return true;
+        }).catch((error) => {
+            const growlerData = new GrowlerModel(
+                'error',
+                'Error',
+                `Reset Failed`,
+                `Failed to reset enrollment token`,
+            );
+            this.growlerService.show(growlerData);
+            return false;
+        });
+    }
+
+    reissueEnrollment(identity, dateVal) {
+        let id = identity?.enrollment?.id;
+        if(!isEmpty(identity?.enrollment?.ott)) {
+            id = identity?.enrollment?.ott.id;
+        } else if(!isEmpty(identity?.enrollment?.ottca)) {
+            id = identity?.enrollment?.ottca.id;
+        } else if (!isEmpty(identity?.enrollment?.updb)) {
+            id = identity?.enrollment?.updb.id;
+        }
+        const dateObj: any = moment(dateVal);
+        return this.dataService.reissueEnrollment(id, dateObj).then(() => {
+            const growlerData = new GrowlerModel(
+                'success',
+                'Success',
+                `Enrollment Token Reissues`,
+                `Successfully reissued enrollment token`,
+            );
+            this.growlerService.show(growlerData);
+            return true;
+        }).catch((error) => {
+            const growlerData = new GrowlerModel(
+                'error',
+                'Error',
+                `Reissue Failed`,
+                `Failed to reissues enrollment token`,
+            );
+            this.growlerService.show(growlerData);
+            return false;
+        });
+    }
+}

--- a/projects/ziti-console-lib/src/lib/pages/identities/identities-page.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/identities/identities-page.component.ts
@@ -151,6 +151,9 @@ export class IdentitiesPageComponent extends ListPageComponent implements OnInit
       case 'reset-enrollment':
         this.resetEnrollment(event.item);
         break;
+      case 'reissue-enrollment':
+        this.reissueEnrollment(event.item);
+        break;
       case 'qr-code':
         this.showQRCode(event.item)
         break;
@@ -175,7 +178,7 @@ export class IdentitiesPageComponent extends ListPageComponent implements OnInit
       jwt: this.svc.getJWT(item),
       expiration: this.svc.getEnrollmentExpiration(item),
       qrCodeSize: 300,
-      identity: item
+      identity: item,
     };
     this.dialogRef = this.dialogForm.open(QrCodeComponent, {
       data: data,
@@ -195,12 +198,30 @@ export class IdentitiesPageComponent extends ListPageComponent implements OnInit
 
   resetEnrollment(identity) {
     this.dialogRef = this.dialogForm.open(ResetEnrollmentComponent, {
-      data: identity,
+      data: {
+        identity: identity,
+        type: 'reset',
+      },
       autoFocus: false,
     });
     this.dialogRef.afterClosed().subscribe((result) => {
       if(result) {
-        this.refreshData();
+        this.refreshData(undefined, true);
+      }
+    })
+  }
+
+  reissueEnrollment(identity) {
+    this.dialogRef = this.dialogForm.open(ResetEnrollmentComponent, {
+      data: {
+        identity: identity,
+        type: 'reissue',
+      },
+      autoFocus: false,
+    });
+    this.dialogRef.afterClosed().subscribe((result) => {
+      if(result) {
+        this.refreshData(undefined, true);
       }
     })
   }

--- a/projects/ziti-console-lib/src/lib/services/node-data.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/node-data.service.ts
@@ -200,6 +200,30 @@ export class NodeDataService extends ZitiDataService {
         );
     }
 
+    override reissueEnrollment(id: string, date: string): Promise<any> {
+        const nodeServerURL = window.location.origin;
+        const serviceUrl = nodeServerURL + '/api/reissueEnroll';
+        const dateStr = moment(date).format("M/D/YYYY hh:mm A");
+        const body = {
+            date: dateStr,
+            id: id
+        }
+        return firstValueFrom(this.httpClient.post(serviceUrl, body, {}).pipe(
+                catchError((err: any) => {
+                    const error = "Server Not Accessible";
+                    if (err.code != "ECONNREFUSED") throw({error: err.code});
+                    throw({error: error});
+                }),
+                map((results: any) => {
+                    if(!isEmpty(results.error)) {
+                        throw({error: results.error});
+                    }
+                    return results;
+                })
+            )
+        );
+    }
+
     override deleteSubdata(entityType: string, id: any, dataType: string, data: any): Promise<any> {
         const nodeServerURL = window.location.origin;
         const serviceUrl = nodeServerURL + '/api/subSave';

--- a/projects/ziti-console-lib/src/lib/services/ziti-controller-data.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/ziti-controller-data.service.ts
@@ -184,6 +184,22 @@ export class ZitiControllerDataService extends ZitiDataService {
         );
     }
 
+    override reissueEnrollment(id: string, date): Promise<any> {
+        const apiVersions = this.settingsService.apiVersions || {};
+        const prefix = apiVersions["edge-management"]?.v1?.path || '/edge/management/v1';
+        const url = this.settingsService.settings.selectedEdgeController + `${prefix}/enrollments/${id}/refresh`;
+        const expiresAt = moment(date).utc().toISOString();
+        const body = { expiresAt: expiresAt };
+        return firstValueFrom(this.httpClient.post(url, body).pipe(
+                catchError((err: any) => {
+                    const error = "Server Not Accessible";
+                    if (err.code != "ECONNREFUSED") throw({error: err.code});
+                    throw({error: error});
+                })
+            )
+        );
+    }
+
     delete(type: string, id: string): Promise<any> {
         const apiVersions = this.settingsService.apiVersions || {};
         const prefix = apiVersions["edge-management"]?.v1?.path;

--- a/projects/ziti-console-lib/src/lib/services/ziti-data.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/ziti-data.service.ts
@@ -45,6 +45,7 @@ export abstract class ZitiDataService {
   abstract deleteSubdata(entityType: string, id: any, dataType: string, params: any): Promise<any>;
   abstract delete(type: string, id: string): Promise<any>;
   abstract call(url: string): Promise<any>;
-  abstract resetEnrollment(id: string, any: string): Promise<any>;
+  abstract resetEnrollment(id: string, date: string): Promise<any>;
+  abstract reissueEnrollment(id: string, date: string): Promise<any>;
   abstract schema(data: any): Promise<any>;
 }

--- a/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
+++ b/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
@@ -306,7 +306,7 @@ lib-form-field-container {
 .icon-copy.copy {
   right: 10px;
   top: 5px;
-  width: 30px;
+  width: 20px;
   display: flex;
   justify-content: flex-end;
   align-items: center;
@@ -323,6 +323,11 @@ lib-form-field-container {
   }
 }
 
+.api-call-container {
+  .icon-copy.copy {
+    background-color: var(--navigation);
+  }
+}
 .download-button {
   display: flex;
   flex-direction: row;

--- a/projects/ziti-console-lib/src/lib/shared/list-page-component.class.ts
+++ b/projects/ziti-console-lib/src/lib/shared/list-page-component.class.ts
@@ -20,6 +20,8 @@ import {Injectable} from "@angular/core";
 import {Subscription} from "rxjs";
 import {ConsoleEventsService} from "../services/console-events.service";
 
+import {defer} from "lodash";
+
 @Injectable()
 export abstract class ListPageComponent {
     abstract title;
@@ -99,11 +101,19 @@ export abstract class ListPageComponent {
         this.itemsSelected = itemSelected;
     }
 
-    refreshData(sort?: { sortBy: string, ordering: string }): void {
+    refreshData(sort?: { sortBy: string, ordering: string }, hardRefresh = false): void {
         this.isLoading = true;
         this.svc.getData(this.filterService.filters, sort, this.currentPage)
             .then((data: any) => {
-                this.rowData = data.data;
+                this.rowData = [];
+                if (hardRefresh) {
+                    defer(() => {
+                        this.rowData = data.data;
+                    });
+                } else {
+                    this.rowData = data.data;
+                }
+
                 this.totalCount = data.meta.pagination.totalCount;
                 this.startCount = (data.meta.pagination.offset + 1);
                 if (this.startCount + data.meta.pagination.limit > this.totalCount) {

--- a/projects/ziti-console-lib/src/public-api.ts
+++ b/projects/ziti-console-lib/src/public-api.ts
@@ -53,6 +53,7 @@ export * from './lib/features/projectable-forms/edge-router/edge-router-form.com
 export * from './lib/features/projectable-forms/edge-router/edge-router-form.service';
 export * from './lib/features/projectable-forms/service/service-form.component';
 export * from './lib/features/projectable-forms/service/service-form.service';
+export * from './lib/features/reset-enrollment/reset-enrollment.service';
 export * from './lib/features/extendable/extensions-noop.service';
 export * from './lib/features/projectable-forms/form-header/form-header.component';
 export * from './lib/features/loading-indicator/loading-indicator.component';


### PR DESCRIPTION
## Select the "re-issue" option from the list page item dropdown:
<img width="296" alt="Screen Shot 2024-02-02 at 11 47 54 AM" src="https://github.com/openziti/ziti-console/assets/102923745/91d15f6b-aa43-4038-bf8e-99feea3d8c6d">


## Select a future date for expiration of the token:
<img width="637" alt="Screen Shot 2024-02-02 at 11 48 06 AM" src="https://github.com/openziti/ziti-console/assets/102923745/83e3fbcb-0675-41e1-bed1-cce986af183c">
