### PR TITLE
Check if ZAC origin is has available Edge API's and only show Username/Password screen if so

### DIFF
--- a/projects/app-ziti-console/src/app/login/login.component.html
+++ b/projects/app-ziti-console/src/app/login/login.component.html
@@ -17,7 +17,9 @@
     </ng-container>
 
     <ng-template #userLogin>
-        <lib-selector-input [fieldName]="'Edge Controller'"
+        <lib-selector-input
+                    *ngIf="!originIsController"
+                    [fieldName]="'Edge Controller'"
                     [(fieldValue)]="selectedEdgeController"
                     [error]="edgeNameError"
                     [placeholder]="'Connect to a new Edge Controller'"

--- a/projects/app-ziti-console/src/app/login/login.component.ts
+++ b/projects/app-ziti-console/src/app/login/login.component.ts
@@ -18,7 +18,7 @@ import {Inject, Component, OnDestroy, OnInit} from '@angular/core';
 import { Router } from '@angular/router';
 import {SettingsServiceClass, LoginServiceClass, SETTINGS_SERVICE, ZAC_LOGIN_SERVICE} from "ziti-console-lib";
 import {Subscription} from "rxjs";
-import {defer, isEmpty, get} from "lodash";
+import {defer, isEmpty, isNil, get} from "lodash";
 
 // @ts-ignore
 const {growler, context} = window;
@@ -41,6 +41,7 @@ export class LoginComponent implements OnInit, OnDestroy {
     edgeUrlError = '';
     backToLogin = false;
     showEdge = false;
+    originIsController = false;
     private subscription = new Subscription();
 
     constructor(
@@ -57,8 +58,22 @@ export class LoginComponent implements OnInit, OnDestroy {
         this.settingsService.settingsChange.subscribe((results: any) => {
             if (results) this.settingsReturned(results);
         }));
-        this.edgeChanged();
-        this.initSettings();
+        this.checkOriginForController();
+    }
+
+    checkOriginForController() {
+        const controllerUrl = window.location.origin;
+        this.settingsService.initApiVersions(controllerUrl).then((result) => {
+            if (isNil(result) || isEmpty(result)) {
+                this.edgeChanged();
+                this.initSettings();
+            } else {
+                this.originIsController = true;
+                this.edgeCreate = false;
+                this.selectedEdgeController = controllerUrl;
+                this.settingsService.addContoller(this.edgeName, window.location.hostname);
+            }
+        });
     }
 
     async login() {
@@ -86,6 +101,7 @@ export class LoginComponent implements OnInit, OnDestroy {
             this.login();
         }
     }
+
     create() {
         if (this.isValid()) {
             this.settingsService.addContoller(this.edgeName, this.edgeUrl);


### PR DESCRIPTION
If ZAC is running on a network controller and has available Edge API's then don't show the input fields to specify a controller URL/Name. Instead, just show the Username/Password screen