### PR TITLE
Enable the opening of the edge router create/edit forms via deep linking

### DIFF
--- a/projects/app-ziti-console/src/app/app-routing.module.ts
+++ b/projects/app-ziti-console/src/app/app-routing.module.ts
@@ -28,7 +28,8 @@ import {
   ServicePoliciesPageComponent,
   NetworkVisualizerComponent,
   EdgeRouterPoliciesPageComponent,
-  IdentityFormComponent
+  IdentityFormComponent,
+  EdgeRouterFormComponent
 } from "ziti-console-lib";
 import {environment} from "./environments/environment";
 import {URLS} from "./app-urls.constants";
@@ -91,6 +92,13 @@ const routes: Routes = [
     path: 'routers',
     component: EdgeRoutersPageComponent,
     canActivate: mapToCanActivate([AuthenticationGuard]),
+    runGuardsAndResolvers: 'always',
+  },
+  {
+    path: 'routers/:id',
+    component: EdgeRouterFormComponent,
+    canActivate: mapToCanActivate([AuthenticationGuard]),
+    canDeactivate: [DeactivateGuardService],
     runGuardsAndResolvers: 'always',
   },
   {

--- a/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-name/table-cell-name.component.html
+++ b/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-name/table-cell-name.component.html
@@ -1,9 +1,13 @@
 <span class="cell-name-container">
-    <a href="./{{cellParams.pathRoot}}/{{item.id}}" (click)="linkClicked($event)">
+    <a href="./{{cellParams.pathRoot}}{{item.id}}" (click)="linkClicked($event)">
         <div class="col cell-name-renderer" data-id="{{item.id}}">
-            <div *ngIf="cellParams.showStatusIcons" class="cell-status-container">
+            <div *ngIf="cellParams.showIdentityIcons" class="cell-status-container">
                 <span class="circle {{item.hasApiSession}}" title="Api Session"></span>
                 <span class="circle {{item.hasEdgeRouterConnection}}" title="Edge Router Connected"></span>
+            </div>
+            <div *ngIf="cellParams.showRouterIcons" class="cell-status-container">
+                <span class="circle {{item.isVerified}}" title="Api Session"></span>
+                <span class="circle {{item.isOnline}}" title="Edge Router Connected"></span>
             </div>
             <strong>{{item.name}}</strong>
         </div>

--- a/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-name/table-cell-name.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-name/table-cell-name.component.ts
@@ -30,7 +30,7 @@ export class TableCellNameComponent  implements ICellRendererAngularComp {
   }
 
   linkClicked(event) {
-    this.router.navigateByUrl(`${this.cellParams.pathRoot}/${this.item.id}`);
+    this.router.navigateByUrl(`${this.cellParams.pathRoot}${this.item.id}`);
     event.stopPropagation();
     event.preventDefault();
   }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
@@ -28,7 +28,7 @@ import {
     ViewChild
 } from "@angular/core";
 
-import {defer, isEqual, unset, debounce, cloneDeep, isEmpty} from "lodash";
+import {defer, isEqual, unset, debounce, cloneDeep, isEmpty, slice} from "lodash";
 import {GrowlerModel} from "../messaging/growler.model";
 import {GrowlerService} from "../messaging/growler.service";
 import {ExtensionService, SHAREDZ_EXTENSION} from "../extendable/extensions-noop.service";
@@ -219,7 +219,8 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
     }
 
     returnToListPage() {
-        this.router?.navigateByUrl(`/${this.entityType}`);
+        const baseUrl = this.getBaseURLPath();
+        this.router?.navigateByUrl(`${baseUrl}`);
     }
 
     ngDoCheck() {
@@ -284,5 +285,18 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
         return this.zitiService.get(type, {}, []).then((results) => {
             return results.data;
         });
+    }
+
+    public getBaseURLPath() {
+        let path = '';
+        const urlSegments = window.location.pathname.split('/');
+        const baseSegments: string[] = slice(urlSegments, 0, urlSegments.length - 1);
+        baseSegments.forEach(segment => {
+            if (isEmpty(segment)) {
+                return;
+            }
+            path += `/${segment}`;
+        });
+        return path;
     }
 }

