### PR TITLE
Allow ZAC extensions to define additional items for the "More Actions" drop down

### DIFF
--- a/projects/app-ziti-console/src/app/app.module.ts
+++ b/projects/app-ziti-console/src/app/app.module.ts
@@ -47,7 +47,8 @@ import {
     ZAC_LOGIN_SERVICE,
     EDGE_ROUTER_EXTENSION_SERVICE,
     SERVICE_EXTENSION_SERVICE,
-    ExtensionsNoopService
+    ExtensionsNoopService,
+    IDENTITY_EXTENSION_SERVICE
 } from "ziti-console-lib";
 
 import {AppRoutingModule} from "./app-routing.module";
@@ -112,6 +113,7 @@ if (environment.nodeIntegration) {
         {provide: ZAC_LOGIN_SERVICE, useClass: loginService},
         {provide: SETTINGS_SERVICE, useClass: settingsService},
         {provide: EDGE_ROUTER_EXTENSION_SERVICE, useClass: ExtensionsNoopService},
+        {provide: IDENTITY_EXTENSION_SERVICE, useClass: ExtensionsNoopService},
         {provide: SERVICE_EXTENSION_SERVICE, useClass: ExtensionsNoopService},
     ],
     bootstrap: [AppComponent]

--- a/projects/app-ziti-console/src/app/examples/extension-service/README.md
+++ b/projects/app-ziti-console/src/app/examples/extension-service/README.md
@@ -1,0 +1,26 @@
+# Extension Service
+
+Below is an example of how to define and use an extension service.
+
+In the file `example-extension.service.ts` is an exported class that implements the `ExtensionService` interface.
+
+Each create/edit form (ie. `identity-form.component.ts`, `edge-router-form.component.ts` etc...) injects an instance of an `ExtensionService` implementation.
+
+To use a specific implementation of an extension service, you must define a provider for it in `app.module.ts`. See below for an example of how to do this: 
+
+```
+// In the "providers" secion of app.module.ts, use the relevant injection token to decalre which instance of the extesnsion service to provide
+
+import { ExampleExtensionService } from "./examples/extension-service/example-extension.service";
+
+@NgModule({
+    declarations: [AppComponent],
+    providers: [
+        // Here we can chose to use the example-extension.service.ts
+        { provide: EDGE_ROUTER_EXTENSION_SERVICE, useClass: ExampleExtensionService },
+    ]
+})
+```
+
+In `example-extension.service.ts` are examples of how the various properties, functions, and events are defined. If you open the EdgeRouter create/edit form
+(either by clicking on an existing router from the list page, or by adding a new one), you should then see the "Edit Form Action" item display as an option in the "More Actions" dropdown

--- a/projects/app-ziti-console/src/app/examples/extension-service/example-extension.service.ts
+++ b/projects/app-ziti-console/src/app/examples/extension-service/example-extension.service.ts
@@ -1,0 +1,51 @@
+import {EventEmitter, Injectable} from '@angular/core';
+import {ExtensionService} from "ziti-console-lib";
+import {BehaviorSubject} from "rxjs";
+
+@Injectable({ providedIn: 'root' })
+export class ExampleExtensionService implements ExtensionService {
+
+    moreActions = [
+        {label: 'Example Action', action: 'more-action', callback: this.executeMoreAction.bind(this)},
+    ]
+    listActions = [
+        {label: 'Example Action', action: 'list-action', callback: this.executeListAction.bind(this)},
+    ]
+    closeAfterSave: boolean;
+    closed: EventEmitter<any>;
+    formDataChanged: BehaviorSubject<any>;
+
+    extendAfterViewInits(extentionPoints: any): void {
+        // This function will execute after the edit form is initialized
+        // Uncomment the alert below to see when this function is called
+        //alert('ExampleExtensionService "extendAfterViewInits()" function executed');
+    }
+
+    formDataSaved(data: any): Promise<any> {
+        // This function will execute before form data is saved in order to do check if extension data is valid
+        // Uncomment the alert below to see when this function is called
+        // alert('ExampleExtensionService "formDataSaved()" function executed');
+        return Promise.resolve(undefined);
+    }
+
+    updateFormData(data: any): void {
+        // This function will pass in a reference to the root data model of the entity being edited
+        // Uncomment the alert below to see when this function is called
+        // alert('ExampleExtensionService "updateFormData()" function executed');
+    }
+
+    validateData(): Promise<any> {
+        // This function will execute before form data is saved in order to do check if extension data is valid
+        // Uncomment the alert below to see when this function is called
+        // alert('ExampleExtensionService "validateData()" function executed');
+        return Promise.resolve(undefined);
+    }
+
+    executeMoreAction() {
+        alert('Example action executed from "More Actions" drop down');
+    }
+
+    executeListAction() {
+        alert('Example action executed from list page menu items');
+    }
+}

