### PR TITLE
Fix issues related to building new simple service form

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
@@ -48,7 +48,7 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
 
     checkDataChangeDebounced = debounce(this.checkDataChange, 100, {maxWait: 100});
 
-    protected constructor(private growlerService: GrowlerService) {
+    protected constructor(protected growlerService: GrowlerService) {
         super();
     }
 
@@ -134,7 +134,7 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
         return tags.val();
     }
 
-    closeModal(refresh = true, ignoreChanges = false): void {
+    closeModal(refresh = true, ignoreChanges = false, data?): void {
         if (!ignoreChanges && this._dataChange) {
             const confirmed = confirm('You have unsaved changes. Do you want to leave this page and discard your changes or stay on this page?');
             if (!confirmed) {


### PR DESCRIPTION
Fixes errors:

`error TS2554: Expected 0-2 arguments, but got 3.`
and
`error TS2341: Property 'growlerService' is private and only accessible within class 'ProjectableForm'.`