### PR TITLE
Check if ZAC origin is has available Edge API's and only show Username/Password screen if so

### DIFF
--- a/projects/app-ziti-console/src/app/login/login.component.html
+++ b/projects/app-ziti-console/src/app/login/login.component.html
@@ -17,7 +17,9 @@
     </ng-container>
 
     <ng-template #userLogin>
-        <lib-selector-input [fieldName]="'Edge Controller'"
+        <lib-selector-input
+                    *ngIf="!originIsController"
+                    [fieldName]="'Edge Controller'"
                     [(fieldValue)]="selectedEdgeController"
                     [error]="edgeNameError"
                     [placeholder]="'Connect to a new Edge Controller'"


### PR DESCRIPTION
If ZAC is running on a network controller and has available Edge API's then don't show the input fields to specify a controller URL/Name. Instead, just show the Username/Password screen