### PR TITLE
#267 Minute value in the "Created At" column of Identities and Routers is always showing the same value

### DIFF
--- a/projects/ziti-console-lib/src/lib/pages/identities/identities-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/identities/identities-page.service.ts
@@ -159,7 +159,7 @@ export class IdentitiesPageService extends ListPageServiceClass {
         }
 
         const createdAtFormatter = (row) => {
-            return moment(row?.data?.createdAt).local().format('M/D/YYYY H:MM A');
+            return moment(row?.data?.createdAt).local().format('M/D/YYYY h:mm A');
         }
 
         const columnFilters = this.columnFilters;


### PR DESCRIPTION
closes #267 

* Moment format string should be using lowercase notation for "minutes"