### PR TITLE
#275 The "Select Edge Controller" dropdown is hidden on the login page after logout

### DIFF
--- a/projects/app-ziti-console/src/app/login/controller-login.service.ts
+++ b/projects/app-ziti-console/src/app/login/controller-login.service.ts
@@ -21,7 +21,7 @@ import {firstValueFrom, lastValueFrom, Observable, ObservableInput, of, switchMa
 import {catchError} from "rxjs/operators";
 import {Router} from "@angular/router";
 import moment from "moment";
-import {debounce, defer, isEmpty} from "lodash";
+import {debounce, defer, isEmpty, isNil} from "lodash";
 
 @Injectable({
     providedIn: 'root'
@@ -44,6 +44,19 @@ export class ControllerLoginService extends LoginServiceClass {
 
     async login(prefix: string, url: string, username: string, password: string) {
         this.controllerLogin(prefix, url, username, password);
+    }
+
+    checkOriginForController(): Promise<any> {
+        const controllerUrl = window.location.origin;
+        return this.settingsService.initApiVersions(controllerUrl).then((result) => {
+            if (isNil(result) || isEmpty(result)) {
+                return false;
+            } else {
+                return true;
+            }
+        }).catch((result) => {
+            return false;
+        });
     }
 
     controllerLogin(prefix: string, url: string, username: string, password: string) {

--- a/projects/app-ziti-console/src/app/login/login.component.ts
+++ b/projects/app-ziti-console/src/app/login/login.component.ts
@@ -62,22 +62,19 @@ export class LoginComponent implements OnInit, OnDestroy {
         }));
     }
 
-    checkOriginForController() {
+    async checkOriginForController() {
         this.isLoading = true;
-        const controllerUrl = window.location.origin;
-        this.settingsService.initApiVersions(controllerUrl).then((result) => {
-            if (isNil(result) || isEmpty(result)) {
-                this.edgeChanged();
-                this.initSettings();
-            } else {
-                this.originIsController = true;
-                this.edgeCreate = false;
-                this.selectedEdgeController = controllerUrl;
-                this.settingsService.addContoller(this.edgeName, window.location.hostname);
-            }
-        }).finally(() => {
-            this.isLoading = false;
-        });
+        this.originIsController = await this.svc.checkOriginForController();
+        if (this.originIsController) {
+            this.originIsController = true;
+            this.edgeCreate = false;
+            this.selectedEdgeController = window.location.origin;
+            this.settingsService.addContoller(this.edgeName, window.location.hostname);
+        } else {
+            this.edgeChanged();
+            this.initSettings();
+        }
+        this.isLoading = false;
     }
 
     async login() {

--- a/projects/app-ziti-console/src/app/login/node-login.service.ts
+++ b/projects/app-ziti-console/src/app/login/node-login.service.ts
@@ -152,4 +152,8 @@ export class NodeLoginService extends LoginServiceClass {
             return false;
         });
     }
+
+    checkOriginForController(): Promise<any> {
+        return Promise.resolve(false);
+    }
 }

--- a/projects/ziti-console-lib/src/lib/services/login-service.class.ts
+++ b/projects/ziti-console-lib/src/lib/services/login-service.class.ts
@@ -16,6 +16,7 @@ export abstract class LoginServiceClass {
     abstract observeLogin(serviceUrl: string, username: string, password: string);
     abstract hasSession(): boolean;
     abstract clearSession();
+    abstract checkOriginForController(): Promise<any>;
     abstract logout();
 
     constructor(

--- a/projects/ziti-console-lib/src/lib/services/noop-login.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/noop-login.service.ts
@@ -37,4 +37,8 @@ export class NoopLoginService extends LoginServiceClass {
 
     observeLogin(serviceUrl: string, username: string, password: string) {
     }
+
+    checkOriginForController(): Promise<any> {
+        return Promise.resolve(true);
+    }
 }


### PR DESCRIPTION
closes #275 

* Moved the `checkOriginForController` function into the login service
* This function should always return`false` when running ZAC via the node server