### PR TITLE
Enable "Re-enroll" edge router feature in ZAC

### DIFF
--- a/projects/app-ziti-console/src/app/examples/extension-service/example-extension.service.ts
+++ b/projects/app-ziti-console/src/app/examples/extension-service/example-extension.service.ts
@@ -48,4 +48,12 @@ export class ExampleExtensionService implements ExtensionService {
     executeListAction() {
         alert('Example action executed from list page menu items');
     }
+
+    processTableColumns(tableColumns: any): any[] {
+        // This function will execute when a list page is initiated.
+        // Use this function to make adjustments to the column definitions of the data table (ie. show/hide, defined custom renderers etc..)
+        // Uncomment the alert below to see when this function is called
+        // alert('ExampleExtensionService "processTableColumns()" function executed');
+        return tableColumns;
+    }
 }

--- a/projects/ziti-console-lib/src/lib/features/confirm/confirm.component.html
+++ b/projects/ziti-console-lib/src/lib/features/confirm/confirm.component.html
@@ -10,7 +10,7 @@
                 <div class="confirm-modal-icon"></div>
                 <div>
                     <div class="confirm-message-content">
-                        <span>{{dataObj.message}}</span>
+                        <span [innerHTML]="dataObj.message"></span>
                     </div>
                     <div class="confirm-message-bullet-list">
                         <ul>

--- a/projects/ziti-console-lib/src/lib/features/data-table/data-table.component.html
+++ b/projects/ziti-console-lib/src/lib/features/data-table/data-table.component.html
@@ -52,10 +52,9 @@
             #contextMenu
     >
         <div
-
                 *ngFor="let menuItem of menuItems"
                 (click)="actionRequested.emit({ action: menuItem.action, item: selectedItem })"
-                [ngClass]="{'menu-item-hidden': !selectedItem.actionList.includes(menuItem.action)}"
+                [ngClass]="{'menu-item-hidden': !selectedItem.actionList.includes(menuItem.action) || (menuItem.isHidden && menuItem.isHidden(selectedItem))}"
                 class="tActionRow"
                 id="TableActionButton_{{menuItem.action}}"
         >

--- a/projects/ziti-console-lib/src/lib/features/extendable/extensions-noop.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/extendable/extensions-noop.service.ts
@@ -29,6 +29,7 @@ export interface ExtensionService {
   updateFormData(data: any): void;
   validateData(): Promise<any>;
   formDataSaved(data: any): Promise<any>;
+  processTableColumns(tableColumns: any): any[];
 }
 
 @Injectable({
@@ -57,4 +58,7 @@ export class ExtensionsNoopService implements ExtensionService {
     return Promise.resolve(true);
   }
 
+  processTableColumns(tableColumns: any): any[] {
+    return tableColumns;
+  }
 }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.html
@@ -90,17 +90,17 @@
                 </div>
             </div>
             <div class="form-group-column two-fifths">
+                <ng-content select="[slot=column-2-slot-1]"></ng-content>
                 <lib-form-field-container
-                        *ngIf="hasEnrolmentToken"
+                        *ngIf="hasEnrolmentToken && !extService['hideZitiRegistration']"
                         [showHeader]="false"
                 >
-                    <ng-content select="[slot=column-2-slot-1]"></ng-content>
                     <lib-qr-code
-                            *ngIf="!extService['hideZitiRegistration']"
                             [identity]="formData"
-                            [jwt]="formData.jwt"
+                            [jwt]="formData.enrollmentJwt"
                             [token]="formData.enrollmentToken"
                             [expiration]="formData.enrollmentExpiresAt"
+                            (doRefresh)="refreshEdgeRouter()"
                             [type]="'router'"
                     ></lib-qr-code>
                 </lib-form-field-container>

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.ts
@@ -14,7 +14,7 @@ import {Subscription} from 'rxjs';
 import {ProjectableForm} from "../projectable-form.class";
 import {SETTINGS_SERVICE, SettingsService} from "../../../services/settings.service";
 
-import {isEmpty, delay, cloneDeep, isEqual} from 'lodash';
+import {isEmpty, delay, cloneDeep, isEqual, set} from 'lodash';
 import {ZITI_DATA_SERVICE, ZitiDataService} from "../../../services/ziti-data.service";
 import {GrowlerService} from "../../messaging/growler.service";
 import {EDGE_ROUTER_EXTENSION_SERVICE, EdgeRouterFormService} from './edge-router-form.service';
@@ -161,6 +161,14 @@ export class EdgeRouterFormComponent extends ProjectableForm implements OnInit, 
       data.enrollment = this.formData.enrollment || {ott: true};
     }
     return data;
