### PR TITLE
Fix rendering of complex config schemas on create/edit service form

### DIFF
--- a/projects/app-ziti-console/src/app/app-routing.module.ts
+++ b/projects/app-ziti-console/src/app/app-routing.module.ts
@@ -23,7 +23,8 @@ import {
   ZacWrapperComponent,
   IdentitiesPageComponent,
   DeactivateGuardService,
-  EdgeRoutersPageComponent
+  EdgeRoutersPageComponent,
+  ServicesPageComponent
 } from "ziti-console-lib";
 import {environment} from "./environments/environment";
 import {URLS} from "./app-urls.constants";
@@ -71,7 +72,7 @@ const routes: Routes = [
   },
   {
     path: 'services',
-    component: ZacWrapperComponent,
+    component: ServicesPageComponent,
     canActivate: mapToCanActivate([AuthenticationGuard]),
     runGuardsAndResolvers: 'always',
   },

--- a/projects/ziti-console-lib/src/lib/assets/scripts/forms/schema.js
+++ b/projects/ziti-console-lib/src/lib/assets/scripts/forms/schema.js
@@ -319,7 +319,7 @@ var schema = {
         if (schema.data&&schema.data.properties) {
             for (var key in schema.data.properties) {
                 if (key!="httpChecks"&&key!="portChecks") {
-                    items.push({ key: key.toLowerCase(), content: schema.getField(key, schema.data.properties[key]) });
+                    items.push({ key: key.toLowerCase(), content: schema.getField(key, schema.data.properties[key]), type: schema.getType(key, schema.data.properties[key]) });
                 }
             }
         }

--- a/projects/ziti-console-lib/src/lib/assets/styles/forms.css
+++ b/projects/ziti-console-lib/src/lib/assets/styles/forms.css
@@ -21,7 +21,7 @@ textarea::placeholder {
 input, select, textarea {
     font-weight: 400;
     font-family: 'Open Sans', Arial, sans-serif;
-    height: 50px;
+    height: var(--defaultInputHeight);
     width: 100%;
     border-color: var(--stroke);
     border-style: solid;

--- a/projects/ziti-console-lib/src/lib/assets/styles/ziti.css
+++ b/projects/ziti-console-lib/src/lib/assets/styles/ziti.css
@@ -20,6 +20,7 @@ body {
     --transition: 0.5s;
     --offWhite: #FCFCFC;
     --dark: #28292B;
+    --formBase: #919ca5;
     --formGroup: #232f3e;
     --formSubGroup: #5e7088;
     --modalBorderRadius: 15px;
@@ -37,6 +38,7 @@ body {
     --gapMedium: 10px;
     --gapLarge: 10px;
     --gapXL: 15px;
+    --defaultInputHeight: 43px;
 }
 
 ::placeholder {

--- a/projects/ziti-console-lib/src/lib/features/card-list/card-list.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/card-list/card-list.component.scss
@@ -52,14 +52,14 @@
       text-transform: uppercase;
       text-align: center;
       line-height: 40px;
-      font-family: icomoon !important;
+      font-family: zac !important;
       font-variant: normal;
       border-radius: 33px;
       transition: all 0.3s ease 0s;
 
       &::before {
-        content: '\e905';
-        font-size: 35px;
+        content: '\e91b';
+        font-size: 30px;
       }
     }
     &:hover {

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/boolean/boolean-toggle-input.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/boolean/boolean-toggle-input.component.scss
@@ -1,0 +1,19 @@
+
+.toggle {
+  margin: 0;
+  &.on {
+    background-color: var(--green)
+  }
+  .yes,
+  .no {
+    position: absolute;
+    top:0.4rem;
+    font-size: 0.75rem;
+  }
+  .yes {
+    left: 0.6rem
+  }
+  .no {
+    right: 0.6rem
+  }
+}

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/boolean/boolean-toggle-input.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/boolean/boolean-toggle-input.component.ts
@@ -16,11 +16,7 @@ import {debounce} from "lodash";
       <div *ngIf="error" class="error">{{error}}</div>
     </div>
   `,
-  styles: [
-      '.on {background-color: var(--green);}',
-      '.toggle .yes, .toggle .no { position: absolute; top:0.4rem; font-size: 0.75rem}',
-    '.toggle .yes {left: 0.6rem}',
-    '.toggle .no {right: 0.6rem}']
+  styleUrls:['./boolean-toggle-input.component.scss'  ]
 })
 export class BooleanToggleInputComponent {
   _fieldName = 'Field Label';

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.component.scss
@@ -9,6 +9,7 @@
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
+    gap: 50px;
   }
 
   .forwarding-config-allowed-inputs {

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.component.ts
@@ -97,7 +97,8 @@ export class ForwardingConfigComponent {
   }
 
   validatePortRanges() {
-    this.errors['allowedPortRanges'] = this.validationService.validatePortRanges(this.allowedPortRanges);
+    const parsedRanges = this.validationService.parsePortRanges(this.allowedPortRanges);
+    this.errors['allowedPortRanges'] = this.validationService.validatePortRanges(parsedRanges);
   }
 
   setAllowedPortRanges(ranges) {
@@ -105,6 +106,6 @@ export class ForwardingConfigComponent {
       this.allowedPortRanges = undefined;
       return;
     }
-    this.allowedPortRanges = this.validationService.parseAllowedPortRanges(ranges);
+    this.allowedPortRanges = this.validationService.combinePortRanges(ranges);
   }
 }

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/object/object.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/object/object.component.scss
@@ -12,6 +12,10 @@
   gap: 5px;
   margin-top: var(--marginMedium);
 
+  &.closed {
+    cursor: pointer;
+  }
+
   .object-main-content {
     &[hidden] {
       display: none;
@@ -36,10 +40,12 @@
     justify-content: space-between;
     align-items: center;
     height: 23px;
+    cursor: pointer;
   }
 
   .object-label {
     margin: 0;
+    cursor: pointer;
   }
 }
 

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/object/object.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/object/object.component.scss
@@ -1,0 +1,109 @@
+:host {
+  >label {
+    margin-top: 0;
+  }
+}
+
+.wrapper {
+  border-radius: 0.5rem;
+  padding: var(--paddingMedium);
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-top: var(--marginMedium);
+
+  .object-main-content {
+    &[hidden] {
+      display: none;
+    }
+  }
+  .save-button {
+    margin-top: var(--marginSmall);
+    height: 35px;
+    min-width: 140px;
+  }
+}
+
+.object-header-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+
+  .object-header-title {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: 23px;
+  }
+
+  .object-label {
+    margin: 0;
+  }
+}
+
+.expand-toggle {
+  font-family: zac;
+  font-weight: 600;
+  font-size: 23px;
+  width: 27px;
+  color: var(--stroke);
+  height: 20px;
+  margin-top: -3px;
+  cursor: pointer;
+  &:before {
+    content: '\e91f';
+  }
+  &.open {
+    transform: rotate(270deg);
+  }
+}
+
+.added-items-list {
+  margin-top: var(--marginSmall);
+  width: 100%;
+
+  label,
+  .added-items-label {
+    margin-top: 0;
+  }
+
+  .object-list-items-container {
+    background-color: rgb(255 255 255 / 30%);
+    border-radius: 7px;
+    display: flex;
+    flex-direction: column;
+    padding: 5px;
+    .none-added-label {
+      padding-left: var(--paddingSmall);
+      color: var(--white);
+      opacity: .7;
+    }
+  }
+  .object-list-item {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+
+    .preview-name {
+      color: var(--formBackground);
+      //cursor: pointer;
+      font-weight: 600;
+      margin-left: var(--marginSmall);
+      margin-bottom: 2px;
+      /*&:hover {
+        text-decoration: underline;
+        color: var(--primary);
+      }*/
+    }
+    .icon-clear {
+      color: var(--formBackground);
+      cursor: pointer;
+      &:hover {
+        color: var(--primary);
+      }
+    }
+  }
+}

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/object/object.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/object/object.component.ts
@@ -1,14 +1,31 @@
-import {Component, Input, ViewChild, ViewContainerRef} from '@angular/core';
+import {Component, EventEmitter, Input, Output, ViewChild, ViewContainerRef} from '@angular/core';
 
 @Component({
   selector: 'lib-object',
   template: `
-    <label for="schema_{{parentage?parentage+'_':''}}{{_idName}}"  [ngStyle]="{'color': labelColor}">{{_fieldName}}</label>
     <div id="schema_{{parentage?parentage+'_':''}}{{_idName}}" class="wrapper" [ngStyle]="{'background-color': bcolor}">
-      <ng-container #wrappercontents></ng-container>
+      <div class="object-header-container">
+        <div class="object-header-title">
+          <label class="object-label" for="schema_{{parentage?parentage+'_':''}}{{_idName}}"  [ngStyle]="{'color': labelColor}">{{_fieldName}}</label>
+          <div class="expand-toggle" [ngClass]="{open: open}" (click)="toggleOpen()"></div>
+        </div>
+        <div class="added-items-list" [hidden]="!open || !showAdd">
+          <div class="object-list-items-container">
+            <span class="none-added-label" *ngIf="!addedItems || addedItems.length <= 0">NONE ADDED...</span>
+            <div (click)="itemClicked(item, i)" *ngFor="let item of addedItems; index as i" class="object-list-item clickable">
+              <div class="icon-clear" (click)="removeItemClicked(item, i)"></div>
+              <span class="preview-name" matTooltip="" matTooltipPosition="below">{{ _fieldName + '_item_' + i  }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="object-main-content" [hidden]="!open">
+        <ng-container #wrappercontents></ng-container>
+        <div *ngIf="showAdd" class="save-button button" (click)="addClicked()">Add</div>
+      </div>
     </div>
   `,
-  styles: ['.wrapper { border-radius: 0.5rem; min-height: 1rem; padding:1rem }']
+  styleUrls: ['./object.component.scss']
 })
 export class ObjectComponent {
   @ViewChild("wrappercontents", {read: ViewContainerRef, static: true}) public wrapperContents!: ViewContainerRef;
@@ -18,7 +35,35 @@ export class ObjectComponent {
     this._fieldName = name;
     this._idName = name.replace(/\s/g, '').toLowerCase();
   }
+  @Input() itemData: any;
   @Input() parentage: string[] = [];
   @Input() bcolor = '#33aaff'
   @Input() labelColor = '#000000';
+  @Input() showAdd = false;
+  @Input() addedItems = [];
+  @Input() open = false;
+  @Output() itemAdded: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Output() itemSelected: EventEmitter<any> = new EventEmitter<any>();
+  @Output() itemRemoved: EventEmitter<any> = new EventEmitter<any>();
+
+  constructor() {
+  }
+  addClicked() {
+    this.itemAdded.emit(true);
+  }
+
+  itemClicked(item, index) {
+    this.itemSelected.emit(item);
+  }
+
+  toggleOpen() {
+    this.open = !this.open;
+  }
+
+  removeItemClicked(item, index) {
+    this.addedItems = this.addedItems.filter((addedItem, itemIndex) => {
+      return index !== itemIndex;
+    });
+    this.itemRemoved.emit(item);
+  }
 }

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/object/object.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/object/object.component.ts
@@ -3,11 +3,11 @@ import {Component, EventEmitter, Input, Output, ViewChild, ViewContainerRef} fro
 @Component({
   selector: 'lib-object',
   template: `
-    <div id="schema_{{parentage?parentage+'_':''}}{{_idName}}" class="wrapper" [ngStyle]="{'background-color': bcolor}">
+    <div id="schema_{{parentage?parentage+'_':''}}{{_idName}}" class="wrapper" [ngStyle]="{'background-color': bcolor}" [ngClass]="{closed: !open}" (click)="toggleOpen($event, 'wrapper')">
       <div class="object-header-container">
-        <div class="object-header-title">
+        <div class="object-header-title" (click)="toggleOpen($event, 'header')">
           <label class="object-label" for="schema_{{parentage?parentage+'_':''}}{{_idName}}"  [ngStyle]="{'color': labelColor}">{{_fieldName}}</label>
-          <div class="expand-toggle" [ngClass]="{open: open}" (click)="toggleOpen()"></div>
+          <div class="expand-toggle" [ngClass]="{open: open}"></div>
         </div>
         <div class="added-items-list" [hidden]="!open || !showAdd">
           <div class="object-list-items-container">
@@ -56,8 +56,14 @@ export class ObjectComponent {
     this.itemSelected.emit(item);
   }
 
-  toggleOpen() {
+  toggleOpen(event, source) {
+    if (this.open && source === 'wrapper') {
+      return;
+    } else if (!this.open && source === 'header') {
+      return;
+    }
     this.open = !this.open;
+    event.stopPropagation();
   }
 
   removeItemClicked(item, index) {

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/port-ranges/port-ranges.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/port-ranges/port-ranges.component.ts
@@ -44,8 +44,8 @@ export class PortRangesComponent {
       this.fieldValue = [];
       return;
     }
-
-    this.fieldValue = this.validationService.parseAllowedPortRanges(ranges);
+    const parsedPortRanges = this.validationService.parsePortRanges(ranges);
+    this.fieldValue = this.validationService.parsePortRanges(parsedPortRanges);
   }
 
   onKeyup(event: any) {

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/port-ranges/port-ranges.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/port-ranges/port-ranges.component.ts
@@ -49,7 +49,8 @@ export class PortRangesComponent {
   }
 
   onKeyup(event: any) {
-    if (event.key === " ") {
+    const key = event.key?.toLowerCase();
+    if (key === " " || key === 'enter') {
       event.preventDefault();
       const element = event.target as HTMLElement;
       element.blur();

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/protocol-address-port/protocol-address-port-input.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/protocol-address-port/protocol-address-port-input.component.scss
@@ -14,6 +14,10 @@
     }
 }
 
+.grid.address-only {
+    grid-template-columns: auto;
+}
+
 .host-name-port {
     grid-template-columns: auto 75px;
 }

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/protocol-address-port/protocol-address-port-input.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/protocol-address-port/protocol-address-port-input.component.ts
@@ -83,8 +83,10 @@ export class ProtocolAddressPortInputComponent implements OnInit, DoCheck {
 
   get className() {
     let className = 'addressFull'
-    if (!this.showProtocol && (this.showHostName || this.showHostName) && (this.showPort)) {
+    if (!this.showProtocol && (this.showHostName || this.showAddress) && (this.showPort)) {
       className = 'host-name-port';
+    } else if (!this.showProtocol && !this.showPort && (this.showHostName || this.showAddress)) {
+      className = 'address-only';
     }
     return className;
   }

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/text-list/text-list-input.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/text-list/text-list-input.component.scss
@@ -4,7 +4,7 @@
     width: 100%;
     font-weight: 400;
     font-family: 'Open Sans', Arial, sans-serif;
-    height: 50px;
+    height: var(--defaultInputHeight);
     border-color: var(--stroke);
     border-style: solid;
     border-width: 2px;
@@ -20,8 +20,7 @@
 
     .p-inputtext.p-chips-multiple-container {
       width: 100%;
-      padding-top: 0;
-      padding-bottom: 0;
+      padding: 0;
       border-width: 2px;
 
       &.p-focus {
@@ -37,7 +36,7 @@
 
   .p-chips .p-chips-multiple-container .p-chips-input-token input {
     height: 25px;
-    font-size: 1rem;
+    font-size: 14px;
     color: #495057;
     padding: 0;
     margin: 0;
@@ -50,14 +49,13 @@
   }
 
   .p-chips .p-chips-multiple-container .p-chips-token {
-    padding: .55rem .5rem;
     margin-right: .5rem;
     font-family: Open Sans, sans-serif;
     font-weight: 600;
     margin-top: 5px;
     margin-bottom: 5px;
-    background: #E3F2FD;
-    color: #495057;
+    background: var(--primary);
+    color: var(--white);
     border-radius: 7px;
     cursor: default;
     display: inline-flex;

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/text-list/text-list-input.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/text-list/text-list-input.component.ts
@@ -66,8 +66,10 @@ export class TextListInputComponent {
   valueChange = new Subject<string> ();
 
   onKeyup(event: any) {
-    if (event.key === " ") {
+    const key = event.key?.toLowerCase();
+    if (key === " " || key === 'enter') {
       event.preventDefault();
+      event.stopPropagation();
       const element = event.target as HTMLElement;
       element.blur();
       element.focus();

--- a/projects/ziti-console-lib/src/lib/features/json-view/json-view.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/json-view/json-view.component.ts
@@ -92,9 +92,19 @@ export class JsonViewComponent implements AfterViewInit, OnChanges {
             this.dataChange.emit(this.content.json);
             this.currentData = this.content.json;
           } else if (this.content?.text) {
-            const newData = JSON.parse(this.content.text)
-            this.dataChange.emit(newData);
-            this.currentData = newData;
+            try {
+              const newData = JSON.parse(this.content.text)
+              this.dataChange.emit(newData);
+              this.currentData = newData;
+            } catch (e) {
+              this.jsonInvalidChange.emit(false);
+            }
+          }
+          const errors = this.validate(this.currentData);
+          if (!errors && !_.isEmpty(this.content.text)) {
+            this.jsonInvalidChange.emit(false);
+          } else {
+            this.jsonInvalidChange.emit(true);
           }
         }
       }

--- a/projects/ziti-console-lib/src/lib/features/preview-list/preview-list.component.html
+++ b/projects/ziti-console-lib/src/lib/features/preview-list/preview-list.component.html
@@ -5,7 +5,7 @@
     <div class="text row">
         <div (click)="selected(name)" *ngFor="let name of names" [ngClass]="{ clickable: clickable }" class="listText">
             <div *ngIf="allowRemove" class="icon-clear" (click)="remove(name)"></div>
-            <span class="preview-name" matTooltip="{{tooltip}}" matTooltipPosition="below">{{ name }}</span>
+            <span class="preview-name" matTooltip="{{tooltip}}" matTooltipPosition="above">{{ name }}</span>
         </div>
     </div>
 </div>

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/form-field-container/form-field-container.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/form-field-container/form-field-container.component.html
@@ -6,7 +6,7 @@
                 *ngIf="helpText"
                 class="form-field-info infoicon"
                 matTooltip="{{helpText}}"
-                matTooltipPosition="below"
+                matTooltipPosition="above"
             ></div>
         </div>
         <span class="form-field-label" *ngIf="label">{{label}}</span>

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/form-field-toggle/form-field-toggle.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/form-field-toggle/form-field-toggle.component.html
@@ -1,8 +1,7 @@
-<div class="form-field-toggle-container" tabindex=0 (keyup.space)="enterKeyPressed($event)">
+<div class="form-field-toggle-container" tabindex=0 (keyup.space)="enterKeyPressed($event)" (click)="toggleSwitch()">
     <span *ngIf="orientation === 'row'" class="form-field-label">{{label}}</span>
     <div class="form-field-line"></div>
     <div
-            (click)="toggleSwitch()"
             [ngClass]="{ on: toggleOn }"
             class="toggle"
     >

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/form-field-toggle/form-field-toggle.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/form-field-toggle/form-field-toggle.component.scss
@@ -3,6 +3,7 @@
   flex-direction: row;
   align-items: center;
   gap: 10px;
+  cursor: pointer;
 
   &:focus {
     .form-field-label {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/form-header/form-header.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/form-header/form-header.component.html
@@ -17,7 +17,7 @@
                                 [ngClass]="{'toggle-option-selected': formView === 'simple'}"
                                 (click)="requestAction('toggle-view', 'raw')"
                         >
-                            SIMPLE
+                            FORM
                         </span>
                 <div class="form-header-toggle" (click)="requestAction('toggle-view', formView)">
                     <div
@@ -33,8 +33,8 @@
                         [ngClass]="{'toggle-option-selected': formView === 'raw'}"
                         (click)="requestAction('toggle-view', 'simple')"
                 >
-                            RAW
-                        </span>
+                    JSON
+                </span>
             </div>
             <div class="more-actions-container" *ngIf="moreActions && moreActions.length > 0" (click)="showMoreActions()" (clickOutside)="closeActionsMoreActions()">
                 <div class="more-actions-button">

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
@@ -15,14 +15,14 @@
 */
 
 import {ExtendableComponent} from "../extendable/extendable.component";
-import {Component, DoCheck, ElementRef, EventEmitter, Input, Output, ViewChild} from "@angular/core";
+import {Component, DoCheck, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild} from "@angular/core";
 
 import {defer, delay, isEqual, unset, debounce} from "lodash";
 import {GrowlerModel} from "../messaging/growler.model";
 import {GrowlerService} from "../messaging/growler.service";
 
 // @ts-ignore
-const {context, tags, resources, service} = window;
+const {context, tags, resources, service, app} = window;
 
 @Component({
     template: '',
@@ -134,7 +134,7 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
         return tags.val();
     }
 
-    closeModal(refresh = true, ignoreChanges = false, data?): void {
+    closeModal(refresh = true, ignoreChanges = false, data?, event?): void {
         if (!ignoreChanges && this._dataChange) {
             const confirmed = confirm('You have unsaved changes. Do you want to leave this page and discard your changes or stay on this page?');
             if (!confirmed) {
@@ -142,18 +142,22 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
             }
         }
         this.close.emit({refresh: refresh});
+        if (event) {
+            event.stopPropagation();
+        }
     }
 
     ngDoCheck() {
         this.checkDataChangeDebounced();
     }
 
-    checkDataChange() {
+    protected checkDataChange() {
         const dataChange = !isEqual(this.initData, this.formData);
         if (dataChange !== this._dataChange) {
             this.dataChange.emit(dataChange);
         }
         this._dataChange = dataChange;
+        app.isDirty = false;
     }
 
     copyToClipboard(val) {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.html
@@ -1,6 +1,7 @@
 <div class="projectable-form-wrapper"
      (keyup.enter)="save($event)"
      (keyup.escape)="closeModal(false)"
+     tabindex="0"
 >
     <lib-form-header
         [data]="formData"
@@ -8,8 +9,8 @@
         [moreActions]="formData.moreActions"
         (actionRequested)="headerActionRequested($event)"
         [(formView)]="formView"
-        [saveDisabled]="svc.saveDisabled"
-        [saveTooltip]="'Complete and attach config definition, or remove before saving'"
+        [saveDisabled]="svc.saveDisabled || formDataInvalid"
+        [saveTooltip]="saveButtonTooltip"
     ></lib-form-header>
     <div class="edge-router-form-container projectable-form-container">
         <div class="projectable-form-main-column form-group-row" [hidden]="formView !== 'simple'">
@@ -198,6 +199,7 @@
                 <lib-form-field-container
                     [title]="'Selected Configurations'"
                     [count]="svc.addedConfigNames ? svc.addedConfigNames.length : 0"
+                    [helpText]="'Preview list of all service configurations that this service is associated with.'"
                 >
                     <lib-preview-list
                         [allNames]="svc.addedConfigNames"
@@ -223,6 +225,7 @@
                         [title]="'API Calls'"
                         [label]="''"
                         [class]="'api-call-container'"
+                        [helpText]="'Preview of the API URL and data model that is used to create/update this service'"
                 >
                     <div class="form-row">
                         <input class="form-field-input" [value]="apiCallURL" readonly/>
@@ -233,7 +236,7 @@
             </div>
         </div>
         <div class="form-group-column" *ngIf="formView === 'raw'">
-            <lib-json-view *ngIf="formData" [(data)]="formData"></lib-json-view>
+            <lib-json-view *ngIf="formData" [(data)]="formData" [(jsonInvalid)]="formDataInvalid"></lib-json-view>
         </div>
     </div>
 </div>

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.scss
@@ -122,6 +122,7 @@
 ::ng-deep .config-form-container {
   label {
     color: var(--white) !important;
+    margin-bottom: 0;
   }
 }
 

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
@@ -90,6 +90,7 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
 
   showMore = false;
   formView = 'simple';
+  formDataInvalid = false;
   settings: any = {};
   subscription: Subscription = new Subscription();
 
@@ -184,6 +185,13 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
     const isExtValid = await this.extService.validateData();
     const isEdit = !isEmpty(this.formData.id);
     if(!isValid || !isExtValid) {
+      const growlerData = new GrowlerModel(
+          'error',
+          'Error',
+          `Data Invalid`,
+          `Service data is invalid. Please update and try again.`,
+      );
+      this.growlerService.show(growlerData);
       return;
     }
 
@@ -211,6 +219,14 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
 
   get apiCallURL() {
     return this.settings.selectedEdgeController + '/edge/management/v1/services' + (this.formData.id ? `/${this.formData.id}` : '');
+  }
+
+  get saveButtonTooltip() {
+    if (this.formDataInvalid) {
+      return 'Service data is invalid. Please update and try again.'
+    } else {
+      return 'Complete and attach config definition, or remove before saving';
+    }
   }
 
   clear(): void {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
@@ -116,15 +116,21 @@ export class ServiceFormService {
     save(formData): Promise<any> {
         const isUpdate = !isEmpty(formData.id);
         const data: any = this.getServiceDataModel(formData, isUpdate);
-        const svc = isUpdate ? this.zitiService.patch.bind(this.zitiService) : this.zitiService.post.bind(this.zitiService);
-        return svc('services', data, formData.id).then(async (result: any) => {
-            const id = result?.data?.id || formData.id;
-            let router = await this.zitiService.getSubdata('services', id, '').then((routerData) => {
-                return routerData.data;
+        let prom;
+        if (isUpdate) {
+            prom = this.zitiService.patch('services', data, formData.id, true);
+        } else {
+            prom = this.zitiService.post('services', data, true);
+        }
+
+        return prom.then(async (result: any) => {
+            const id = isUpdate ? formData.id : (result?.data?.id || result?.id);
+            let svc = await this.zitiService.getSubdata('services', id, '').then((svcData) => {
+                return svcData.data;
             });
-            return this.extService.formDataSaved(router).then((formSavedResult: any) => {
+            return this.extService.formDataSaved(svc).then((formSavedResult: any) => {
                 if (!formSavedResult) {
-                    return router;
+                    return svc;
                 }
                 const growlerData = new GrowlerModel(
                     'success',
@@ -133,7 +139,7 @@ export class ServiceFormService {
                     `Successfully ${isUpdate ? 'updated' : 'created'} Service: ${formData.name}`,
                 );
                 this.growlerService.show(growlerData);
-                return router;
+                return svc;
             }).catch((result) => {
                 return false;
             });

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.html
@@ -1,6 +1,7 @@
 <div class="projectable-form-wrapper simple-service-wrapper"
      (keyup.enter)="save($event)"
-     (keyup.escape)="closeModalHandler()"
+     (keyup.escape)="closeModal(true, false, 'cards', $event)"
+     tabindex="0"
 >
     <lib-form-header
             [data]="formData"
@@ -35,7 +36,7 @@
                                     <span class="form-field-title">SELECT OR CREATE SERVICE ATTRIBUTES</span>
                                 </div>
                                 <lib-tag-selector
-                                    [(selectedRoleAttributes)]="serviceApiData.attributes"
+                                    [(selectedRoleAttributes)]="serviceApiData.roleAttributes"
                                     [availableRoleAttributes]="serviceRoleAttributes"
                                     [placeholder]="'Add attributes to group services'"
                                 ></lib-tag-selector>
@@ -66,6 +67,7 @@
                                     [hasError]="errors.dialIdentities"
                                     (selectedNamedAttributesChange)="validateDialIdentities()"
                                     (selectedRoleAttributesChange)="validateDialIdentities()"
+                                    (filterChange)="getIdentityNamedAttributes($event)"
                             ></lib-tag-selector>
                         </div>
                         <div class="form-field-sub-group">

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.html
@@ -96,7 +96,15 @@
                                     </div>
                                 </div>
                                 <div class="config-item-container" [ngClass]="{disabled: sdkOnlyDial}">
-                                    <span class="config-item-label">HOSTNAME / IP</span>
+                                    <div class="config-hostname-label">
+                                        <span class="config-item-label">HOSTNAME / IP</span>
+                                        <div
+                                            class="form-field-info infoicon"
+                                            matTooltip="Accessing hostnames must include a '.'"
+                                            matTooltipPosition="above"
+                                        ></div>
+                                        <span *ngIf="errors.interceptAddressFormat" class="error-label">Accessing hostnames must include a '.'</span>
+                                    </div>
                                     <input id="HowTo" type="text" maxlength="100" data-i18n="EgHost" (change)="validateInterceptAddress()" [ngClass]="{error: errors.interceptAddress}" [placeholder]="sdkOnlyDial ? '' : 'e.g. myservice.ziti'" [(ngModel)]="sdkOnlyDial ? '' : interceptConfigApiData.data.addresses[0]">
                                 </div>
                                 <div class="config-item-container" [ngClass]="{disabled: sdkOnlyDial}">

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.scss
@@ -49,7 +49,7 @@
         color: var(--white);
         display: flex;
         justify-content: space-between;
-        height: 43px;
+        height: var(--defaultInputHeight);
         align-items: center;
         margin-bottom: 0;
         .label {
@@ -125,7 +125,7 @@
       }
       .addressFull {
         select {
-          height: 43px;
+          height: var(--defaultInputHeight);
         }
       }
     }
@@ -213,9 +213,9 @@
 
 ::ng-deep .simple-service-wrapper {
   input {
-    max-height: 43px;
+    max-height: var(--defaultInputHeight);
     min-height: 0px;
-    height: 43px;
+    height: var(--defaultInputHeight);
   }
   .select2-search__field {
     height: 100%;

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.scss
@@ -10,7 +10,8 @@
   .simple-service-form-container {
     .form-group-column {
       height: fit-content;
-      width: 650px;
+      max-width: 650px;
+      width: 100%;
       transition: var(--transition);
       flex-grow: 0;
       padding-bottom: 0;
@@ -97,6 +98,19 @@
           .off-label {
             margin-left: 32px;
           }
+        }
+      }
+      .config-hostname-label {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-start;
+        white-space: nowrap;
+
+        .form-field-info {
+          margin-top: 1px;
+        }
+        .error-label {
+          margin-left: 5px;
         }
       }
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
@@ -553,14 +553,17 @@ export class SimpleServiceComponent extends ProjectableForm {
   validateInterceptAddress() {
     if (this.sdkOnlyDial) {
       unset(this.errors, 'interceptAddress');
+      unset(this.errors, 'interceptAddressFormat');
       return;
     }
     if (isEmpty(this.interceptConfigApiData.data.addresses) || isEmpty(this.interceptConfigApiData.data.addresses[0])) {
       this.errors.interceptAddress = true;
     } else if (!this.validationService.isValidInterceptHost(this.interceptConfigApiData.data.addresses[0])) {
       this.errors.interceptAddress = true;
+      this.errors.interceptAddressFormat = true;
     } else {
       unset(this.errors, 'interceptAddress');
+      unset(this.errors, 'interceptAddressFormat');
     }
   }
 

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
@@ -8,7 +8,12 @@ import {ExtensionService} from "../../../extendable/extensions-noop.service";
 import {GrowlerModel} from "../../../messaging/growler.model";
 import {MatDialog} from "@angular/material/dialog";
 import {CreationSummaryDialogComponent} from "../../../creation-summary-dialog/creation-summary-dialog.component";
-import {isEmpty, isNil, isNaN, unset, cloneDeep} from 'lodash';
+import {isEmpty, isNil, isNaN, unset, cloneDeep, isEqual} from 'lodash';
+import {ValidationService} from '../../../../services/validation.service';
+import {ServicesPageService} from "../../../../pages/services/services-page.service";
+
+// @ts-ignore
+const {app} = window;
 
 @Component({
   selector: 'lib-simple-service',
@@ -42,7 +47,7 @@ export class SimpleServiceComponent extends ProjectableForm {
   bindPolicyApiUrl = '';
   initServiceApiData = {
     name: "",
-    attributes: [],
+    roleAttributes: [],
     configs: [],
     encryptionRequired: true
   };
@@ -103,6 +108,12 @@ export class SimpleServiceComponent extends ProjectableForm {
   dialIncrement = -1;
   bindIncrement = -1;
 
+  serviceDataChange = false;
+  interceptDataChange = false;
+  hostDataChange = false;
+  dialDataChange = false;
+  bindDataChange = false;
+
   @Output() close: EventEmitter<any> = new EventEmitter<any>();
   @Output() selected: EventEmitter<any> = new EventEmitter<any>();
 
@@ -113,6 +124,8 @@ export class SimpleServiceComponent extends ProjectableForm {
       growlerService: GrowlerService,
       @Inject(SERVICE_EXTENSION_SERVICE) private extService: ExtensionService,
       private dialogForm: MatDialog,
+      private validationService: ValidationService,
+      private servicesPageService: ServicesPageService
   ) {
     super(growlerService);
   }
@@ -150,10 +163,21 @@ export class SimpleServiceComponent extends ProjectableForm {
     this.hostConfigApiData = cloneDeep(this.initHostConfigApiData);
     this.dialPolicyApiData = cloneDeep(this.initDialPolicyApiData);
     this.bindPolicyApiData = cloneDeep(this.initBindPolicyApiData);
+    this.servicesPageService.getServiceRoleAttributes().then((result) => {
+      this.serviceRoleAttributes = result.data;
+    });
   }
 
-  getIdentityNamedAttributes() {
-    this.zitiService.get('identities', {}, []).then((result) => {
+  getIdentityNamedAttributes(filter?) {
+    const paging = {
+      searchOn: 'name',
+      filter: filter || '',
+      total: 30,
+      page: 1,
+      sort: 'name',
+      order: 'asc'
+    };
+    this.zitiService.get('identities', paging, []).then((result) => {
       const namedAttributes = result.data.map((identity) => {
         this.identitiesNameIdMap[identity.name] = identity.id;
         return identity.name;
@@ -168,19 +192,11 @@ export class SimpleServiceComponent extends ProjectableForm {
         this.save();
         break;
       case 'close':
-        this.closeModalHandler();
+        this.closeModal(true, true, 'cards')
         break;
       case 'toggle-view':
         this.formView = action.data;
         break;
-    }
-  }
-
-  closeModalHandler() {
-    if (!this.showForm) {
-      this.showForm = true;
-    } else {
-      this.closeModal(true, true, 'cards');
     }
   }
 
@@ -535,7 +551,13 @@ export class SimpleServiceComponent extends ProjectableForm {
   }
 
   validateInterceptAddress() {
-    if (!this.sdkOnlyDial && (isEmpty(this.interceptConfigApiData.data.addresses) || isEmpty(this.interceptConfigApiData.data.addresses[0]))) {
+    if (this.sdkOnlyDial) {
+      unset(this.errors, 'interceptAddress');
+      return;
+    }
+    if (isEmpty(this.interceptConfigApiData.data.addresses) || isEmpty(this.interceptConfigApiData.data.addresses[0])) {
+      this.errors.interceptAddress = true;
+    } else if (!this.validationService.isValidInterceptHost(this.interceptConfigApiData.data.addresses[0])) {
       this.errors.interceptAddress = true;
     } else {
       unset(this.errors, 'interceptAddress');
@@ -543,7 +565,13 @@ export class SimpleServiceComponent extends ProjectableForm {
   }
 
   validateInterceptPort() {
-    if (!this.sdkOnlyDial && isEmpty(this.interceptConfigApiData.data.portRanges)) {
+    if (this.sdkOnlyDial) {
+      unset(this.errors, 'interceptPort');
+      return;
+    }
+    if (isEmpty(this.interceptConfigApiData.data.portRanges)) {
+      this.errors.interceptPort = true;
+    } else if (this.validationService.validatePortRanges(this.interceptConfigApiData.data.portRanges)) {
       this.errors.interceptPort = true;
     } else {
       unset(this.errors, 'interceptPort');
@@ -559,7 +587,13 @@ export class SimpleServiceComponent extends ProjectableForm {
   }
 
   validateHostPort() {
-    if (!this.sdkOnlyBind && isNil(this.hostConfigApiData.data.port) || isNaN(this.hostConfigApiData.data.port)) {
+    if (this.sdkOnlyBind) {
+      unset(this.errors, 'hostPort');
+      return;
+    }
+    if (isNil(this.hostConfigApiData.data.port) || isNaN(this.hostConfigApiData.data.port)) {
+      this.errors.hostPort = true;
+    } else if (!this.validationService.isValidPort(this.hostConfigApiData.data.port)) {
       this.errors.hostPort = true;
     } else {
       unset(this.errors, 'hostPort');
@@ -620,6 +654,26 @@ export class SimpleServiceComponent extends ProjectableForm {
       -H 'content-type: application/json' \\
       -H 'zt-session: ${this.zitiSessionId}' \\
       --data-raw '${JSON.stringify(this.bindPolicyApiData)}' \\`;
+  }
+
+  override checkDataChange() {
+    const serviceDataChange = !isEqual(this.initServiceApiData, this.serviceApiData);
+    const interceptDataChange = !isEqual(this.initInterceptConfigApiData.data, this.interceptConfigApiData.data);
+    const hostDataChange = !isEqual(this.initHostConfigApiData.data, this.hostConfigApiData.data);
+    const dialDataChange = !isEqual(this.initDialPolicyApiData, this.dialPolicyApiData);
+    const bindDataChange = !isEqual(this.initBindPolicyApiData, this.bindPolicyApiData);
+    const dataChange = serviceDataChange !== this.serviceDataChange || interceptDataChange !== this.interceptDataChange || hostDataChange !== this.hostDataChange ||
+        dialDataChange !== this.dialDataChange || bindDataChange !== this.bindDataChange;
+    if (dataChange) {
+      this.serviceDataChange = serviceDataChange;
+      this.interceptDataChange = interceptDataChange;
+      this.hostDataChange = hostDataChange;
+      this.dialDataChange = dialDataChange;
+      this.bindDataChange = bindDataChange;
+      this.dataChange.emit(dataChange);
+    }
+    this._dataChange = serviceDataChange || interceptDataChange || hostDataChange || dialDataChange || bindDataChange;
+    app.isDirty = false;
   }
 
   clear(): void {

--- a/projects/ziti-console-lib/src/lib/features/tag-selector/tag-selector.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/tag-selector/tag-selector.component.scss
@@ -318,7 +318,7 @@
 
   .select2-container {
     .select2-selection__rendered:not(.empty) {
-      min-height: 50px;
+      min-height: var(--defaultInputHeight);
     }
 
     input {

--- a/projects/ziti-console-lib/src/lib/features/tag-selector/tag-selector.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/tag-selector/tag-selector.component.ts
@@ -21,6 +21,7 @@ export class TagSelectorComponent {
   @Output() namedAttributeRemoved = new EventEmitter<any>();
   @Output() selectedRoleAttributesChange = new EventEmitter<any>();
   @Output() selectedNamedAttributesChange = new EventEmitter<any>();
+  @Output() filterChange = new EventEmitter<any>();
 
   hideSelect = true;
   displayedRoleOptions: any[] = [];
@@ -168,6 +169,7 @@ export class TagSelectorComponent {
       default:
         this.applyFilter();
     }
+    this.filterChange.emit(filterString);
   }
 
   handleKeyDown($event: KeyboardEvent) {

--- a/projects/ziti-console-lib/src/lib/services/validation.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/validation.service.ts
@@ -1,5 +1,5 @@
 import {Injectable} from "@angular/core";
-import {isNumber} from "lodash";
+import {isEmpty, isNumber} from "lodash";
 
 @Injectable({
     providedIn: 'root'
@@ -27,7 +27,7 @@ export class ValidationService {
         return ranges;
     }
 
-    parseAllowedPortRanges(allowedPortRanges) {
+    combinePortRanges(allowedPortRanges) {
         const val = [];
         if (!allowedPortRanges) {
             return val;
@@ -42,31 +42,40 @@ export class ValidationService {
         return val;
     }
 
-    validatePortRanges(allowedPortRanges) {
-        let invalid = false;
-        if (!allowedPortRanges) {
-            return invalid;
-        }
-        allowedPortRanges.forEach((val: string) => {
+    parsePortRanges(portRanges) {
+        const parsedPortRanges = [];
+        portRanges.forEach((val: string) => {
             const vals = val.split('-');
             if (vals.length === 1) {
                 const port = parseInt(val);
-                if (!this.isValidPort(port)) {
-                    invalid = true;
-                    return;
-                }
+                parsedPortRanges.push({
+                    low: port,
+                    high: port
+                });
             } else if (vals.length === 2) {
                 const port1 = parseInt(vals[0]);
                 const port2 = parseInt(vals[1]);
-                if (!this.isValidPort(port1) || !this.isValidPort(port2)) {
-                    invalid = true;
-                    return;
-                } else if (port1 > port2) {
-                    invalid = true;
-                    return;
-                }
-            } else {
+                parsedPortRanges.push({
+                    low: port1,
+                    high: port2
+                });
+            }
+        });
+        return parsedPortRanges;
+    }
+
+    validatePortRanges(portRanges) {
+        let invalid = false;
+        if (!portRanges) {
+            return invalid;
+        }
+        portRanges.forEach((range: any) => {
+            if (!this.isValidPort(range.low) || !this.isValidPort(range.high)) {
                 invalid = true;
+                return;
+            } else if (range.low > range.high) {
+                invalid = true;
+                return;
             }
         });
         return invalid;
@@ -76,4 +85,7 @@ export class ValidationService {
         return !isNaN(port) && isNumber(port) && port >= 1 && port <= 65535;
     }
 
+    isValidInterceptHost(address) {
+        return /^[^.]+\.[^.]+$/.test(address);
+    }
 }

--- a/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
+++ b/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
@@ -396,7 +396,7 @@ lib-form-field-container {
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  height: 40px;
+  height: 35px;
   background-image: linear-gradient(to right,var(--backgroundTransparent0) 0 20%,var(--backgroundTransparent1) 20% 100%);
 
   &:hover {

--- a/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
+++ b/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
@@ -742,6 +742,10 @@ lib-tag-selector {
   }
 }
 
+.error-label {
+  color: red;
+}
+
 @keyframes loading {
   to {
     -webkit-transform: rotate(360deg);

--- a/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
+++ b/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
@@ -177,7 +177,7 @@ input {
   background-repeat: no-repeat;
   background-size: 18px;
   padding-right: 28px;
-  min-height: 50px;
+  min-height: var(--defaultInputHeight);
 
   &.error {
     border-color: var(--red);
@@ -185,7 +185,7 @@ input {
 }
 
 .form-field-input {
-  min-height: 50px;
+  min-height: var(--defaultInputHeight);
 }
 
 .form-field-input-group {
@@ -725,11 +725,13 @@ lib-form-field-container {
 }
 
 .icon-close {
-  font-size: 25px;
-  top: 15px;
-  right: 15px;
-  width: 35px;
-  font-weight: 600;
+  &.close {
+    font-size: 25px;
+    top: 15px;
+    right: 15px;
+    width: 35px;
+    font-weight: 600;
+  }
 }
 
 lib-tag-selector {

--- a/projects/ziti-console-lib/src/lib/ziti-console-lib.module.ts
+++ b/projects/ziti-console-lib/src/lib/ziti-console-lib.module.ts
@@ -93,6 +93,7 @@ import { ForwardingConfigComponent } from './features/dynamic-widgets/forwarding
 import { CardListComponent } from './features/card-list/card-list.component';
 import { SimpleServiceComponent } from './features/projectable-forms/service/simple-service/simple-service.component';
 import { CardComponent } from './features/card/card.component';
+import { CreationSummaryDialogComponent } from './features/creation-summary-dialog/creation-summary-dialog.component';
 
 export function playerFactory() {
     return import(/* webpackChunkName: 'lottie-web' */ 'lottie-web');
@@ -158,6 +159,7 @@ export function playerFactory() {
         CardListComponent,
         SimpleServiceComponent,
         CardComponent,
+        CreationSummaryDialogComponent,
     ],
     imports: [
         CommonModule,


### PR DESCRIPTION
closes #291 

* Added expand collapse behavior for Object/Array property types
* Adjusted whitespace, padding, margins, and sizing of fields
* Use of css variables where applicable
* Fixed rendering of config when toggling back and forth between JSON & form views

<img width="1415" alt="Screen Shot 2024-04-02 at 8 25 02 AM" src="https://github.com/openziti/ziti-console/assets/102923745/93606bbb-df06-4a08-b408-46a6090d1e19">