--- a/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.ts
@@ -61,7 +61,7 @@ export class EdgeRoutersPageComponent extends ListPageComponent implements OnIni
   headerActionClicked(action: string) {
     switch(action) {
       case 'add':
-        this.svc.openUpdate();
+        this.svc.openEditForm();
         break;
       case 'edit':
         this.svc.openUpdate();
@@ -108,10 +108,10 @@ export class EdgeRoutersPageComponent extends ListPageComponent implements OnIni
         this.itemToggled(event.item)
         break;
       case 'update':
-        this.svc.openUpdate(event.item);
+        this.svc.openEditForm(event?.item?.id);
         break;
       case 'create':
-        this.svc.openUpdate();
+        this.svc.openEditForm();
         break;
       case 'delete':
         this.deleteItem(event.item)

--- a/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.service.ts
@@ -22,6 +22,8 @@ import {SettingsServiceClass} from "../../services/settings-service.class";
 import {EDGE_ROUTER_EXTENSION_SERVICE} from "../../features/projectable-forms/edge-router/edge-router-form.service";
 import {ExtensionService} from "../../features/extendable/extensions-noop.service";
 import {ConfirmComponent} from "../../features/confirm/confirm.component";
+import {Router} from "@angular/router";
+import {TableCellNameComponent} from "../../features/data-table/cells/table-cell-name/table-cell-name.component";
 
 const CSV_COLUMNS = [
     {label: 'Name', path: 'name'},
@@ -79,9 +81,10 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
         override csvDownloadService: CsvDownloadService,
         private growlerService: GrowlerService,
         private dialogForm: MatDialog,
-        @Inject(EDGE_ROUTER_EXTENSION_SERVICE) private extService: ExtensionService
+        @Inject(EDGE_ROUTER_EXTENSION_SERVICE) private extService: ExtensionService,
+        protected override router: Router
     ) {
-        super(settings, filterService, csvDownloadService, extService);
+        super(settings, filterService, csvDownloadService, extService, router);
     }
 
     validate = (formData): Promise<CallbackResults> => {
@@ -96,7 +99,7 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
                 <span class="circle ${row?.data?.isVerified}" title="Verified Status"></span>
                 <span class="circle ${row?.data?.isOnline}" title="Online Status"></span>
                 <strong>${row?.data?.name}</strong>
-              </div>`
+              </div>`;
         }
 
         const rolesRenderer = (row) => {
@@ -161,14 +164,15 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
                 headerName: 'Name',
                 headerComponent: TableColumnDefaultComponent,
                 headerComponentParams: this.headerComponentParams,
+                cellRenderer: TableCellNameComponent,
+                cellRendererParams: { pathRoot: this.getBaseURLPath(), showRouterIcons: true },
                 onCellClicked: (data) => {
                     if (this.hasSelectedText()) {
                         return;
                     }
-                    this.openUpdate(data.data);
+                    this.openEditForm(data?.data?.id);
                 },
                 resizable: true,
-                cellRenderer: nameRenderer,
                 cellClass: 'nf-cell-vert-align tCol',
                 sortable: true,
                 filter: true,
@@ -197,7 +201,7 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
                     if (this.hasSelectedText()) {
                         return;
                     }
-                    this.openUpdate(data.data);
+                    this.openEditForm(data?.data?.id);
                 },
                 resizable: true,
                 cellRenderer: this.rolesRenderer,

--- a/projects/ziti-console-lib/src/lib/pages/identities/identities-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/identities/identities-page.service.ts
@@ -184,7 +184,7 @@ export class IdentitiesPageService extends ListPageServiceClass {
                 headerComponent: TableColumnDefaultComponent,
                 headerComponentParams: this.headerComponentParams,
                 cellRenderer: TableCellNameComponent,
-                cellRendererParams: { pathRoot: 'identities', showStatusIcons: true },
+                cellRendererParams: { pathRoot: this.getBaseURLPath(), showIdentityIcons: true },
                 onCellClicked: (data) => {
                     if (this.hasSelectedText()) {
                         return;

--- a/projects/ziti-console-lib/src/lib/shared/list-page-service.class.ts
+++ b/projects/ziti-console-lib/src/lib/shared/list-page-service.class.ts
@@ -187,6 +187,18 @@ export abstract class ListPageServiceClass {
         if (isEmpty(itemId)) {
             itemId = 'create';
         }
-        this.router?.navigateByUrl(`/${this.resourceType}/${itemId}`)
+        const baseUrl = this.getBaseURLPath();
+        this.router?.navigateByUrl(`${baseUrl}${itemId}`);
+    }
+
+    public getBaseURLPath() {
+        let path = '';
+        window.location.pathname.split('/').forEach(segment => {
+            if (isEmpty(segment)) {
+                return;
+            }
+            path += `${segment}/`;
+        });
+        return path;
     }
 }


### PR DESCRIPTION
Angular supports the opening of various pages/screens via "deep routes" or "deep linking", so that a specific entity can be loaded via an ID included in the URL path.

This will allow users to go to the url /identities/some-ziti-id, and open the identity edit page with the details of a specific identity already loaded on the page.

Also wrapped the "name" cell render with an anchor tag to allow the "open in new tab" behavior via browser context menu.