+  }
+
+  refreshEdgeRouter() {
+    this.svc.refreshRouter(this.formData.id).then(result => {
+      this.formData = result.data;
+      this.initData = cloneDeep(this.formData);
+      this.extService.updateFormData(this.formData);
+    })
   }
 
   _apiData = {};

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.service.ts
@@ -131,4 +131,9 @@ export class EdgeRouterFormService {
             });
         });
     }
+
+    refreshRouter(id) {
+        const url: any = `/edge-routers/${id}`
+        return this.zitiService.call(url);
+    }
 }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
@@ -122,6 +122,7 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
       this.initData = cloneDeep(this.formData);
       this.enrollmentExpiration = this.identitiesService.getEnrollmentExpiration(this.formData);
       this.jwt = this.identitiesService.getJWT(this.formData);
+      this.extService.updateFormData(this.formData);
     })
   }
 

--- a/projects/ziti-console-lib/src/lib/features/qr-code/qr-code.component.html
+++ b/projects/ziti-console-lib/src/lib/features/qr-code/qr-code.component.html
@@ -1,7 +1,7 @@
 <div class="qr-code-container" [ngClass]="{'modal-view': isModal}">
     <div *ngIf="!qrOnly" class="qr-code-buttons">
-        <span class="info-text" *ngIf="!jwtExpired && type !== 'router'">TO REGISTER THIS IDENTITY</span>
-        <span class="info-text" *ngIf="!jwtExpired && type === 'router'">TO REGISTER THIS ROUTER</span>
+        <span class="info-text" *ngIf="hasJWT && !jwtExpired && type !== 'router'">TO REGISTER THIS IDENTITY</span>
+        <span class="info-text" *ngIf="hasJWT && !jwtExpired && type === 'router'">TO REGISTER THIS ROUTER</span>
         <div (click)="identitiesSvc.downloadJWT(jwt, identity.name)" *ngIf="hasJWT && !jwtExpired && type !== 'router'" class="download-button">
             <div class="download-key"></div>
             <div>DOWNLOAD ENROLLMENT JWT</div>
@@ -22,7 +22,7 @@
             <div>REISSUE ENROLLMENT</div>
             <div class="tap-to-download"></div>
         </div>
-        <span class="info-text" *ngIf="!jwtExpired && type !== 'router'">OR SCAN QR CODE</span>
+        <span class="info-text" *ngIf="hasJWT && !jwtExpired && type !== 'router'">OR SCAN QR CODE</span>
     </div>
     <qrcode
             *ngIf="!jwtExpired && type !== 'router'"
@@ -38,5 +38,10 @@
             <div class="tap-to-download"></div>
         </div>
         <span class="info-text" *ngIf="!showResetToken">{{jwtExpired ? 'REGISTRATION EXPIRED' : 'EXPIRES'}} {{expirationDate}}</span>
+        <div (click)="reenroll()" *ngIf="showReenrollToken" class="download-button" >
+            <div class="download-key"></div>
+            <div>REISSUE ENROLLMENT</div>
+            <div class="tap-to-download"></div>
+        </div>
     </div>
 </div>

--- a/projects/ziti-console-lib/src/lib/features/qr-code/qr-code.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/qr-code/qr-code.component.ts
@@ -20,6 +20,7 @@ import {isEmpty} from 'lodash';
 import {MAT_DIALOG_DATA, MatDialog, MatDialogRef} from "@angular/material/dialog";
 import {IdentitiesPageService} from "../../pages/identities/identities-page.service";
 import {DialogRef} from "@angular/cdk/dialog";
