### PR TITLE
add container image for the spa build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,90 @@
+name: Push SPA Image to Docker Hub
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: 
+      # Publish semver tags as releases.
+      - 'app-ziti-console-v*.*.*'
+
+env:
+  REGISTRY_LOGIN_PUSH: docker.io
+  REGISTRY_ATTEST: index.docker.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ vars.ZITI_CONSOLE_IMAGE_NAME || 'openziti/ziti-console-assets' }}
+  # oldest, supported, compatible LTS (even numbered Node versions); defines the source image version used to build the
+  # ziti-console container image
+  NODE_VERSION: 20
+
+jobs:
+  docker-build-push:
+    name: Push SPA Image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Login against a Docker registry
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY_LOGIN_PUSH }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_LOGIN_PUSH }}
+          username: ${{ vars.DOCKER_HUB_API_USER || secrets.DOCKER_HUB_API_USER }}
+          password: ${{ secrets.DOCKER_HUB_API_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Define Docker Tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_LOGIN_PUSH }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # set "main" tag on revisions that are accepted into the default branch
+            type=raw,value=${{ github.ref_name }},enable={{is_default_branch}}
+            # set "latest" tag on releases
+            type=raw,value=latest,enable=${{startsWith(github.ref, 'refs/tags/app-ziti-console-v')}}
+            # set (e.g., "1.2.3") semver tag on releases
+            type=match,pattern=app-ziti-console-v(.*),group=1,enable=${{startsWith(github.ref, 'refs/tags/app-ziti-console-v')}}
+            # set (e.g., "v1") major version tag on releases
+            type=match,pattern=app-ziti-console-(v\d+)\..*,group=1,enable=${{startsWith(github.ref, 'refs/tags/app-ziti-console-v')}}
+
+      - name: Set Up Docker BuildKit
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build and push Docker image with Buildx
+      # https://github.com/docker/build-push-action
+      - name: Build and Push Docker Image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker-images/ziti-console-assets/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          build-args: |
+            NODE_VERSION=${{ env.NODE_VERSION }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY_ATTEST }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: build
+name: Test Build for All Platforms
 
 on:
   pull_request:
@@ -14,8 +14,8 @@ concurrency:
 env: {}
 
 jobs:
-  build:
-    name: Build Project for All Platforms
+  build-spa-zac:
+    name: Test Build SPA ZAC for All Platforms
     # allow fors to opt-out of time-consuming macOS builds
     runs-on: ubuntu-latest
     steps:
@@ -37,6 +37,36 @@ jobs:
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: ${{ github.workspace }}/
+          file: ./docker-images/ziti-console-assets/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-node-zac:
+    name: Test Build Node ZAC for All Platforms
+    # allow fors to opt-out of time-consuming macOS builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set Up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64,arm64
+
+      - name: Set Up Docker BuildKit
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Multi-Platform Container Image to exercise amd64, arm64 builds
+        uses: docker/build-push-action@v5
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ${{ github.workspace }}/
+          file: ./docker-images/zac/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: false
           cache-from: type=gha

--- a/.github/workflows/push-zac-container.yml
+++ b/.github/workflows/push-zac-container.yml
@@ -1,4 +1,4 @@
-name: Deploy Quickstart Container
+name: Deploy Node ZAC Container
 
 on:
   workflow_dispatch:
@@ -13,7 +13,9 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_HUB_API_USER }}
+          username: ${{ vars.DOCKER_HUB_API_USER || secrets.DOCKER_HUB_API_USER }}
           password: ${{ secrets.DOCKER_HUB_API_TOKEN }}
       - name: Push to Docker
+        env:
+          ZAC_IMAGE_REPO: ${{ vars.ZAC_IMAGE_REPO || 'openziti/zac' }}
         run: ./pushLatestDocker.sh

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://npm.pkg.github.com/
       - name: build and upload ziti-console.zip as SPA for use with controller
         env:
@@ -33,15 +33,20 @@ jobs:
       BUILD_CONFIG: "Release"
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://npm.pkg.github.com/
+
       - name: Set VERSION Environment Variable
         run: echo "VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
+
       - name: Set VERSION Environment Variable
         run: |
           VERSION=$(echo "${{ github.event.release.name }}" | grep -oP '^.*-v(.*)$')
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
       - name: Build and Publish Shared Library - ziti-console-lib
+        if: github.repository_owner == 'openziti'
         run: ./publishSharedLib.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+