--- a/projects/ziti-console-lib/src/lib/features/card-list/card-list.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/card-list/card-list.component.ts
@@ -22,9 +22,9 @@ export class CardListComponent extends ProjectableForm {
       public svc: ServiceFormService,
       @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
       growlerService: GrowlerService,
-      @Inject(SERVICE_EXTENSION_SERVICE) private extService: ExtensionService
+      @Inject(SERVICE_EXTENSION_SERVICE) extService: ExtensionService
   ) {
-    super(growlerService);
+    super(growlerService, extService);
   }
   clear(): void {
   }

--- a/projects/ziti-console-lib/src/lib/features/data-table/data-table.component.html
+++ b/projects/ziti-console-lib/src/lib/features/data-table/data-table.component.html
@@ -41,7 +41,7 @@
             class="tActionRow"
             id="ResetTableButton"
         >
-            {{headerAction.name}}
+            {{headerAction.name || headerAction.label}}
         </div>
     </div>
     <div
@@ -59,7 +59,7 @@
                 class="tActionRow"
                 id="TableActionButton_{{menuItem.action}}"
         >
-            {{menuItem.name}}
+            {{menuItem.name || menuItem.label}}
         </div>
     </div>
     <div

--- a/projects/ziti-console-lib/src/lib/features/extendable/extensions-noop.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/extendable/extensions-noop.service.ts
@@ -23,6 +23,8 @@ export interface ExtensionService {
   formDataChanged: BehaviorSubject<any>;
   closed: EventEmitter<any>;
   closeAfterSave: boolean;
+  moreActions?: any[];
+  listActions?: any[];
   extendAfterViewInits(extentionPoints: any): void;
   updateFormData(data: any): void;
   validateData(): Promise<any>;
@@ -37,6 +39,7 @@ export class ExtensionsNoopService implements ExtensionService {
   formDataChanged = new BehaviorSubject<any>({isEmpty: true});
   closed: EventEmitter<any> = new EventEmitter<any>();
   closeAfterSave = true;
+  moreActions = [];
 
   constructor() { }
 

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.ts
@@ -17,7 +17,7 @@
 import {
     Component,
     ComponentRef,
-    EventEmitter,
+    EventEmitter, Inject,
     Input,
     OnDestroy,
     OnInit, Output,
@@ -31,6 +31,8 @@ import {ProjectableForm} from "../projectable-form.class";
 import {JsonEditorComponent, JsonEditorOptions} from 'ang-jsoneditor';
 import _ from "lodash";
 import {GrowlerService} from "../../messaging/growler.service";
+import {ExtensionService, SHAREDZ_EXTENSION} from "../../extendable/extensions-noop.service";
+import {SERVICE_EXTENSION_SERVICE} from "../service/service-form.service";
 
 
 @Component({
@@ -74,8 +76,9 @@ export class ConfigurationFormComponent extends ProjectableForm implements OnIni
 
     constructor(private svc: ConfigurationService,
                 private schemaSvc: SchemaService,
-                growlerService: GrowlerService) {
-        super(growlerService);
+                growlerService: GrowlerService,
+                @Inject(SHAREDZ_EXTENSION) extService: ExtensionService) {
+        super(growlerService, extService);
     }
 
     async createForm() {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.html
@@ -34,7 +34,7 @@
                             [placeholder]="'Add attributes to group Edge Routers'"
                     ></lib-tag-selector>
                 </lib-form-field-container>
-                <ng-content select="[slot=provider]"></ng-content>
+                <ng-content select="[slot=column-1-slot-1]"></ng-content>
                 <lib-form-field-toggle [(toggleOn)]="showMore" style="margin: 0px 10px"></lib-form-field-toggle>
                 <div *ngIf="showMore" class="form-group-column">
                     <lib-form-field-container
@@ -94,7 +94,7 @@
                         *ngIf="hasEnrolmentToken"
                         [showHeader]="false"
                 >
-                    <ng-content select="[slot=registration]"></ng-content>
+                    <ng-content select="[slot=column-2-slot-1]"></ng-content>
                     <lib-qr-code
                             *ngIf="!extService['hideZitiRegistration']"
                             [identity]="formData"

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.html
@@ -5,7 +5,7 @@
     <lib-form-header
         [data]="formData"
         [title]="formData.id ? 'Edit Edge Router: ' : 'Create New Edge Router'"
-        [moreActions]="formData.moreActions"
+        [moreActions]="moreActions"
         (actionRequested)="headerActionRequested($event)"
         [(formView)]="formView"
     ></lib-form-header>
@@ -94,7 +94,9 @@
                         *ngIf="hasEnrolmentToken"
                         [showHeader]="false"
                 >
+                    <ng-content select="[slot=registration]"></ng-content>
                     <lib-qr-code
+                            *ngIf="!extService['hideZitiRegistration']"
                             [identity]="formData"
                             [jwt]="formData.jwt"
                             [token]="formData.enrollmentToken"

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.ts
@@ -55,9 +55,9 @@ export class EdgeRouterFormComponent extends ProjectableForm implements OnInit, 
       public svc: EdgeRouterFormService,
       @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
       growlerService: GrowlerService,
-      @Inject(EDGE_ROUTER_EXTENSION_SERVICE) private extService: ExtensionService
+      @Inject(EDGE_ROUTER_EXTENSION_SERVICE) extService: ExtensionService
   ) {
-    super(growlerService);
+    super(growlerService, extService);
   }
 
   ngOnInit(): void {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/form-header/form-header.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/form-header/form-header.component.html
@@ -31,7 +31,7 @@
                 <span
                         class="toggle-option-text"
                         [ngClass]="{'toggle-option-selected': formView === 'raw'}"
-                        (click)="requestAction({name:'toggle-view', action: 'simple'})"
+                        (click)="requestAction({name:'toggle-view', data: 'simple'})"
                 >
                     JSON
                 </span>

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/form-header/form-header.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/form-header/form-header.component.html
@@ -1,7 +1,7 @@
 <div class="form-header-container" [ngClass]="{'show-more-actions': moreActions && moreActions.length > 0}">
     <div class="form-header-group">
         <div class="form-title-container">
-            <div class="form-title-back-button" (click)="requestAction('close')">
+            <div class="form-title-back-button" (click)="requestAction({name: 'close'})">
                 <div class="form-title-back-button-image"></div>
                 <div class="form-title-back-button-line"></div>
             </div>
@@ -15,11 +15,11 @@
                         <span
                                 class="toggle-option-text"
                                 [ngClass]="{'toggle-option-selected': formView === 'simple'}"
-                                (click)="requestAction('toggle-view', 'raw')"
+                                (click)="requestAction({name: 'toggle-view', data: 'raw'})"
                         >
                             FORM
                         </span>
-                <div class="form-header-toggle" (click)="requestAction('toggle-view', formView)">
+                <div class="form-header-toggle" (click)="requestAction({name: 'toggle-view', data: formView})">
                     <div
                             class="form-toggle-switch"
                             [ngClass]="{'toggle-left': formView === 'simple', 'toggle-right': formView === 'raw'}"
@@ -31,7 +31,7 @@
                 <span
                         class="toggle-option-text"
                         [ngClass]="{'toggle-option-selected': formView === 'raw'}"
-                        (click)="requestAction('toggle-view', 'simple')"
+                        (click)="requestAction({name:'toggle-view', action: 'simple'})"
                 >
                     JSON
                 </span>
@@ -47,14 +47,14 @@
                     <div
                         *ngFor="let action of moreActions"
                         class="more-actions-item"
-                        (click)="requestAction(action.name, action.data)"
+                        (click)="requestAction(action)"
                     >
                         {{action.label}}
                     </div>
                 </div>
             </div>
             <div class="save-button"
-                 (click)="requestAction('save')"
+                 (click)="requestAction({name: 'save'})"
                  [ngClass]="{'save-disabled': saveDisabled}"
                  matTooltip="{{saveDisabled ? saveTooltip : ''}}"
                  matTooltipPosition="below"

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/form-header/form-header.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/form-header/form-header.component.ts
@@ -38,17 +38,20 @@ export class FormHeaderComponent {
 
   constructor() {}
 
-  requestAction(action, data?: any) {
-    if (action === 'toggle-view') {
-      if (data === 'simple') {
+  requestAction(action) {
+    if (action.name === 'toggle-view') {
+      if (action.data === 'simple') {
         this.formView = 'raw';
       } else {
         this.formView = 'simple';
       }
-      data = this.formView;
+      action.data = this.formView;
       this.formViewChange.emit();
     }
-    this.actionRequested.emit({name: action, data: data})
+    if (action.callback) {
+      action.callback();
+    }
+    this.actionRequested.emit({name: action.name, data: action.data})
     this.showActionsDropDown = false;
   }
 

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.html
@@ -5,7 +5,7 @@
     <lib-form-header
             [data]="formData"
             [title]="formData.id ? 'Edit Identity: ' : 'Create New Identity'"
-            [moreActions]="formData.moreActions"
+            [moreActions]="moreActions"
             (actionRequested)="headerActionRequested($event)"
             [(formView)]="formView"
     ></lib-form-header>

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
@@ -22,21 +22,20 @@ import {
   Output,
   OnChanges,
   SimpleChanges,
-  ViewChild,
-  ElementRef,
-  AfterViewInit, Inject
+  AfterViewInit,
+  Inject
 } from '@angular/core';
 import {ProjectableForm} from "../projectable-form.class";
 import {SETTINGS_SERVICE, SettingsService} from "../../../services/settings.service";
 
-import {isEmpty, isNil, forEach, delay, unset, keys, forOwn, cloneDeep, isEqual, set, result} from 'lodash';
+import {isEmpty, isNil, forOwn, cloneDeep, set} from 'lodash';
 import {ZITI_DATA_SERVICE, ZitiDataService} from "../../../services/ziti-data.service";
 import {GrowlerService} from "../../messaging/growler.service";
-import {GrowlerModel} from "../../messaging/growler.model";
-import {Identity} from "../../../models/identity";
-import { IdentityFormService } from './identity-form.service';
+import {IDENTITY_EXTENSION_SERVICE, IdentityFormService} from './identity-form.service';
 import {MatDialogRef} from "@angular/material/dialog";
 import {IdentitiesPageService} from "../../../pages/identities/identities-page.service";
+import {ExtensionService} from "../../extendable/extensions-noop.service";
+
 
 @Component({
   selector: 'lib-identity-form',
@@ -84,9 +83,10 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
       public svc: IdentityFormService,
       public identitiesService: IdentitiesPageService,
       @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
-      growlerService: GrowlerService
+      growlerService: GrowlerService,
+      @Inject(IDENTITY_EXTENSION_SERVICE) extService: ExtensionService
   ) {
-    super(growlerService);
+    super(growlerService, extService);
     this.identityRoleAttributes = [];
   }
 
@@ -103,6 +103,7 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
     this.getCertificateAuthorities();
     this.initData = cloneDeep(this.formData);
     this.loadTags();
+    this.extService.updateFormData(this.formData);
   }
 
   override ngAfterViewInit() {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.service.ts
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-import {Injectable, Inject} from "@angular/core";
+import {Injectable, Inject, InjectionToken} from "@angular/core";
 import moment from 'moment';
 
 import {isEmpty, unset, keys} from 'lodash';
@@ -23,6 +23,10 @@ import {GrowlerService} from "../../messaging/growler.service";
 import {GrowlerModel} from "../../messaging/growler.model";
 import {Identity} from "../../../models/identity";
 import {SETTINGS_SERVICE, SettingsService} from "../../../services/settings.service";
+
+
+export const IDENTITY_EXTENSION_SERVICE = new InjectionToken<any>('IDENTITY_EXTENSION_SERVICE');
+
 
 @Injectable({
     providedIn: 'root'

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
@@ -15,11 +15,12 @@
 */
 
 import {ExtendableComponent} from "../extendable/extendable.component";
-import {Component, DoCheck, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild} from "@angular/core";
+import {Component, DoCheck, ElementRef, EventEmitter, Inject, Input, OnInit, Output, ViewChild} from "@angular/core";
 
 import {defer, delay, isEqual, unset, debounce} from "lodash";
 import {GrowlerModel} from "../messaging/growler.model";
 import {GrowlerService} from "../messaging/growler.service";
+import {ExtensionService, SHAREDZ_EXTENSION} from "../extendable/extensions-noop.service";
 
 // @ts-ignore
 const {context, tags, resources, service, app} = window;
@@ -40,6 +41,7 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
     public errors: any = {};
     protected entityType = 'identity';
 
+    moreActions: any[] = [];
     tagElements: any = [];
     tagData: any = [];
     hideTags = false;
@@ -48,7 +50,7 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
 
     checkDataChangeDebounced = debounce(this.checkDataChange, 100, {maxWait: 100});
 
-    protected constructor(protected growlerService: GrowlerService) {
+    protected constructor(protected growlerService: GrowlerService, @Inject(SHAREDZ_EXTENSION) protected extService: ExtensionService) {
         super();
     }
 
@@ -56,6 +58,9 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
         super.ngAfterViewInit();
         this.errors = {};
         this.nameFieldInput.nativeElement.focus();
+        if (this.extService?.moreActions) {
+            this.moreActions = [...this.moreActions, ...this.extService.moreActions];
+        }
     }
 
     showMoreChanged(showMore) {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
@@ -17,7 +17,7 @@
 import {ExtendableComponent} from "../extendable/extendable.component";
 import {Component, DoCheck, ElementRef, EventEmitter, Inject, Input, OnInit, Output, ViewChild} from "@angular/core";
 
-import {defer, delay, isEqual, unset, debounce} from "lodash";
+import {defer, isEqual, unset, debounce} from "lodash";
 import {GrowlerModel} from "../messaging/growler.model";
 import {GrowlerService} from "../messaging/growler.service";
 import {ExtensionService, SHAREDZ_EXTENSION} from "../extendable/extensions-noop.service";
@@ -50,7 +50,10 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
 
     checkDataChangeDebounced = debounce(this.checkDataChange, 100, {maxWait: 100});
 
-    protected constructor(protected growlerService: GrowlerService, @Inject(SHAREDZ_EXTENSION) protected extService: ExtensionService) {
+    protected constructor(
+        protected growlerService: GrowlerService,
+        @Inject(SHAREDZ_EXTENSION) protected extService: ExtensionService
+    ) {
         super();
     }
 

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
@@ -100,9 +100,9 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
       public svc: ServiceFormService,
       @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
       growlerService: GrowlerService,
-      @Inject(SERVICE_EXTENSION_SERVICE) private extService: ExtensionService
+      @Inject(SERVICE_EXTENSION_SERVICE) extService: ExtensionService
   ) {
-    super(growlerService);
+    super(growlerService, extService);
   }
 
   ngOnInit(): void {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
@@ -25,10 +25,6 @@ export class SimpleServiceComponent extends ProjectableForm {
   @Input() identityRoleAttributes: any[] = [];
   @Input() identityNamedAttributes: any[] = [];
 
-  moreActions = [
-    {name: 'copyCLI', action: 'copy-cli', label: 'Copy as CLI'},
-    {name: 'copyAPI', action: 'copy-api', label: 'Copy as API'}
-  ]
   showForm = true;
   formView = 'simple';
   controllerDomain = '';
@@ -122,12 +118,12 @@ export class SimpleServiceComponent extends ProjectableForm {
       public svc: ServiceFormService,
       @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
       growlerService: GrowlerService,
-      @Inject(SERVICE_EXTENSION_SERVICE) private extService: ExtensionService,
+      @Inject(SERVICE_EXTENSION_SERVICE) extService: ExtensionService,
       private dialogForm: MatDialog,
       private validationService: ValidationService,
       private servicesPageService: ServicesPageService
   ) {
-    super(growlerService);
+    super(growlerService, extService);
   }
 
   ngOnInit() {

--- a/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.html
@@ -28,6 +28,7 @@
         (dataChange)="dataChanged($event)"
     >
         <ng-content select="[slot=provider]" slot="provider"></ng-content>
+        <ng-content select="[slot=registration]" slot="registration"></ng-content>
     </lib-edge-router-form>
 </lib-side-modal>
 <lib-loading-indicator *ngIf="isLoading" [isLoading]="isLoading"></lib-loading-indicator>

--- a/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.ts
@@ -14,6 +14,8 @@ import {ZacWrapperServiceClass, ZAC_WRAPPER_SERVICE} from "../../features/wrappe
 import {SettingsService} from "../../services/settings.service";
 import {ConsoleEventsService} from "../../services/console-events.service";
 import {EdgeRouter} from "../../models/edge-router";
+import {EDGE_ROUTER_EXTENSION_SERVICE} from "../../features/projectable-forms/edge-router/edge-router-form.service";
+import {ExtensionService} from "../../features/extendable/extensions-noop.service";
 
 @Component({
   selector: 'lib-edge-routers',
@@ -34,7 +36,8 @@ export class EdgeRoutersPageComponent extends ListPageComponent implements OnIni
       dialogForm: MatDialog,
       private tabNames: TabNameService,
       consoleEvents: ConsoleEventsService,
-      @Inject(ZAC_WRAPPER_SERVICE)private zacWrapperService: ZacWrapperServiceClass
+      @Inject(ZAC_WRAPPER_SERVICE)private zacWrapperService: ZacWrapperServiceClass,
+      @Inject(EDGE_ROUTER_EXTENSION_SERVICE) private extService: ExtensionService
   ) {
     super(filterService, svc, consoleEvents, dialogForm);
   }
@@ -111,6 +114,13 @@ export class EdgeRoutersPageComponent extends ListPageComponent implements OnIni
         this.svc.downloadItems(this.selectedItems);
         break;
       default:
+        if (this.extService.listActions) {
+          this.extService.listActions.forEach((action) => {
+            if (action.action === event.action) {
+              action.callback(event.item);
+            }
+          })
+        }
         break;
     }
   }

--- a/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.service.ts
@@ -19,6 +19,8 @@ import {GrowlerModel} from "../../features/messaging/growler.model";
 import {GrowlerService} from "../../features/messaging/growler.service";
 import {MatDialog} from "@angular/material/dialog";
 import {SettingsServiceClass} from "../../services/settings-service.class";
+import {EDGE_ROUTER_EXTENSION_SERVICE} from "../../features/projectable-forms/edge-router/edge-router-form.service";
+import {ExtensionService} from "../../features/extendable/extensions-noop.service";
 
 const CSV_COLUMNS = [
     {label: 'Name', path: 'name'},
@@ -77,8 +79,12 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
         override csvDownloadService: CsvDownloadService,
         private growlerService: GrowlerService,
         private dialogForm: MatDialog,
+        @Inject(EDGE_ROUTER_EXTENSION_SERVICE) private extService: ExtensionService
     ) {
         super(settings, filterService, csvDownloadService);
+        if (this.extService.listActions) {
+            this.menuItems = [...this.menuItems, ...this.extService.listActions];
+        }
     }
 
     validate = (formData): Promise<CallbackResults> => {
@@ -256,6 +262,12 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
             row.actionList = ['update', 'delete'];
             if (this.hasEnrolmentToken(row)) {
                 row.actionList.push('download-enrollment');
+            }
+            if (this.extService.listActions) {
+                const keys = this.extService.listActions.map((action) => {
+                    return action.action;
+                });
+                row.actionList = [...row.actionList, ...keys];
             }
             return row;
         });


### PR DESCRIPTION
* refactored header component "requestActions()" functions to emit generic actions to support extension service actions
* added No-Op functions for forms that don't require additional "More Actions" items

<img width="1715" alt="Screen Shot 2024-04-25 at 10 51 07 AM" src="https://github.com/openziti/ziti-console/assets/102923745/5233eb78-3f5e-45df-8d1e-d07d59c4d46d">
