### PR TITLE
show the identity service path visualizer menu for all identities.

### DIFF
--- a/projects/ziti-console-lib/src/lib/pages/identities/identities-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/identities/identities-page.service.ts
@@ -32,7 +32,6 @@ import {ITooltipAngularComp} from "ag-grid-angular";
 import {ITooltipParams} from "ag-grid-community";
 import {OSTooltipComponent} from "../../features/data-table/tooltips/os-tooltip.component";
 import {SDKTooltipComponent} from "../../features/data-table/tooltips/sdk-tooltip.component";
-import {IdentityServicePathComponent} from "../../features/visualizer/identity-service-path/identity-service-path.component";
 import {GrowlerModel} from "../../features/messaging/growler.model";
 import {GrowlerService} from "../../features/messaging/growler.service";
 import {ResetEnrollmentComponent} from "../../features/reset-enrollment/reset-enrollment.component";
@@ -320,15 +319,10 @@ export class IdentitiesPageService extends ListPageServiceClass {
 
     private addActionsPerRow(results: any): any[] {
         return results.data.map((row) => {
-            row.actionList = ['update', 'override', 'delete'];
-
-            if (row.typeId && row.typeId === 'Device' || row.typeId === 'Default' ) {
-              row.actionList.push('identity-service-path');
-            }
+            row.actionList = ['update', 'override', 'delete', 'identity-service-path'];
 
             if (this.hasEnrolmentToken(row)) {
                 row.actionList.push('reissue-enrollment');
-                row.actionList.push('identity-service-path');
                 if (!this.enrollmentExpired(row)) {
                     row.actionList.push('download-enrollment');
                     row.actionList.push('qr-code');


### PR DESCRIPTION
I have removed the code that restricted display/access to the Visualizer menu based on identity typeId.