+# CHANGELOG
+
+## v3.2.0
+
+### What's New?
+
+- Add a container image to ship the single-page application (SPA) build of the console: `openziti/ziti-console:3.2.0` (also `:v3` and `:latest`). The tag scheme follows the Git version of each release. See [the deployment guide](https://openziti.io/docs/guides/deployments/docker/console) for more information.

--- a/docker-images/zac/Dockerfile
+++ b/docker-images/zac/Dockerfile
@@ -9,7 +9,6 @@ RUN npm install --omit=optional
 
 COPY . .
 RUN ng build ziti-console-lib
-RUN ng build ziti-console
 RUN ng build ziti-console-node
 
 

--- a/docker-images/zac/README.md
+++ b/docker-images/zac/README.md
@@ -1,0 +1,10 @@
+
+# build the openziti/zac image
+
+This is the deprecated Node.js-based Ziti Administration Console (ZAC) image. It provides a standalone web server for the console web UI.
+
+In the project root:
+
+```bash
+docker build -f ./docker-images/zac/Dockerfile .
+```

--- a/docker-images/ziti-console-assets/Dockerfile
+++ b/docker-images/ziti-console-assets/Dockerfile
@@ -1,0 +1,26 @@
+# this Dockerfile builds openziti/ziti-console-assets
+
+ARG NODE_VERSION=20
+FROM node:${NODE_VERSION}-bookworm-slim as builder
+
+ARG BASE_HREF=/zac/
+ARG DEPLOY_URL=${BASE_HREF}
+
+WORKDIR /usr/src/app
+
+RUN npm install -g @angular/cli@16.0.0-next.0
+
+COPY package*.json ./
+RUN npm install --omit=optional
+
+COPY . .
+RUN ng build ziti-console-lib
+RUN ng build ziti-console --base-href ${BASE_HREF} --deploy-url ${DEPLOY_URL}
+
+ARG NODE_VERSION=${NODE_VERSION}
+FROM node:${NODE_VERSION}-bookworm-slim
+WORKDIR /usr/src/app
+
+COPY --from=builder /usr/src/app/dist/app-ziti-console ./dist/app-ziti-console
+
+CMD echo "deployment guide https://openziti.io/docs/guides/deployments/docker/console"

--- a/docker-images/ziti-console-assets/README.md
+++ b/docker-images/ziti-console-assets/README.md
@@ -1,0 +1,27 @@
+
+# openziti/ziti-console-assets
+
+## Overview
+
+This image is only for embedding the console in the controller container image. It doesn't do anything by itself.
+
+## Deploy
+
+[Link to console deployment guide](https://openziti.io/docs/guides/deployments/docker/console) shows how enable the console in the controller image.
+
+## Build
+
+In the project root, build the image with the `BASE_HREF` build argument set to the path where the console will be served (default: `/zac/` is hard-coded in `ziti controller`).
+
+In this Dockerfile, the default value of `DEPLOY_URL` is set to the value of `BASE_HREF`. These correspond to [Angular `ng build` options](https://angular.io/cli/build).
+
+```bash
+docker build \
+    --tag ziti-console-assets \
+    --file ./docker-images/ziti-console-assets/Dockerfile \
+    --build-arg BASE_HREF=/zac/ \
+    --build-arg DEPLOY_URL=/zac/ \
+    "${PWD}"
+```
+
+Refer to [the `openziti/ziti-controller` image](https://github.com/openziti/ziti/blob/release-next/dist/docker-images/ziti-controller/Dockerfile) to see how this image is used to build a controller image.

--- a/pushLatestDocker.sh
+++ b/pushLatestDocker.sh
@@ -1,3 +1,11 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+: "${ZAC_IMAGE_REPO:="openziti/zac"}"
 ZAC_VERSION=$(jq -r .version package.json)
 
 if [ -z "${ZAC_VERSION}" ]; then
@@ -5,10 +13,11 @@ if [ -z "${ZAC_VERSION}" ]; then
   exit 1
 fi
 
-echo "Building ZAC version ${ZAC_VERSION} for amd64/arm64"
+echo "Building node ZAC version ${ZAC_VERSION} for amd64/arm64"
 
 docker buildx create --use --name=zac
 docker buildx build --platform linux/amd64,linux/arm64 . \
-  --tag "openziti/zac:${ZAC_VERSION}" \
-  --tag "openziti/zac:latest" \
+  --tag "${ZAC_IMAGE_REPO}:${ZAC_VERSION}" \
+  --tag "${ZAC_IMAGE_REPO}:latest" \
+  --file docker-images/zac/Dockerfile \
   --push


### PR DESCRIPTION
This container image is in a transitional state now that the node integration is deprecated in favor of the SPA deployment model. 

This does not change how the node integration behaves in Docker or Kubernetes. Only the SPA build's base URL is updated with this change. This allows the existing SPA build to be used wherever this image is deployed, most notably by the ziti-controller image, e.g. https://github.com/openziti/ziti/blob/605fe4e5c36c7c898894a4a524603897b81e04e8/dist/docker-images/ziti-controller/Dockerfile#L5. 

This image will be refactored once more when the node integration is decommissioned to remove the node integration, preserving only the SPA build.