### PR TITLE
changed to pull item instead of item id so name will show

### DIFF
--- a/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.ts
@@ -118,7 +118,7 @@ export class EdgeRoutersPageComponent extends ListPageComponent implements OnIni
   }
 
   deleteItem(item: any) {
-    this.openBulkDelete([item.id], 'router');
+    this.openBulkDelete([item], 'router');
   }
 
   getEdgeRouterRoleAttributes() {


### PR DESCRIPTION
closes issue #310 - When deleting edge router(s) the delete modal does not populate the names of the edge routers that the user is trying to delete. Currently the modal list shows as empty.