### PR TITLE
Added client-side checks for forwarding configs in advanced services

### DIFF
--- a/projects/app-ziti-console/src/app/login/controller-login.service.ts
+++ b/projects/app-ziti-console/src/app/login/controller-login.service.ts
@@ -104,6 +104,10 @@ export class ControllerLoginService extends LoginServiceClass {
                         );
                         this.router.navigate(['/login']);
                     }
+                    if (this.settingsService?.settings?.session) {
+                        this.settingsService.settings.session.id = undefined;
+                    }
+                    this.settingsService.set(this.settingsService.settings)
                     this.growlerService.show(growlerData);
                     throw({error: errorMessage});
                 })

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.component.html
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.component.html
@@ -10,6 +10,7 @@
         [(protocol)]="protocol"
         [(address)]="address"
         [(port)]="port"
+        #papComponent
     ></lib-protocol-address-port-input>
     <div class="forwarding-config-toggles">
         <lib-boolean-toggle-input
@@ -34,6 +35,7 @@
     <div class="forwarding-config-allowed-inputs">
         <lib-checkbox-list-input
             *ngIf="forwardProtocol"
+            [ngClass]="{invalid: errors['allowedProtocols']}"
             [fieldName]="'ALLOWED PROTOCOLS'"
             [valueList]="['tcp', 'udp']"
             [(fieldValue)]="allowedProtocols"
@@ -41,6 +43,7 @@
         </lib-checkbox-list-input>
         <lib-text-list-input
             *ngIf="forwardAddress"
+            [ngClass]="{invalid: errors['allowedAddresses']}"
             [fieldName]="'ALLOWED ADDRESSES'"
             [placeholder]="'10.10.0.0/24 domain.com'"
             [(fieldValue)]="allowedAddresses"
@@ -49,6 +52,7 @@
         </lib-text-list-input>
         <lib-text-list-input
             *ngIf="forwardPort"
+            [ngClass]="{invalid: errors['allowedPortRanges']}"
             [fieldName]="'ALLOWED PORT RANGES'"
             [placeholder]="'80 120-125 443 8080'"
             [(fieldValue)]="allowedPortRanges"

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/forwarding-config/forwarding-config.component.ts
@@ -14,10 +14,11 @@
     limitations under the License.
 */
 
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {Component, EventEmitter, Input, Output, ViewChild, ViewContainerRef} from '@angular/core';
 import {ForwardingConfigService} from "./forwarding-config.service";
 import {ValidationService} from "../../../services/validation.service";