+import {EdgeRoutersPageService} from "../../pages/edge-routers/edge-routers-page.service";
 
 @Component({
   selector: 'lib-qr-code',
@@ -48,6 +49,7 @@ export class QrCodeComponent implements OnChanges {
       @Optional() private dialogForm: MatDialog,
       @Optional() @Inject(MAT_DIALOG_DATA) public data: any,
       public identitiesSvc: IdentitiesPageService,
+      public edgeRoutersSvc: EdgeRoutersPageService,
   )
   {
     if (!isEmpty(data)) {
@@ -75,6 +77,10 @@ export class QrCodeComponent implements OnChanges {
     return (this.identity?.enrollment?.ott?.id || this.identity?.enrollment?.updb?.id) && moment(this.expiration).isBefore();
   }
 
+  get showReenrollToken() {
+    return this.jwtExpired && this.type === 'router';
+  }
+
   getJwtExpired() {
     return moment(this.expiration).isBefore();
   }
@@ -89,6 +95,12 @@ export class QrCodeComponent implements OnChanges {
         if (result) {
           this.doRefresh.emit(true);
         }
+    });
+  }
+
+  reenroll() {
+    this.edgeRoutersSvc.reenroll(this.identity).then(() => {
+      this.doRefresh.emit(true);
     });
   }
 

--- a/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.html
@@ -27,8 +27,8 @@
         (close)="closeModal($event)"
         (dataChange)="dataChanged($event)"
     >
-        <ng-content select="[slot=provider]" slot="provider"></ng-content>
-        <ng-content select="[slot=registration]" slot="registration"></ng-content>
+        <ng-content select="[slot=column-1-slot-1]" slot="column-1-slot-1"></ng-content>
+        <ng-content select="[slot=column-2-slot-1]" slot="column-2-slot-1"></ng-content>
     </lib-edge-router-form>
 </lib-side-modal>
 <lib-loading-indicator *ngIf="isLoading" [isLoading]="isLoading"></lib-loading-indicator>

--- a/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.ts
@@ -5,7 +5,7 @@ import {DataTableFilterService} from "../../features/data-table/data-table-filte
 import {ListPageComponent} from "../../shared/list-page-component.class";
 import {TabNameService} from "../../services/tab-name.service";
 
-import {invoke, isEmpty, defer, unset, cloneDeep} from 'lodash';
+import {invoke, isEmpty, defer, unset, cloneDeep, result} from 'lodash';
 import moment from 'moment';
 import $ from 'jquery';
 import {ConfirmComponent} from "../../features/confirm/confirm.component";
@@ -112,6 +112,11 @@ export class EdgeRoutersPageComponent extends ListPageComponent implements OnIni
         break;
       case 'download-selected':
         this.svc.downloadItems(this.selectedItems);
+        break;
+      case 're-enroll':
+        this.svc.reenroll(event.item).then((result) => {
+          this.refreshData(this.svc.currentSort);
+        });
         break;
       default:
         if (this.extService.listActions) {

--- a/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.ts
@@ -90,6 +90,18 @@ export class EdgeRoutersPageComponent extends ListPageComponent implements OnIni
   }
 
   tableAction(event: any) {
+    if (this.extService?.listActions?.length > 0) {
+      let extensionFound = false;
+      this.extService?.listActions?.forEach((extAction) => {
+        if (extAction?.action === event?.action) {
+          extAction.callback(event.item);
+          extensionFound = true;
+        }
+      });
+      if (extensionFound) {
+        return;
+      }
+    }
     switch(event?.action) {
       case 'toggleAll':
       case 'toggleItem':
@@ -119,13 +131,6 @@ export class EdgeRoutersPageComponent extends ListPageComponent implements OnIni
         });
         break;
       default:
-        if (this.extService.listActions) {
-          this.extService.listActions.forEach((action) => {
-            if (action.action === event.action) {
-              action.callback(event.item);
-            }
-          })
-        }
         break;
     }
   }

--- a/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.service.ts
@@ -21,6 +21,7 @@ import {MatDialog} from "@angular/material/dialog";
 import {SettingsServiceClass} from "../../services/settings-service.class";
 import {EDGE_ROUTER_EXTENSION_SERVICE} from "../../features/projectable-forms/edge-router/edge-router-form.service";
 import {ExtensionService} from "../../features/extendable/extensions-noop.service";
