### PR TITLE
#235 Make QR code registration expandable for smaller resolutions

### DIFF
--- a/projects/ziti-console-lib/src/lib/assets/html/cas.htm
+++ b/projects/ziti-console-lib/src/lib/assets/html/cas.htm
@@ -203,7 +203,7 @@
             </div>
 
             <label for="Pem"><span data-i18n="PEM"></span> <span id="SelectFile" class="note" data-i18n="SelectFile"></span><input id="PemFile" type="file" accept=".pem"/></label>
-            <textarea id="Pem" data-bind="data.certPem" style="height: 300px; font-size: 12px;" data-i18n="PastePEM"></textarea>
+            <textarea id="Pem" data-bind="data.certPem" style="height: 300px; font-size: 12px; margin-top: 0;" data-i18n="PastePEM"></textarea>
             
             <div id="TagArea"></div>
             {{html.api}}

--- a/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-token/table-cell-token.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-token/table-cell-token.component.ts
@@ -101,7 +101,7 @@ export class TableCellTokenComponent implements ICellRendererAngularComp {
     const data = {
       jwt: this.getJWT(this.item),
       expiration: this.getEnrollmentExpiration(this.item),
-      qrCodeSize: 300,
+      qrCodeSize: 400,
       identity: this.item
     };
     this.dialogRef = this.dialogForm.open(QrCodeComponent, {

--- a/projects/ziti-console-lib/src/lib/features/preview-list/preview-list.component.html
+++ b/projects/ziti-console-lib/src/lib/features/preview-list/preview-list.component.html
@@ -5,7 +5,7 @@
     <div class="text row">
         <div (click)="selected(name)" *ngFor="let name of names" [ngClass]="{ clickable: clickable }" class="listText">
             <div *ngIf="allowRemove" class="icon-clear" (click)="remove(name)"></div>
-            {{ name }}
+            <span class="preview-name" matTooltip="{{tooltip}}" matTooltipPosition="below">{{ name }}</span>
         </div>
     </div>
 </div>

--- a/projects/ziti-console-lib/src/lib/features/preview-list/preview-list.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/preview-list/preview-list.component.scss
@@ -73,13 +73,20 @@
 .clickable:hover,
 .clickable:focus {
     filter: brightness(90%);
-    text-decoration: underline;
 }
 
 .clickable:active {
     color: var(--icon);
     -webkit-transform: translateY(1px);
     transform: translateY(1px);
+}
+
+.clickable .preview-name:hover,
+.clickable .preview-name:focus {
+    text-decoration: underline;
+}
+
+.clickable .preview-name:active {
     text-decoration: underline;
 }
 

--- a/projects/ziti-console-lib/src/lib/features/preview-list/preview-list.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/preview-list/preview-list.component.ts
@@ -28,6 +28,7 @@ export class PreviewListComponent {
   @Input() isLoading = false;
   @Input() allNames = [];
   @Input() allowRemove = false
+  @Input() tooltip = '';
   @Output() itemSelected = new EventEmitter<string>();
   @Output() itemRemoved = new EventEmitter<string>();
   public names = [];

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.html
@@ -97,7 +97,7 @@
                     <lib-qr-code
                             [identity]="formData"
                             [jwt]="formData.jwt"
-                            [token]="formData.token"
+                            [token]="formData.enrollmentToken"
                             [expiration]="formData.enrollmentExpiresAt"
                             [type]="'router'"
                     ></lib-qr-code>

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.ts
@@ -124,8 +124,9 @@ export class EdgeRouterFormComponent extends ProjectableForm implements OnInit, 
       if (result?.close) {
         this.closeModal(true, true);
       }
-      if (!isEmpty(result?.id)) {
-        this.formData = result?.data || this.formData;
+      const data = result?.data?.id ? result.data : result;
+      if (!isEmpty(data.id)) {
+        this.formData = data || this.formData;
         this.initData = this.formData;
       } else {
         this.initData = this.formData;

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.service.ts
@@ -103,18 +103,6 @@ export class EdgeRouterFormService {
         });
     }
 
-    copyToClipboard(val) {
-        navigator.clipboard.writeText(val);
-        const growlerData = new GrowlerModel(
-            'success',
-            'Success',
-            `Text Copied`,
-            `API call URL copied to clipboard`,
-        );
-        this.growlerService.show(growlerData);
-    }
-
-
     getAssociatedServices(id) {
         this.zitiService.getSubdata('edge-routers', id, 'services').then((result: any) => {
             this.associatedServices = result.data;

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.service.ts
@@ -103,6 +103,17 @@ export class EdgeRouterFormService {
         });
     }
 
+    copyToClipboard(val) {
+        navigator.clipboard.writeText(val);
+        const growlerData = new GrowlerModel(
+            'success',
+            'Success',
+            `Text Copied`,
+            `API call URL copied to clipboard`,
+        );
+        this.growlerService.show(growlerData);
+    }
+
     getAssociatedServices(id) {
         this.zitiService.getSubdata('edge-routers', id, 'services').then((result: any) => {
             this.associatedServices = result.data;

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.html
@@ -58,7 +58,7 @@
                 <div [hidden]="!showMore" class="form-group-column">
                     <lib-form-field-container
                         [title]="'Enrollment Type'"
-                        [title2]="enrollmentType === 'CA' ? 'CERTIFICATE AUTHORITY' : (enrollmentType === 'updb' ? 'UPDB USERNAME' : undefined)"
+                        [title2]="enrollmentTypeTitle"
                         [layout]="'row'"
                         class="form-field-advanced"
                     >
@@ -79,11 +79,14 @@
                             *ngIf="enrollmentType === 'CA'"
                             [ngClass]="{disabled: isEditing}"
                             [(ngModel)]="enrollmentCA"
+                            [ngClass]="{error: errors.enrollmentCA}"
                             (change)="updateEnrollment()"
-                        ></select>
+                        >
+                            <option *ngFor="let ca of cas" [value]="ca.id">{{ca.name}}</option>
+                        </select>
                         <input
-                            *ngIf="enrollmentType === 'updb'"
-                            [ngClass]="{disabled: isEditing}"
+                            *ngIf="enrollmentType === 'updb' && !isEditing"
+                            [ngClass]="{disabled: isEditing, error: errors.enrollmentUPDB}"
                             [(ngModel)]="enrollmentUPDB"
                             (keyup)="updateEnrollment()"
                             class="form-field-input"
@@ -94,27 +97,24 @@
                         >
                     </lib-form-field-container>
                     <lib-form-field-container
-                            [title]="'Identity Type'"
-                            [title2]="'Is Admin'"
+                            [title]="'Admin'"
                             [layout]="'row'"
                             class="form-field-advanced is-admin-container"
                     >
-                        <select id="IdentityType"
-                                style="padding-right: 0px; margin-right: 10px;"
-                                [ngClass]="{disabled: isEditing}"
-                                [(ngModel)]="identityType"
-                        >
-                            <option value="Device">Device</option>
-                            <option value="Service">Service</option>
-                            <option value="User">User</option>
-                        </select>
-                        <lib-form-field-toggle
-                                [(toggleOn)]="formData.isAdmin"
-                                [orientation]="'column'"
-                                [labelOn]="'YES'"
-                                [labelOff]="'NO'"
-                                class="admin-toggle"
-                        ></lib-form-field-toggle>
+                        <div class="config-item">
+                            <div class="config-container toggle-container">
+                                <div class="config-container-label">IS ADMIN</div>
+                                <div
+                                        (click)="toggleIsAdmin()"
+                                        [ngClass]="{ on: formData.isAdmin }"
+                                        class="toggle"
+                                >
+                                    <span [hidden]="!formData.isAdmin" class="on-label">YES</span>
+                                    <span [hidden]="formData.isAdmin" class="off-label">NO</span>
+                                    <div class="switch"></div>
+                                </div>
+                            </div>
+                        </div>
                     </lib-form-field-container>
                     <lib-form-field-container
                             [title]="'Hosting Cost'"
@@ -168,6 +168,7 @@
                         [expiration]="enrollmentExpiration"
                         [authenticators]="formData.authenticators"
                         [type]="'identity'"
+                        [canExpand]="true"
                         (doRefresh)="refreshIdentity()"
                     ></lib-qr-code>
                 </lib-form-field-container>

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
@@ -85,7 +85,7 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
       public svc: IdentityFormService,
       public identitiesService: IdentitiesPageService,
       @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
-      growlerService: GrowlerService
+      public growlerService: GrowlerService
   ) {
     super();
     this.identityRoleAttributes = [];

--- a/projects/ziti-console-lib/src/lib/features/qr-code/qr-code.component.html
+++ b/projects/ziti-console-lib/src/lib/features/qr-code/qr-code.component.html
@@ -1,33 +1,42 @@
 <div class="qr-code-container" [ngClass]="{'modal-view': isModal}">
-    <span class="info-text" *ngIf="!jwtExpired && type !== 'router'">TO REGISTER THIS IDENTITY</span>
-    <span class="info-text" *ngIf="!jwtExpired && type === 'router'">TO REGISTER THIS ROUTER</span>
-    <div (click)="identitiesSvc.downloadJWT(jwt, identity.name)" *ngIf="hasJWT && !jwtExpired && type !== 'router'" class="download-button">
-        <div class="download-key"></div>
-        <div>DOWNLOAD ENROLLMENT JWT</div>
-        <div class="download-key"></div>
+    <div *ngIf="!qrOnly" class="qr-code-buttons">
+        <span class="info-text" *ngIf="!jwtExpired && type !== 'router'">TO REGISTER THIS IDENTITY</span>
+        <span class="info-text" *ngIf="!jwtExpired && type === 'router'">TO REGISTER THIS ROUTER</span>
+        <div (click)="identitiesSvc.downloadJWT(jwt, identity.name)" *ngIf="hasJWT && !jwtExpired && type !== 'router'" class="download-button">
+            <div class="download-key"></div>
+            <div>DOWNLOAD ENROLLMENT JWT</div>
+            <div class="tap-to-download"></div>
+        </div>
+        <div (click)="identitiesSvc.copyToken(token)" *ngIf="!jwtExpired && type === 'router'" class="download-button" style="background-color: #232f3e!important;">
+            <div class="download-key"></div>
+            <div>COPY ENROLLMENT TOKEN</div>
+            <div class="tap-to-download"></div>
+        </div>
+        <div (click)="identitiesSvc.resetJWT(identity)" *ngIf="showResetToken" class="download-button" >
+            <div class="download-key"></div>
+            <div>RESET ENROLLMENT</div>
+            <div class="tap-to-download"></div>
+        </div>
+        <div (click)="reissue()" *ngIf="showReissueToken" class="download-button" >
+            <div class="download-key"></div>
+            <div>REISSUE ENROLLMENT</div>
+            <div class="tap-to-download"></div>
+        </div>
+        <span class="info-text" *ngIf="!jwtExpired && type !== 'router'">OR SCAN QR CODE</span>
     </div>
-    <div (click)="identitiesSvc.copyToken(token)" *ngIf="!jwtExpired && type === 'router'" class="download-button" style="background-color: #232f3e!important;">
-        <div class="download-key"></div>
-        <div>COPY ENROLLMENT TOKEN</div>
-        <div class="download-key"></div>
+    <qrcode
+            *ngIf="!jwtExpired && type !== 'router'"
+            [errorCorrectionLevel]="'M'" [qrdata]="jwt"
+            [width]="qrCodeSize" (click)="expandQRCode()"
+            [ngClass]="{'qr-code-expandable': canExpand}"
+    ></qrcode>
+    <div *ngIf="!qrOnly" class="qr-code-buttons">
+        <span class="info-text" *ngIf="!jwtExpired && type === 'router'">OR</span>
+        <div (click)="identitiesSvc.downloadJWT(jwt, identity.name)" *ngIf="!jwtExpired && type === 'router'" class="download-button">
+            <div class="download-key"></div>
+            <div>DOWNLOAD ENROLLMENT JWT</div>
+            <div class="tap-to-download"></div>
+        </div>
+        <span class="info-text" *ngIf="!showResetToken">{{jwtExpired ? 'REGISTRATION EXPIRED' : 'EXPIRES'}} {{expirationDate}}</span>
     </div>
-    <div (click)="identitiesSvc.resetJWT(identity)" *ngIf="showResetToken" class="download-button" >
-        <div class="download-key"></div>
-        <div>RESET ENROLLMENT</div>
-        <div class="tap-to-download"></div>
-    </div>
-    <div (click)="reissue()" *ngIf="showReissueToken" class="download-button" >
-        <div class="download-key"></div>
-        <div>REISSUE ENROLLMENT</div>
-        <div class="tap-to-download"></div>
-    </div>
-    <span class="info-text" *ngIf="!jwtExpired && type !== 'router'">OR SCAN QR CODE</span>
-    <qrcode *ngIf="!jwtExpired && type !== 'router'" [errorCorrectionLevel]="'M'" [qrdata]="jwt" [width]="qrCodeSize"></qrcode>
-    <span class="info-text" *ngIf="!jwtExpired && type === 'router'">OR DOWNLOAD THE JWT</span>
-    <div (click)="identitiesSvc.downloadJWT(jwt, identity.name)" *ngIf="!jwtExpired && type === 'router'" class="download-button">
-        <div class="download-key"></div>
-        <div>DOWNLOAD ENROLLMENT JWT</div>
-        <div class="download-key"></div>
-    </div>
-    <span class="info-text" *ngIf="!showResetToken">{{jwtExpired ? 'REGISTRATION EXPIRED' : 'EXPIRES'}} {{expirationDate}}</span>
 </div>

--- a/projects/ziti-console-lib/src/lib/features/qr-code/qr-code.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/qr-code/qr-code.component.scss
@@ -14,9 +14,23 @@
   }
 
   &.modal-view {
-    width: 400px;
+    width: 500px;
     background-color: var(--background);
     padding: 20px;
     border-radius: 15px;
+  }
+  .qr-code-buttons {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+  }
+  .qr-code-expandable {
+    cursor: pointer;
+    transition: transform .25s;
+    &:hover {
+      transform: scale(1.15);
+    }
   }
 }

--- a/projects/ziti-console-lib/src/lib/features/qr-code/qr-code.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/qr-code/qr-code.component.ts
@@ -17,7 +17,7 @@
 import {Component, EventEmitter, Input, Output, OnChanges, Inject, Optional} from '@angular/core';
 import moment from 'moment';
 import {isEmpty} from 'lodash';
-import {MAT_DIALOG_DATA, MatDialogRef} from "@angular/material/dialog";
+import {MAT_DIALOG_DATA, MatDialog, MatDialogRef} from "@angular/material/dialog";
 import {IdentitiesPageService} from "../../pages/identities/identities-page.service";
 import {DialogRef} from "@angular/cdk/dialog";
 
@@ -34,6 +34,8 @@ export class QrCodeComponent implements OnChanges {
   @Input() identity: any = {};
   @Input() type: string = 'identity';
   @Input() authenticators: any;
+  @Input() qrOnly: boolean = false;
+  @Input() canExpand: boolean = false;
   @Output() doRefresh: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   jwtExpired;
@@ -41,11 +43,11 @@ export class QrCodeComponent implements OnChanges {
   qrCodeSize = 200;
   isModal = false;
 
-
   constructor(
       @Optional() private dialogRef: MatDialogRef<QrCodeComponent>,
+      @Optional() private dialogForm: MatDialog,
       @Optional() @Inject(MAT_DIALOG_DATA) public data: any,
-      public identitiesSvc: IdentitiesPageService
+      public identitiesSvc: IdentitiesPageService,
   )
   {
     if (!isEmpty(data)) {
@@ -57,6 +59,7 @@ export class QrCodeComponent implements OnChanges {
       this.expirationDate = this.getExpirationDate();
       this.isModal = true;
       this.identity = data.identity;
+      this.qrOnly = data.qrOnly;
     }
   }
 
@@ -95,6 +98,20 @@ export class QrCodeComponent implements OnChanges {
       if (result) {
         this.doRefresh.emit(true);
       }
+    });
+  }
+
+  expandQRCode() {
+    const data = {
+      jwt: this.jwt,
+      expiration: this.expiration,
+      qrCodeSize: 400,
+      identity: this.identity,
+      qrOnly: true
+    };
+    const dialogRef = this.dialogForm.open(QrCodeComponent, {
+      data: data,
+      autoFocus: false,
     });
   }
 

--- a/projects/ziti-console-lib/src/lib/pages/identities/identities-page.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/identities/identities-page.component.ts
@@ -153,7 +153,7 @@ export class IdentitiesPageComponent extends ListPageComponent implements OnInit
     const data = {
       jwt: this.svc.getJWT(item),
       expiration: this.svc.getEnrollmentExpiration(item),
-      qrCodeSize: 300,
+      qrCodeSize: 400,
       identity: item,
     };
     this.dialogRef = this.dialogForm.open(QrCodeComponent, {
@@ -184,7 +184,7 @@ export class IdentitiesPageComponent extends ListPageComponent implements OnInit
       if(result) {
         this.refreshData(undefined, true);
       }
-    })
+    });
   }
 
   reissueEnrollment(identity) {

--- a/projects/ziti-console-lib/src/lib/pages/services/services-page.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/services/services-page.component.ts
@@ -52,6 +52,7 @@ export class ServicesPageComponent extends ListPageComponent implements OnInit, 
 
   override ngOnInit() {
     super.ngOnInit();
+    this.getServiceRoleAttributes();
     this.tabs = this.tabNames.getTabs('services');
   }
 
@@ -101,7 +102,8 @@ export class ServicesPageComponent extends ListPageComponent implements OnInit, 
   }
 
   deleteItem(item: any) {
-    this.openBulkDelete([item.id], 'service');
+    this.openBulkDelete([item], 'service');
+    console.log('test');
   }
 
 

--- a/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
+++ b/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
@@ -138,6 +138,10 @@ body {
   background-size: 18px;
   padding-right: 28px;
   min-height: 50px;
+
+  &.error {
+    border-color: var(--red);
+  }
 }
 
 .form-field-input {


### PR DESCRIPTION
* Added "Click to expand" functionality to QR Code component
* Fixed enrollment token button display on edge router edit form
* Added underline styling for clickable links on the preview-list component

<img width="1275" alt="Screen Shot 2024-02-15 at 2 34 40 PM" src="https://github.com/openziti/ziti-console/assets/102923745/18d90038-6851-489b-b004-7cadb1c73750">
