### PR TITLE
Remove "hide this summary" option on summary modal

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/creation-summary-dialog/creation-summary-dialog.component.html
+++ b/projects/ziti-console-lib/src/lib/features/creation-summary-dialog/creation-summary-dialog.component.html
@@ -50,10 +50,6 @@
         </div>
     </lib-form-field-container>
 
-    <div class="visibility-config-container">
-        <input type="checkbox" [checked]="hideSummaryNextTime" class="config-check">
-        <span>Hide this summary next time</span>
-    </div>
     <div class="confirm-buttons-container">
         <button class="button save alert" (click)="done()">Done</button>
         <button class="button save cancel" (click)="confirm()">Create another</button>


### PR DESCRIPTION
*This option is not functional yet

relates to #285 