-import {isEmpty} from "lodash";
+import {isEmpty, isNil, unset} from "lodash";
+import {ProtocolAddressPortInputComponent} from "../protocol-address-port/protocol-address-port-input.component";
 
 @Component({
   selector: 'lib-forwarding-config',
@@ -50,6 +51,7 @@ export class ForwardingConfigComponent {
   disableAddress = false;
   disablePort = false;
 
+  @ViewChild("papComponent") papComponent:ProtocolAddressPortInputComponent;
   constructor(private svc: ForwardingConfigService, private validationService: ValidationService) {}
 
   forwardProtocolToggled(event) {
@@ -96,9 +98,21 @@ export class ForwardingConfigComponent {
     return this.svc.getProperties(this.protocol, this.address, this.port, this.forwardProtocol, this.forwardAddress, this.forwardPort, this.allowedProtocols, this.allowedAddresses, this.allowedPortRanges);
   }
 
+  validateAllowedAddresses() {
+    unset(this.errors, 'allowedAddresses');
+    if (isNil(this.allowedAddresses) || isEmpty(this.allowedAddresses)) {
+      this.errors['allowedAddresses'] = true;
+    }
+    return this.errors['allowedAddresses'];
+  }
+
   validatePortRanges() {
+    unset(this.errors, 'allowedPortRanges');
     const parsedRanges = this.validationService.parsePortRanges(this.allowedPortRanges);
-    this.errors['allowedPortRanges'] = this.validationService.validatePortRanges(parsedRanges);
+    if (isNil(this.allowedPortRanges) || isEmpty(this.allowedPortRanges) || this.validationService.validatePortRanges(parsedRanges)) {
+      this.errors['allowedPortRanges'] = true;
+    }
+    return this.errors['allowedPortRanges'];
   }
 
   setAllowedPortRanges(ranges) {
@@ -107,5 +121,17 @@ export class ForwardingConfigComponent {
       return;
     }
     this.allowedPortRanges = this.validationService.combinePortRanges(ranges);
+  }
+
+  isValid() {
+    this.errors = {};
+    const papIsValid = this.papComponent.isValid();
+    if (this.forwardPort) {
+      this.validatePortRanges();
+    }
+    if (this.forwardAddress) {
+      this.validateAllowedAddresses();
+    }
+    return isEmpty(this.errors) && papIsValid;
   }
 }

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/port-ranges/port-ranges.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/port-ranges/port-ranges.component.ts
@@ -44,8 +44,7 @@ export class PortRangesComponent {
       this.fieldValue = [];
       return;
     }
-    const parsedPortRanges = this.validationService.parsePortRanges(ranges);
-    this.fieldValue = this.validationService.parsePortRanges(parsedPortRanges);
+    this.fieldValue = this.validationService.combinePortRanges(ranges);
   }
 
   onKeyup(event: any) {

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/protocol-address-port/protocol-address-port-input.component.html
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/protocol-address-port/protocol-address-port-input.component.html
@@ -1,5 +1,5 @@
 <div class="grid {{className}}">
-    <div *ngIf="showProtocol" [ngClass]="{disabled: disableProtocol}">
+    <div *ngIf="showProtocol" [ngClass]="{disabled: disableProtocol, invalid: errors['protocol']}">
         <lib-selector-input [fieldName]="protocolFieldName"
                       [(fieldValue)]="protocol"
                       [labelColor]="labelColor"
@@ -8,7 +8,7 @@
                       (fieldValueChange)="update()"
         ></lib-selector-input>
     </div>
-    <div *ngIf="showAddress" [ngClass]="{disabled: disableAddress}">
+    <div *ngIf="showAddress" [ngClass]="{disabled: disableAddress, invalid: errors['address']}">
         <lib-string-input [fieldName]="addressFieldName"
                     [(fieldValue)]="address"
                     [labelColor]="labelColor"
@@ -16,7 +16,7 @@
                           (fieldValueChange)="update()"
         ></lib-string-input>
     </div>
-    <div *ngIf="showHostName" [ngClass]="{disabled: disableHostName}">
+    <div *ngIf="showHostName" [ngClass]="{disabled: disableHostName, invalid: errors['hostname']}">
         <lib-string-input [fieldName]="hostnameFieldName"
                           [(fieldValue)]="hostname"
                           [labelColor]="labelColor"
@@ -24,7 +24,7 @@
                           (fieldValueChange)="update()"
         ></lib-string-input>
     </div>
-    <div *ngIf="showPort" [ngClass]="{disabled: disablePort}">
+    <div *ngIf="showPort" [ngClass]="{disabled: disablePort, invalid: errors['port']}">
         <lib-number-input [fieldName]="portFieldName"
                     [(fieldValue)]="port"
                     [labelColor]="labelColor"

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/protocol-address-port/protocol-address-port-input.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/protocol-address-port/protocol-address-port-input.component.ts
@@ -16,7 +16,7 @@
 
 import {Component, DoCheck, EventEmitter, Input, OnInit, Output, ViewChild, ViewContainerRef} from '@angular/core';
 import {Subject} from "rxjs";
-import _, {debounce, isEmpty, isNumber} from "lodash";
+import _, {debounce, isEmpty, isNumber, isNil, isNaN} from "lodash";
 import {ValidationService} from "../../../services/validation.service";
 
 @Component({
@@ -56,6 +56,8 @@ export class ProtocolAddressPortInputComponent implements OnInit, DoCheck {
   portFieldName = 'Port';
 
   checkAddressDebounced = debounce(this.checkAddress, 100, {maxWait: 100, leading: true});
+
+  errors = {};
 
   constructor(private validationService: ValidationService) {
   }
@@ -104,6 +106,34 @@ export class ProtocolAddressPortInputComponent implements OnInit, DoCheck {
       {key: 'port', value: port}
     ];
     return props;
+  }
+
+  isValid() {
+    this.errors = {};
+    if (!isEmpty(this.parentage)) {
+      return true;
+    }
+    if (this.showProtocol && !this.disableProtocol) {
+      if(isEmpty(this.protocol)) {
+        this.errors['protocol'] = true;
+      }
+    }
+    if (this.showAddress && !this.disableAddress) {
+      if(isEmpty(this.address)) {
+        this.errors['address'] = true;
+      }
+    }
+    if (this.showHostName && !this.disableHostName) {
+      if(isEmpty(this.hostname)) {
+        this.errors['hostname'] = true;
+      }
+    }
+    if (this.showPort && !this.disablePort) {
+      if(isNil(this.port) || isNaN(this.port)) {
+        this.errors['port'] = true;
+      }
+    }
+    return isEmpty(this.errors);
   }
 
   setProperties(data: any) {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.scss
@@ -124,6 +124,16 @@
     color: var(--white) !important;
     margin-bottom: 0;
   }
+  .invalid {
+    input {
+      border-color: var(--red);
+    }
+    .p-component {
+      &.p-input-wrapper {
+        border-color: var(--red);
+      }
+    }
+  }
 }
 
 .config-title-row {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
@@ -371,7 +371,7 @@ export class ServiceFormService {
                 .then((result) => {
                     const cfg = result?.data;
                     newConfig.id = result?.id ? result.id : result?.data?.id;
-                    this.associatedConfigsMap[newConfig.name] = newConfig.data;
+                    this.associatedConfigsMap[newConfig.name] = {data: newConfig.data, name: newConfig.name, configTypeId: newConfig.configTypeId};
                     return newConfig.id;
                 })
                 .catch((result) => {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
@@ -353,6 +353,13 @@ export class ServiceFormService {
                 this.getConfigDataFromForm();
             }
             if (!this.validateConfig()) {
+                const growlerData = new GrowlerModel(
+                    'error',
+                    'Error',
+                    `Error Validating Config`,
+                    'The entered configuration is invalid. Please update missing/invalid fields and try again.',
+                );
+                this.growlerService.show(growlerData);
                 return;
             }
             const newConfig: any = {
@@ -497,6 +504,30 @@ export class ServiceFormService {
         return data;
     }
 
+    validateConfigItems(items, parentType = 'object') {
+        let isValid = true;
+        items.forEach((item) => {
+            if (item.type === 'array') {
+                if (item?.component?.instance?.isValid) {
+                    if (!item?.component?.instance?.isValid()) {
+                        isValid = false;
+                    }
+                }
+            } else if (item.type === 'object') {
+                if (!this.validateConfigItems(item.items, item.type)) {
+                    isValid = false;
+                }
+            } else {
+                if (item?.component?.instance?.isValid) {
+                    if (!item?.component?.instance?.isValid()) {
+                        isValid = false;
+                    }
+                }
+            }
+        });
+        return isValid;
+    }
+
     async configChanged(dynamicForm, resetData = true) {
         let selectedConfig: any = {};
         this.configData = resetData ? undefined : this.configData;
@@ -625,6 +656,10 @@ export class ServiceFormService {
         this.configErrors = {};
         if (isEmpty(this.newConfigName)) {
             this.configErrors['name'] = true;
+        }
+        const configItemsValid = this.validateConfigItems(this.items);
+        if (!configItemsValid) {
+            this.configErrors['configData'] = true;
         }
         return isEmpty(this.configErrors);
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
@@ -507,21 +507,13 @@ export class ServiceFormService {
     validateConfigItems(items, parentType = 'object') {
         let isValid = true;
         items.forEach((item) => {
-            if (item.type === 'array') {
-                if (item?.component?.instance?.isValid) {
-                    if (!item?.component?.instance?.isValid()) {
-                        isValid = false;
-                    }
-                }
-            } else if (item.type === 'object') {
+            if (item.type === 'object') {
                 if (!this.validateConfigItems(item.items, item.type)) {
                     isValid = false;
                 }
-            } else {
-                if (item?.component?.instance?.isValid) {
-                    if (!item?.component?.instance?.isValid()) {
-                        isValid = false;
-                    }
+            } else if (item?.component?.instance?.isValid) {
+                if (!item?.component?.instance?.isValid()) {
+                    isValid = false;
                 }
             }
         });

--- a/projects/ziti-console-lib/src/lib/services/schema.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/schema.service.ts
@@ -612,17 +612,9 @@ export class SchemaService {
                     }
                 });
             } else {
-                if (subItem?.component?.instance?.getProperties) {
-                    if (subItem?.component?.instance?.isValid) {
-                        if (!subItem?.component?.instance?.isValid()) {
-                            isValid = false;
-                        }
-                    }
-                } else if (subItem?.component?.instance?.fieldValue) {
-                    if (subItem?.component?.instance?.isValid) {
-                        if (!subItem?.component?.instance?.isValid()) {
-                            isValid = false;
-                        }
+                if (subItem?.component?.instance?.isValid) {
+                    if (!subItem?.component?.instance?.isValid()) {
+                        isValid = false;
                     }
                 }
             }
@@ -635,16 +627,6 @@ export class SchemaService {
         item.items.forEach((subItem) => {
             let isValid = true;
             if (subItem.type === 'array') {
-                subItem.addedItems.forEach((addedItem) => {
-                    if (addedItem?.component?.instance?.isValid) {
-                        if (!addedItem?.component?.instance?.isValid()) {
-                            isValid = false;
-                        }
-                    }
-                });
-                if (!isValid) {
-                    return;
-                }
                 if (subItem.addedItems) {
                     itemData[subItem.key] = subItem.addedItems;
                 } else {
@@ -652,28 +634,12 @@ export class SchemaService {
                 }
             } else {
                 if (subItem?.component?.instance?.getProperties) {
-                    if (subItem?.component?.instance?.isValid) {
-                        if (!subItem?.component?.instance?.isValid()) {
-                            isValid = false;
-                        }
-                    }
-                    if (!isValid) {
-                        return;
-                    }
                     const props = subItem?.component?.instance?.getProperties();
                     props.forEach((prop) => {
                         itemData[prop.key] = prop.value;
                     });
                     subItem?.component?.instance?.setProperties({});
                 } else if (subItem?.component?.instance?.fieldValue) {
-                    if (subItem?.component?.instance?.isValid) {
-                        if (!subItem?.component?.instance?.isValid()) {
-                            isValid = false;
-                        }
-                    }
-                    if (!isValid) {
-                        return;
-                    }
                     itemData[subItem.key] = subItem.component.instance.fieldValue;
                     subItem.component.instance.fieldValue = undefined;
                 }

--- a/projects/ziti-console-lib/src/lib/services/schema.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/schema.service.ts
@@ -29,6 +29,8 @@ import {
 import {PortRangesComponent} from "../features/dynamic-widgets/port-ranges/port-ranges.component";
 import {ForwardingConfigComponent} from "../features/dynamic-widgets/forwarding-config/forwarding-config.component";
 import {Subscription} from "rxjs";
+import {GrowlerModel} from "../features/messaging/growler.model";
+import {GrowlerService} from "../features/messaging/growler.service";
 
 export type ProtocolAddressPort = {
     protocol: any;
@@ -57,12 +59,13 @@ export class SchemaService {
         allowedAddresses: undefined,
         forwardAddress: undefined
     };
+    requiredProperties: any[] = ['allowedAddresses', 'allowedProtocols', 'allowedPorts'];
     subscriptions: Subscription = new Subscription();
     private items: any[] = [];
     private bColorArray: string[] = [];
     private lColorArray: string[] = [];
 
-    constructor() {
+    constructor(private growlerService: GrowlerService) {
     }
 
     getType(property: any) {
@@ -477,7 +480,8 @@ export class SchemaService {
         let componentRef = view.createComponent(ForwardingConfigComponent);
         return {
             key: 'forwardingconfig',
-            component: componentRef
+            component: componentRef,
+            required: true
         };
     }
 
@@ -571,6 +575,16 @@ export class SchemaService {
         }
         this.subscriptions.add(
             item?.component?.instance?.itemAdded.subscribe((event) => {
+                if (!this.itemDataValid(item)) {
+                    const growlerData = new GrowlerModel(
+                        'error',
+                        'Error',
+                        `Error Validating Config`,
+                        'The entered configuration is invalid. Please update missing/invalid fields and try again.',
+                    );
+                    this.growlerService.show(growlerData);
+                    return
+                }
                 const itemData = this.addItemData(item);
                 if (!item.addedItems || item.addedItems.length <= 0) {
                     item.addedItems = [];
@@ -586,10 +600,51 @@ export class SchemaService {
         );
     }
 
+    itemDataValid(item: any) {
+        let isValid = true;
+        item.items.forEach((subItem) => {
+            if (subItem.type === 'array') {
+                subItem.addedItems.forEach((addedItem) => {
+                    if (addedItem?.component?.instance?.isValid) {
+                        if (!addedItem?.component?.instance?.isValid()) {
+                            isValid = false;
+                        }
+                    }
+                });
+            } else {
+                if (subItem?.component?.instance?.getProperties) {
+                    if (subItem?.component?.instance?.isValid) {
+                        if (!subItem?.component?.instance?.isValid()) {
+                            isValid = false;
+                        }
+                    }
+                } else if (subItem?.component?.instance?.fieldValue) {
+                    if (subItem?.component?.instance?.isValid) {
+                        if (!subItem?.component?.instance?.isValid()) {
+                            isValid = false;
+                        }
+                    }
+                }
+            }
+        });
+        return isValid;
+    }
+
     addItemData(item) {
         let itemData = {};
         item.items.forEach((subItem) => {
+            let isValid = true;
             if (subItem.type === 'array') {
+                subItem.addedItems.forEach((addedItem) => {
+                    if (addedItem?.component?.instance?.isValid) {
+                        if (!addedItem?.component?.instance?.isValid()) {
+                            isValid = false;
+                        }
+                    }
+                });
+                if (!isValid) {
+                    return;
+                }
                 if (subItem.addedItems) {
                     itemData[subItem.key] = subItem.addedItems;
                 } else {
@@ -597,17 +652,33 @@ export class SchemaService {
                 }
             } else {
                 if (subItem?.component?.instance?.getProperties) {
+                    if (subItem?.component?.instance?.isValid) {
+                        if (!subItem?.component?.instance?.isValid()) {
+                            isValid = false;
+                        }
+                    }
+                    if (!isValid) {
+                        return;
+                    }
                     const props = subItem?.component?.instance?.getProperties();
                     props.forEach((prop) => {
                         itemData[prop.key] = prop.value;
                     });
                     subItem?.component?.instance?.setProperties({});
                 } else if (subItem?.component?.instance?.fieldValue) {
+                    if (subItem?.component?.instance?.isValid) {
+                        if (!subItem?.component?.instance?.isValid()) {
+                            isValid = false;
+                        }
+                    }
+                    if (!isValid) {
+                        return;
+                    }
                     itemData[subItem.key] = subItem.component.instance.fieldValue;
                     subItem.component.instance.fieldValue = undefined;
                 }
             }
-        })
+        });
         return itemData;
     }
 

--- a/projects/ziti-console-lib/src/lib/services/validation.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/validation.service.ts
@@ -44,6 +44,9 @@ export class ValidationService {
 
     parsePortRanges(portRanges) {
         const parsedPortRanges = [];
+        if (!portRanges) {
+            return parsedPortRanges;
+        }
         portRanges.forEach((val: string) => {
             const vals = val.split('-');
             if (vals.length === 1) {


### PR DESCRIPTION
closes #307 
Will highlight missing/required fields and display a more user friendly error message growler.

See below screenshot for an example:

<img width="1190" alt="Screen Shot 2024-04-09 at 6 18 53 PM" src="https://github.com/openziti/ziti-console/assets/102923745/c538c040-9da1-4a94-8976-32bd535ff1ca">
