### PR TITLE
Enable the opening of the identity create/edit forms via deep linking

### DIFF
--- a/projects/app-ziti-console/src/app/app-routing.module.ts
+++ b/projects/app-ziti-console/src/app/app-routing.module.ts
@@ -27,7 +27,8 @@ import {
   ServicesPageComponent,
   ServicePoliciesPageComponent,
   NetworkVisualizerComponent,
-  EdgeRouterPoliciesPageComponent
+  EdgeRouterPoliciesPageComponent,
+  IdentityFormComponent
 } from "ziti-console-lib";
 import {environment} from "./environments/environment";
 import {URLS} from "./app-urls.constants";
@@ -63,6 +64,13 @@ const routes: Routes = [
   {
     path: 'identities',
     component: IdentitiesPageComponent,
+    canActivate: mapToCanActivate([AuthenticationGuard]),
+    canDeactivate: [DeactivateGuardService],
+    runGuardsAndResolvers: 'always',
+  },
+  {
+    path: 'identities/:id',
+    component: IdentityFormComponent,
     canActivate: mapToCanActivate([AuthenticationGuard]),
     canDeactivate: [DeactivateGuardService],
     runGuardsAndResolvers: 'always',

--- a/projects/ziti-console-lib/src/lib/features/card-list/card-list.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/card-list/card-list.component.ts
@@ -20,11 +20,11 @@ export class CardListComponent extends ProjectableForm {
   constructor(
       @Inject(SETTINGS_SERVICE) public settingsService: SettingsService,
       public svc: ServiceFormService,
-      @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
+      @Inject(ZITI_DATA_SERVICE) override zitiService: ZitiDataService,
       growlerService: GrowlerService,
       @Inject(SERVICE_EXTENSION_SERVICE) extService: ExtensionService
   ) {
-    super(growlerService, extService);
+    super(growlerService, extService, zitiService);
   }
   clear(): void {
   }

--- a/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-name/table-cell-name.component.html
+++ b/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-name/table-cell-name.component.html
@@ -1,0 +1,11 @@
+<span class="cell-name-container">
+    <a href="./{{cellParams.pathRoot}}/{{item.id}}" (click)="linkClicked($event)">
+        <div class="col cell-name-renderer" data-id="{{item.id}}">
+            <div *ngIf="cellParams.showStatusIcons" class="cell-status-container">
+                <span class="circle {{item.hasApiSession}}" title="Api Session"></span>
+                <span class="circle {{item.hasEdgeRouterConnection}}" title="Edge Router Connected"></span>
+            </div>
+            <strong>{{item.name}}</strong>
+        </div>
+    </a>
+</span>

--- a/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-name/table-cell-name.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-name/table-cell-name.component.scss
@@ -1,0 +1,19 @@
+.cell-name-renderer {
+  display: flex;
+  flex-direction: row;
+  gap: 5px;
+}
+
+.cell-name-container {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+}
+
+.cell-status-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}

--- a/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-name/table-cell-name.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-name/table-cell-name.component.ts
@@ -1,0 +1,37 @@
+import { Component } from '@angular/core';
+import {ICellRendererAngularComp} from "ag-grid-angular";
+import {MatDialog} from "@angular/material/dialog";
+import {ICellRendererParams} from "ag-grid-community";
+import {Router} from "@angular/router";
+
+@Component({
+  selector: 'lib-table-cell-name',
+  templateUrl: './table-cell-name.component.html',
+  styleUrls: ['./table-cell-name.component.scss']
+})
+export class TableCellNameComponent  implements ICellRendererAngularComp {
+
+  cellParams: any;
+  item: any;
+  dialogRef: any;
+
+  constructor(public dialogForm: MatDialog, private router: Router) {
+  }
+
+  agInit(params: ICellRendererParams): void {
+    this.cellParams = params;
+    this.item = params.data;
+  }
+
+  refresh(params: ICellRendererParams<any>): boolean {
+    this.cellParams = params;
+    this.item = params.data;
+    return true;
+  }
+
+  linkClicked(event) {
+    this.router.navigateByUrl(`${this.cellParams.pathRoot}/${this.item.id}`);
+    event.stopPropagation();
+    event.preventDefault();
+  }
+}

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.ts
@@ -33,6 +33,7 @@ import {ConfigEditorComponent} from "../../config-editor/config-editor.component
 import {cloneDeep, defer, isEmpty} from 'lodash';
 import {GrowlerModel} from "../../messaging/growler.model";
 import {SETTINGS_SERVICE, SettingsService} from "../../../services/settings.service";
+import {ZITI_DATA_SERVICE, ZitiDataService} from "../../../services/ziti-data.service";
 
 @Component({
     selector: 'lib-configuration',
@@ -45,14 +46,12 @@ export class ConfigurationFormComponent extends ProjectableForm implements OnIni
     @Input() override errors: any = {};
     @Output() close: EventEmitter<void> = new EventEmitter<void>();
 
-    isLoading = false;
     options: any[] = [];
     isEditing = !isEmpty(this.formData.id);
     formView = 'simple';
     formDataInvalid = false;
     editMode = false;
     items: any = [];
-    subscription = new Subscription();
     selectedSchema: any = '';
     associatedServices = [];
     associatedServiceNames = [];
@@ -67,11 +66,13 @@ export class ConfigurationFormComponent extends ProjectableForm implements OnIni
         growlerService: GrowlerService,
         @Inject(SHAREDZ_EXTENSION) extService: ExtensionService,
         @Inject(SETTINGS_SERVICE) public settingsService: SettingsService,
+        @Inject(ZITI_DATA_SERVICE) override zitiService: ZitiDataService,
     ) {
-        super(growlerService, extService);
+        super(growlerService, extService, zitiService);
     }
 
-    ngOnInit(): void {
+    override ngOnInit(): void {
+        super.ngOnInit();
         this.settingsService.settingsChange.subscribe((results:any) => {
             this.settings = results;
         });

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.component.ts
@@ -51,26 +51,25 @@ export class EdgeRouterPolicyFormComponent extends ProjectableForm implements On
 
   formView = 'simple';
   isEditing = false;
-  isLoading = false;
   edgeRoutersLoading = false;
   identitiesLoading = false;
   postureChecksLoading = false;
 
   showMore = false;
   settings: any = {};
-  subscription: Subscription = new Subscription();
 
   constructor(
       @Inject(SETTINGS_SERVICE) public settingsService: SettingsService,
       public svc: EdgeRouterPolicyFormService,
-      @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
+      @Inject(ZITI_DATA_SERVICE) override zitiService: ZitiDataService,
       growlerService: GrowlerService,
       @Inject(EDGE_ROUTER_POLICY_EXTENSION_SERVICE) extService: ExtensionService
   ) {
-    super(growlerService, extService);
+    super(growlerService, extService, zitiService);
   }
 
-  ngOnInit(): void {
+  override ngOnInit(): void {
+    super.ngOnInit();
     this.subscription.add(
         this.settingsService.settingsChange.subscribe((results:any) => {
           this.settings = results;

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.ts
@@ -39,7 +39,6 @@ export class EdgeRouterFormComponent extends ProjectableForm implements OnInit, 
 
   formView = 'simple';
   isEditing = false;
-  isLoading = false;
   servicesLoading = false;
   identitiesLoading = false;
   authPolicies: any = [
@@ -48,19 +47,19 @@ export class EdgeRouterFormComponent extends ProjectableForm implements OnInit, 
 
   showMore = false;
   settings: any = {};
-  subscription: Subscription = new Subscription();
 
   constructor(
       @Inject(SETTINGS_SERVICE) public settingsService: SettingsService,
       public svc: EdgeRouterFormService,
-      @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
+      @Inject(ZITI_DATA_SERVICE) override zitiService: ZitiDataService,
       growlerService: GrowlerService,
       @Inject(EDGE_ROUTER_EXTENSION_SERVICE) extService: ExtensionService
   ) {
-    super(growlerService, extService);
+    super(growlerService, extService, zitiService);
   }
 
-  ngOnInit(): void {
+  override ngOnInit(): void {
+    super.ngOnInit();
     this.subscription.add(
       this.settingsService.settingsChange.subscribe((results:any) => {
         this.settings = results;

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.component.ts
@@ -56,26 +56,25 @@ export class ServicePolicyFormComponent extends ProjectableForm implements OnIni
 
   formView = 'simple';
   isEditing = false;
-  isLoading = false;
   servicesLoading = false;
   identitiesLoading = false;
   postureChecksLoading = false;
 
   showMore = false;
   settings: any = {};
-  subscription: Subscription = new Subscription();
 
   constructor(
       @Inject(SETTINGS_SERVICE) public settingsService: SettingsService,
       public svc: ServicePolicyFormService,
-      @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
+      @Inject(ZITI_DATA_SERVICE) override zitiService: ZitiDataService,
       growlerService: GrowlerService,
       @Inject(SERVICE_POLICY_EXTENSION_SERVICE) extService: ExtensionService
   ) {
-    super(growlerService, extService);
+    super(growlerService, extService, zitiService);
   }
 
-  ngOnInit(): void {
+  override ngOnInit(): void {
+    super.ngOnInit();
     this.subscription.add(
         this.settingsService.settingsChange.subscribe((results:any) => {
           this.settings = results;
@@ -257,7 +256,12 @@ export class ServicePolicyFormComponent extends ProjectableForm implements OnIni
     const pcRoles = this.svc.getSelectedRoles(this.selectedPostureRoleAttributes, this.selectedPostureNamedAttributes, this.postureNamedAttributesMap);
     const pcRolesVar = this.getRolesCURLVariable(pcRoles);
 
-    const command = `curl '${this.apiCallURL}' \\ ${this.formData.id ? '--request PATCH \\' : '\\'} -H 'accept: application/json' \\ -H 'content-type: application/json' \\ -H 'zt-session: ${this.settings.session.id}' \\ --data-raw '{"name":"${this.formData.name}","serviceRoles":${serviceRolesVar},"identityRoles":${identityRolesVar},"postureCheckRoles":${pcRolesVar},"semantic":"${this.formData.semantic}","type":"${this.formData.type}"}'`;
+    const command = `curl '${this.apiCallURL}' \\
+    ${this.formData.id ? '--request PATCH \\' : '\\'}
+    -H 'accept: application/json' \\
+    -H 'content-type: application/json' \\
+    -H 'zt-session: ${this.settings.session.id}' \\
+    --data-raw '{"name":"${this.formData.name}","serviceRoles":${serviceRolesVar},"identityRoles":${identityRolesVar},"postureCheckRoles":${pcRolesVar},"semantic":"${this.formData.semantic}","type":"${this.formData.type}"}'`;
 
     navigator.clipboard.writeText(command);
     const growlerData = new GrowlerModel(

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
@@ -72,7 +72,6 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
   enrollmentExpiration: any;
   jwt: any;
   token: any;
-  isLoading = false;
   strategies = [
     {id: 'smartrouting', label: 'Smart Routing'},
     {id: 'weighted', label: 'Weighted'},
@@ -93,20 +92,20 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
   formView = 'simple';
   formDataInvalid = false;
   settings: any = {};
-  subscription: Subscription = new Subscription();
 
   @ViewChild("configEditor", {read: ConfigEditorComponent}) configEditor!: ConfigEditorComponent;
   constructor(
       @Inject(SETTINGS_SERVICE) public settingsService: SettingsService,
       public svc: ServiceFormService,
-      @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
+      @Inject(ZITI_DATA_SERVICE) override zitiService: ZitiDataService,
       growlerService: GrowlerService,
       @Inject(SERVICE_EXTENSION_SERVICE) extService: ExtensionService
   ) {
-    super(growlerService, extService);
+    super(growlerService, extService, zitiService);
   }
 
-  ngOnInit(): void {
+  override ngOnInit(): void {
+    super.ngOnInit();
     this.subscription.add(
       this.settingsService.settingsChange.subscribe((results:any) => {
         this.settings = results;

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
@@ -116,17 +116,18 @@ export class SimpleServiceComponent extends ProjectableForm {
   constructor(
       @Inject(SETTINGS_SERVICE) public settingsService: SettingsService,
       public svc: ServiceFormService,
-      @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
+      @Inject(ZITI_DATA_SERVICE) override zitiService: ZitiDataService,
       growlerService: GrowlerService,
       @Inject(SERVICE_EXTENSION_SERVICE) extService: ExtensionService,
       private dialogForm: MatDialog,
       private validationService: ValidationService,
-      private servicesPageService: ServicesPageService
+      private servicesPageService: ServicesPageService,
   ) {
-    super(growlerService, extService);
+    super(growlerService, extService, zitiService);
   }
 
-  ngOnInit() {
+  override ngOnInit() {
+    super.ngOnInit();
     this.controllerDomain = this.settingsService?.settings?.selectedEdgeController;
     this.zitiSessionId = this.settingsService?.settings?.session?.id;
     this.initFormData();

--- a/projects/ziti-console-lib/src/lib/pages/identities/identities-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/identities/identities-page.component.html
@@ -25,7 +25,8 @@
 <lib-side-modal [(open)]="svc.sideModalOpen" [showClose]="false">
     <lib-identity-form
         *ngIf="svc.modalType === 'identity' && svc.sideModalOpen"
-        [formData]="svc.selectedIdentity"
+        [isModal]="true"
+        [entityId]="svc.selectedEntityId"
         [identityRoleAttributes]="identityRoleAttributes"
         (close)="closeModal($event)"
         (dataChange)="dataChanged($event)"

--- a/projects/ziti-console-lib/src/lib/pages/identities/identities-page.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/identities/identities-page.component.ts
@@ -15,7 +15,7 @@
 */
 
 import {Component, Inject, OnInit, OnDestroy} from '@angular/core';
-import {Router, NavigationEnd} from '@angular/router'
+import {Router, NavigationEnd, ActivatedRoute} from '@angular/router'
 import {IdentitiesPageService} from "./identities-page.service";
 import {DataTableFilterService} from "../../features/data-table/data-table-filter.service";
 import {ListPageComponent} from "../../shared/list-page-component.class";
@@ -50,7 +50,7 @@ export class IdentitiesPageComponent extends ListPageComponent implements OnInit
       @Inject(ZAC_WRAPPER_SERVICE)private zacWrapperService: ZacWrapperServiceClass,
       private router: Router,
       consoleEvents: ConsoleEventsService,
-      @Inject(IDENTITY_EXTENSION_SERVICE) private extService: ExtensionService
+      @Inject(IDENTITY_EXTENSION_SERVICE) private extService: ExtensionService,
   ) {
     super(filterService, svc, consoleEvents, dialogForm);
   }
@@ -78,7 +78,7 @@ export class IdentitiesPageComponent extends ListPageComponent implements OnInit
   headerActionClicked(action: string) {
     switch(action) {
       case 'add':
-        this.svc.openUpdate();
+        this.svc.openEditForm();
         break;
       case 'edit':
         this.svc.openUpdate();
@@ -125,10 +125,10 @@ export class IdentitiesPageComponent extends ListPageComponent implements OnInit
         this.itemToggled(event.item)
         break;
       case 'update':
-        this.svc.openUpdate(event.item);
+        this.svc.openEditForm(event?.item?.id);
         break;
       case 'create':
-        this.svc.openUpdate();
+        this.svc.openEditForm();
         break;
       case 'override':
         this.svc.openOverridesModal(event.item);

--- a/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
+++ b/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
@@ -116,9 +116,16 @@ input {
   display: flex;
   flex-direction: column;
   align-items: center;
+  position: absolute;
+  top: 0px;
+  left: 0;
   height: 100%;
   width: 100%;
   min-width: 675px;
+  padding-top: 14px;
+  padding-left: 20px;
+  padding-right: 20px;
+  background-color: var(--formBackground);
   overflow: hidden;
 
   .projectable-form-container {
@@ -587,7 +594,7 @@ lib-form-field-container {
 }
 
 .cdk-overlay-container {
-  z-index: 999999 !important;
+  z-index: 99999999 !important;
 }
 
 .zac-wrapper-container .dots {

--- a/projects/ziti-console-lib/src/lib/shared/list-page-component.class.ts
+++ b/projects/ziti-console-lib/src/lib/shared/list-page-component.class.ts
@@ -22,7 +22,8 @@ import {ConsoleEventsService} from "../services/console-events.service";
 import {ConfirmComponent} from "../features/confirm/confirm.component";
 import {MatDialog} from "@angular/material/dialog";
 
-import {defer} from "lodash";
+import {defer, isEmpty} from "lodash";
+import {ActivatedRoute} from "@angular/router";
 
 @Injectable()
 export abstract class ListPageComponent {
@@ -52,7 +53,7 @@ export abstract class ListPageComponent {
         protected filterService: DataTableFilterService,
         public svc: ListPageServiceClass,
         protected consoleEvents: ConsoleEventsService,
-        protected dialogForm: MatDialog,
+        protected dialogForm: MatDialog
     ) {}
 
     ngOnInit() {

--- a/projects/ziti-console-lib/src/lib/shared/list-page-service.class.ts
+++ b/projects/ziti-console-lib/src/lib/shared/list-page-service.class.ts
@@ -28,12 +28,14 @@ import {CsvDownloadService} from "../services/csv-download.service";
 import {SettingsServiceClass} from "../services/settings-service.class";
 import {ExtensionService, SHAREDZ_EXTENSION} from "../features/extendable/extensions-noop.service";
 import moment from "moment/moment";
+import {Router} from "@angular/router";
 
 export abstract class ListPageServiceClass {
 
     abstract initTableColumns(): any[];
-    abstract getData(filters?: FilterObj[], sort?: any, page?: any): Promise<any[]>
+    abstract getData(filters?: FilterObj[], sort?: any, page?: any): Promise<any[]>;
     abstract validate: ValidatorCallback;
+    abstract openUpdate(entity?: any);
     abstract resourceType: string;
 
     headerComponentParams = {
@@ -54,6 +56,7 @@ export abstract class ListPageServiceClass {
     dataService: ZitiDataService;
     refreshData: (sort?: {sortBy: string, ordering: string}) => void | undefined;
 
+    selectedEntityId: String;
     menuItems: any = [];
     tableHeaderActions: any = [];
     currentSettings: any = {};
@@ -101,7 +104,8 @@ export abstract class ListPageServiceClass {
         @Inject(SETTINGS_SERVICE) protected settings: SettingsServiceClass,
         protected filterService: DataTableFilterService,
         protected csvDownloadService: CsvDownloadService,
-        @Inject(SHAREDZ_EXTENSION) protected extensionService: ExtensionService
+        @Inject(SHAREDZ_EXTENSION) protected extensionService: ExtensionService,
+        protected router?: Router
     ) {
         this.dataService = inject(ZITI_DATA_SERVICE);
         this.settings.settingsChange.subscribe((settings) => {
@@ -177,5 +181,12 @@ export abstract class ListPageServiceClass {
             text = window.getSelection().toString();
         }
         return text?.length > 0;
+    }
+
+    public openEditForm(itemId = '') {
+        if (isEmpty(itemId)) {
+            itemId = 'create';
+        }
+        this.router?.navigateByUrl(`/${this.resourceType}/${itemId}`)
     }
 }

--- a/projects/ziti-console-lib/src/lib/ziti-console-lib.module.ts
+++ b/projects/ziti-console-lib/src/lib/ziti-console-lib.module.ts
@@ -103,6 +103,7 @@ import { ServicePoliciesPageComponent } from './pages/service-policies/service-p
 import { ServicePolicyFormComponent } from './features/projectable-forms/service-policy/service-policy-form.component';
 import { EdgeRouterPolicyFormComponent } from './features/projectable-forms/edge-router-policy/edge-router-policy-form.component';
 import { MultiActionButtonComponent } from './features/multi-action-button/multi-action-button.component';
+import { TableCellNameComponent } from './features/data-table/cells/table-cell-name/table-cell-name.component';
 
 export function playerFactory() {
     return import(/* webpackChunkName: 'lottie-web' */ 'lottie-web');
@@ -176,7 +177,8 @@ export function playerFactory() {
         ServicePolicyFormComponent,
         EdgeRouterPoliciesPageComponent,
         EdgeRouterPolicyFormComponent,
-        MultiActionButtonComponent
+        MultiActionButtonComponent,
+        TableCellNameComponent
     ],
     imports: [
         CommonModule,

--- a/server-edge.js
+++ b/server-edge.js
@@ -52,6 +52,7 @@ app.use(helmet(helmetOptions));
 
 app.use('/', express.static('dist/app-ziti-console'));
 app.use('/:name', express.static('dist/app-ziti-console'));
+app.use('/:name/:id', express.static('dist/app-ziti-console'));
 
 let maxAttempts = 100;
 StartServer(port);


### PR DESCRIPTION
Angular support the opening of various pages/screens via "deep routes" or "deep linking, so that a specific entity can be loaded via an ID included in the URL path.

This will allow users to go to the url `/identities/some-ziti-id`, and open the identity edit page with the details of a specific identity already loaded on the page.

Also wrapped the "name" cell render with an anchor tag to allow the "open in new tab" behavior via browser context menu.

![new-tab](https://github.com/user-attachments/assets/7948de80-fae6-4b08-9d67-e62545e3e3dd)

