### PR TITLE
Fix selection of attributes using the multiselect widget

### DIFF
--- a/projects/ziti-console-lib/src/lib/assets/scripts/components/multiselect.js
+++ b/projects/ziti-console-lib/src/lib/assets/scripts/components/multiselect.js
@@ -205,7 +205,6 @@ var MultiSelect = function(id, max=10, freeform=false) {
         id = app.validate(id);
         name = app.validate(name);
         type = app.validate(type);
-        selected = app.validate(selected);
         if (name.charAt(0)=="@") type = "at";
         else if (name.charAt(0)=="#") type = "hash";
         if (type=="at" && id.charAt(0)!='@') id = "@"+id;


### PR DESCRIPTION
* Removed validation on the "selected" field/parameter when drawing the item html, as this is always a boolean value and not user input

closes #378 