+import {ConfirmComponent} from "../../features/confirm/confirm.component";
 
 const CSV_COLUMNS = [
     {label: 'Name', path: 'name'},
@@ -328,14 +329,32 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
     }
 
     reenroll(router: any) {
-        return this.zitiService.post(`edge-routers/${router.id}/re-enroll`, {}, true).then((result) => {
-            const growlerData = new GrowlerModel(
-                'success',
-                'Success',
-                `Re-enroll Confirmed`,
-                `Router re-enroll was sent. A new enrollment token is now available`,
-            );
-            this.growlerService.show(growlerData);
+        const data = {
+            appendId: 'ReenrollRouter',
+            title: 'Re-Enroll Router',
+            message: `If the router is currently connected, it will be disconnected until the enrollment process is completed with the newly generated JWT. <p> Are you sure you want to re-enroll the selected router?`,
+            confirmLabel: 'Yes',
+            cancelLabel: 'Oops, no get me out of here',
+            showCancelLink: true
+        };
+        this.dialogRef = this.dialogForm.open(ConfirmComponent, {
+            data: data,
+            autoFocus: false,
+        });
+        return this.dialogRef.afterClosed().toPromise().then((result) => {
+            if (result) {
+                return this.zitiService.post(`edge-routers/${router.id}/re-enroll`, {}, true).then((result) => {
+                    const growlerData = new GrowlerModel(
+                        'success',
+                        'Success',
+                        `Re-enroll Confirmed`,
+                        `Router re-enroll was sent. A new enrollment token is now available`,
+                    );
+                    this.growlerService.show(growlerData);
+                });
+            } else {
+                return Promise.resolve();
+            }
         });
     }
 

--- a/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.service.ts
@@ -59,9 +59,8 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
     override menuItems = [
         {name: 'Edit', action: 'update'},
         {name: 'Download JWT', action: 'download-enrollment'},
-        {name: 'View QR', action: 'qr-code'},
         {name: 'Reset Enrollment', action: 'reset-enrollment'},
-        {name: 'Override', action: 'override'},
+        {name: 'Re-enroll', action: 're-enroll'},
         {name: 'Delete', action: 'delete'},
     ]
 
@@ -83,7 +82,18 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
     ) {
         super(settings, filterService, csvDownloadService);
         if (this.extService.listActions) {
-            this.menuItems = [...this.menuItems, ...this.extService.listActions];
+            let filteredActions = [];
+            this.menuItems = this.menuItems.map((item) => {
+                filteredActions = this.extService.listActions.filter((extItem) => {
+                    if (item.action === extItem.action) {
+                        item = extItem;
+                        return false;
+                    }
+                    return true;
+                });
+                return item;
+            });
+            this.menuItems = [...this.menuItems, ...filteredActions];
         }
     }
 
@@ -259,7 +269,7 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
 
     private addActionsPerRow(results: any): any[] {
         return results.data.map((row) => {
-            row.actionList = ['update', 'delete'];
+            row.actionList = ['update', 're-enroll', 'delete'];
             if (this.hasEnrolmentToken(row)) {
                 row.actionList.push('download-enrollment');
             }
@@ -315,6 +325,18 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
             undefined,
             false
         );
+    }
+
+    reenroll(router: any) {
+        return this.zitiService.post(`edge-routers/${router.id}/re-enroll`, {}, true).then((result) => {
+            const growlerData = new GrowlerModel(
+                'success',
+                'Success',
+                `Re-enroll Confirmed`,
+                `Router re-enroll was sent. A new enrollment token is now available`,
+            );
+            this.growlerService.show(growlerData);
+        });
     }
 
     public openUpdate(item?: any) {

--- a/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.service.ts
@@ -61,7 +61,7 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
         {name: 'Edit', action: 'update'},
         {name: 'Download JWT', action: 'download-enrollment'},
         {name: 'Reset Enrollment', action: 'reset-enrollment'},
-        {name: 'Re-enroll', action: 're-enroll'},
+        {name: 'Re-Enroll', action: 're-enroll'},
         {name: 'Delete', action: 'delete'},
     ]
 
@@ -83,16 +83,18 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
     ) {
         super(settings, filterService, csvDownloadService);
         if (this.extService.listActions) {
-            let filteredActions = [];
             this.menuItems = this.menuItems.map((item) => {
-                filteredActions = this.extService.listActions.filter((extItem) => {
+                this.extService.listActions.forEach((extItem) => {
                     if (item.action === extItem.action) {
                         item = extItem;
-                        return false;
                     }
-                    return true;
                 });
                 return item;
+            });
+            let filteredActions = this.extService.listActions.filter((extItem) => {
+                return !this.menuItems.some((item) => {
+                    return item.action === extItem.action;
+                });
             });
             this.menuItems = [...this.menuItems, ...filteredActions];
         }
@@ -157,7 +159,7 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
             columnFilters,
         };
 
-        return [
+        let tableColumns = [
             {
                 colId: 'name',
                 field: 'name',
@@ -250,6 +252,12 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
                 cellClass: 'nf-cell-vert-align tCol',
             }
         ];
+
+        if (this.extService.processTableColumns) {
+            tableColumns = this.extService.processTableColumns(tableColumns);
+        }
+
+        return tableColumns;
     }
 
     getData(filters?: FilterObj[], sort?: any): Promise<any> {
@@ -332,7 +340,7 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
         const data = {
             appendId: 'ReenrollRouter',
             title: 'Re-Enroll Router',
-            message: `If the router is currently connected, it will be disconnected until the enrollment process is completed with the newly generated JWT. <p> Are you sure you want to re-enroll the selected router?`,
+            message: `<p>If the router is currently connected, it will be disconnected until the enrollment process is completed with the newly generated JWT. <p> Are you sure you want to re-enroll the selected router?`,
             confirmLabel: 'Yes',
             cancelLabel: 'Oops, no get me out of here',
             showCancelLink: true


### PR DESCRIPTION
* Added "Re-enroll" menu item on routers list page
* Added button to re-enroll on router edit form (if registration is expired)
* Added refresh events to be triggered when router updates are made
* 
<img width="990" alt="Screen Shot 2024-05-09 at 10 34 39 AM" src="https://github.com/openziti/ziti-console/assets/102923745/0da44f0d-2a5a-4ece-9205-8e4a307e01d3">
<img width="365" alt="Screen Shot 2024-05-09 at 10 34 53 AM" src="https://github.com/openziti/ziti-console/assets/102923745/c6dd2438-a959-4a83-a413-9e6467b8b1f8">

