### PR TITLE
Enable the opening of the services create/edit forms via deep linking

### DIFF
--- a/projects/app-ziti-console/src/app/app-routing.module.ts
+++ b/projects/app-ziti-console/src/app/app-routing.module.ts
@@ -29,7 +29,10 @@ import {
   NetworkVisualizerComponent,
   EdgeRouterPoliciesPageComponent,
   IdentityFormComponent,
-  EdgeRouterFormComponent
+  EdgeRouterFormComponent,
+  CardListComponent,
+  ServiceFormComponent,
+  SimpleServiceComponent
 } from "ziti-console-lib";
 import {environment} from "./environments/environment";
 import {URLS} from "./app-urls.constants";
@@ -85,6 +88,29 @@ const routes: Routes = [
   {
     path: 'services',
     component: ServicesPageComponent,
+    canActivate: mapToCanActivate([AuthenticationGuard]),
+    runGuardsAndResolvers: 'always',
+  },
+  {
+    path: 'services/simple',
+    component: SimpleServiceComponent,
+    canActivate: mapToCanActivate([AuthenticationGuard]),
+    runGuardsAndResolvers: 'always',
+  },
+  {
+    path: 'services/select',
+    component: CardListComponent,
+    canActivate: mapToCanActivate([AuthenticationGuard]),
+    runGuardsAndResolvers: 'always',
+  },
+  {
+    path: 'services/advanced',
+    redirectTo: 'services/advanced/create',
+    pathMatch: 'full'
+  },
+  {
+    path: 'services/advanced/:id',
+    component: ServiceFormComponent,
     canActivate: mapToCanActivate([AuthenticationGuard]),
     runGuardsAndResolvers: 'always',
   },

--- a/projects/ziti-console-lib/src/lib/features/card-list/card-list.component.html
+++ b/projects/ziti-console-lib/src/lib/features/card-list/card-list.component.html
@@ -1,4 +1,4 @@
-<div class="card-list-wrapper fullModal opened">
+<div class="card-list-wrapper ziti-page-container fullModal opened">
     <div class="title" style="filter: brightness(50%)">Create a service</div>
     <div class="subtitle">Choose a service type</div>
     <div class="card-list-container">
@@ -9,17 +9,19 @@
             [content]="'Simple services required fewer details, only asking for the most commonly used fields.'"
             [buttonText]="'Create Simple Service'"
             [id]="'SimpleServiceCard'"
+            [href]="'services/simple'"
         ></lib-card>
         <lib-card
-                (click)="cardSelected('advanced')"
-                [imageUrl]="'/assets/svgs/Advanced.svg'"
-                [title]="'Advanced'"
-                [content]="'Advanced services allow you to configure any option supported by the controller but are subsequently a bit more complex.'"
-                [buttonText]="'Create Advanced Service'"
-                [id]="'AdvancedServiceCard'"
+            (click)="cardSelected('advanced')"
+            [imageUrl]="'/assets/svgs/Advanced.svg'"
+            [title]="'Advanced'"
+            [content]="'Advanced services allow you to configure any option supported by the controller but are subsequently a bit more complex.'"
+            [buttonText]="'Create Advanced Service'"
+            [id]="'AdvancedServiceCard'"
+            [href]="'services/advanced'"
         ></lib-card>
     </div>
-    <div (click)="closeModal()" class="buttonBall close" id="EscZitiAWClose">
+    <div (click)="returnToListPage()" class="buttonBall close" id="EscZitiAWClose">
         <div class="buttonLabel">ESC</div>
     </div>
 

--- a/projects/ziti-console-lib/src/lib/features/card-list/card-list.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/card-list/card-list.component.ts
@@ -5,6 +5,7 @@ import {SERVICE_EXTENSION_SERVICE, ServiceFormService} from "../projectable-form
 import {ZITI_DATA_SERVICE, ZitiDataService} from "../../services/ziti-data.service";
 import {GrowlerService} from "../messaging/growler.service";
 import {ExtensionService} from "../extendable/extensions-noop.service";
+import {ActivatedRoute, Router} from "@angular/router";
 
 @Component({
   selector: 'lib-card-list',
@@ -22,9 +23,11 @@ export class CardListComponent extends ProjectableForm {
       public svc: ServiceFormService,
       @Inject(ZITI_DATA_SERVICE) override zitiService: ZitiDataService,
       growlerService: GrowlerService,
-      @Inject(SERVICE_EXTENSION_SERVICE) extService: ExtensionService
+      @Inject(SERVICE_EXTENSION_SERVICE) extService: ExtensionService,
+      protected override router: Router,
+      protected override route: ActivatedRoute,
   ) {
-    super(growlerService, extService, zitiService);
+    super(growlerService, extService, zitiService, router, route);
   }
   clear(): void {
   }
@@ -33,6 +36,6 @@ export class CardListComponent extends ProjectableForm {
   }
 
   cardSelected(type) {
-    this.selected.emit(type)
+    this.router.navigateByUrl(`/services/${type}`);
   }
 }

--- a/projects/ziti-console-lib/src/lib/features/card/card.component.html
+++ b/projects/ziti-console-lib/src/lib/features/card/card.component.html
@@ -1,12 +1,14 @@
-<div class="service-card-container">
-    <div class="buttonCard selectType" [id]="id">
-        <div style="background-image: url({{imageUrl}})" class="icon"></div>
-        <div class="title">{{title}}</div>
-        <div class="content">
-            {{ content }}
-        </div>
-        <div class="row center buttonArea">
-            <button class="save">{{buttonText}}</button>
+<a href="/{{href}}" (click)="linkClicked($event)">
+    <div class="service-card-container">
+        <div class="buttonCard selectType" [id]="id">
+            <div style="background-image: url({{imageUrl}})" class="icon"></div>
+            <div class="title">{{title}}</div>
+            <div class="content">
+                {{ content }}
+            </div>
+            <div class="row center buttonArea">
+                <button class="save">{{buttonText}}</button>
+            </div>
         </div>
     </div>
-</div>
+</a>

--- a/projects/ziti-console-lib/src/lib/features/card/card.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/card/card.component.ts
@@ -12,4 +12,9 @@ export class CardComponent {
   @Input() content = '';
   @Input() buttonText = '';
   @Input() id = '';
+  @Input() href = '';
+
+  linkClicked(event) {
+    event.preventDefault();
+  }
 }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.html
@@ -1,6 +1,6 @@
 <div class="projectable-form-wrapper"
      (keyup.enter)="save($event)"
-     (keyup.escape)="closeModal(false)"
+     (keyup.escape)="returnToListPage()"
      tabindex="0"
 >
     <lib-form-header

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
@@ -46,7 +46,7 @@ export class ServiceFormService {
         total: 100
     }
 
-    formData: any;
+    formData: any = {};
     configData: any;
     selectedConfigId: any = '';
     configs: any = [];

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
@@ -11,6 +11,7 @@ import {CreationSummaryDialogComponent} from "../../../creation-summary-dialog/c
 import {isEmpty, isNil, isNaN, unset, cloneDeep, isEqual} from 'lodash';
 import {ValidationService} from '../../../../services/validation.service';
 import {ServicesPageService} from "../../../../pages/services/services-page.service";
+import {ActivatedRoute, Router} from "@angular/router";
 
 // @ts-ignore
 const {app} = window;
@@ -122,8 +123,10 @@ export class SimpleServiceComponent extends ProjectableForm {
       private dialogForm: MatDialog,
       private validationService: ValidationService,
       private servicesPageService: ServicesPageService,
+      protected override router: Router,
+      protected override route: ActivatedRoute,
   ) {
-    super(growlerService, extService, zitiService);
+    super(growlerService, extService, zitiService, router, route);
   }
 
   override ngOnInit() {
@@ -189,7 +192,7 @@ export class SimpleServiceComponent extends ProjectableForm {
         this.save();
         break;
       case 'close':
-        this.closeModal(true, true, 'cards')
+        this.router?.navigateByUrl(`/services/select`);
         break;
       case 'toggle-view':
         this.formView = action.data;

--- a/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.html
@@ -19,16 +19,4 @@
     >
     </lib-data-table>
 </div>
-<lib-side-modal [(open)]="svc.sideModalOpen" [showClose]="false">
-    <lib-edge-router-form
-        *ngIf="svc.modalType === 'edge-router' && svc.sideModalOpen"
-        [formData]="svc.selectedEdgeRouter"
-        [edgeRouterRoleAttributes]="edgeRouterRoleAttributes"
-        (close)="closeModal($event)"
-        (dataChange)="dataChanged($event)"
-    >
-        <ng-content select="[slot=column-1-slot-1]" slot="column-1-slot-1"></ng-content>
-        <ng-content select="[slot=column-2-slot-1]" slot="column-2-slot-1"></ng-content>
-    </lib-edge-router-form>
-</lib-side-modal>
 <lib-loading-indicator *ngIf="isLoading" [isLoading]="isLoading"></lib-loading-indicator>

--- a/projects/ziti-console-lib/src/lib/pages/identities/identities-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/identities/identities-page.component.html
@@ -23,14 +23,6 @@
     </lib-data-table>
 </div>
 <lib-side-modal [(open)]="svc.sideModalOpen" [showClose]="false">
-    <lib-identity-form
-        *ngIf="svc.modalType === 'identity' && svc.sideModalOpen"
-        [isModal]="true"
-        [entityId]="svc.selectedEntityId"
-        [identityRoleAttributes]="identityRoleAttributes"
-        (close)="closeModal($event)"
-        (dataChange)="dataChanged($event)"
-    ></lib-identity-form>
     <lib-overrides
             *ngIf="svc.modalType === 'overrides' && svc.sideModalOpen"
             [identity]="svc.selectedIdentity"

--- a/projects/ziti-console-lib/src/lib/pages/services/services-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/services/services-page.component.html
@@ -19,25 +19,4 @@
     >
     </lib-data-table>
 </div>
-<lib-side-modal [(open)]="svc.sideModalOpen" [showClose]="false">
-    <lib-card-list
-        *ngIf="showCardList"
-        (close)="closeModal($event)"
-        (selected)="serviceTypeSelected($event)"
-    ></lib-card-list>
-    <lib-service-form
-            *ngIf="svc.sideModalOpen && svc.serviceType === 'advanced'"
-            [formData]="svc.selectedService"
-            [serviceRoleAttributes]="serviceRoleAttributes"
-            (close)="closeModal($event)"
-            (dataChange)="dataChanged($event)"
-    ></lib-service-form>
-    <lib-simple-service
-            *ngIf="svc.sideModalOpen && svc.serviceType === 'simple'"
-            (close)="closeModal($event)"
-            (dataChange)="dataChanged($event)"
-            [serviceRoleAttributes]="serviceRoleAttributes"
-            [identityRoleAttributes]="identityRoleAttributes"
-    ></lib-simple-service>
-</lib-side-modal>
 <lib-loading-indicator *ngIf="isLoading" [isLoading]="isLoading"></lib-loading-indicator>

--- a/projects/ziti-console-lib/src/lib/pages/services/services-page.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/services/services-page.component.ts
@@ -61,11 +61,10 @@ export class ServicesPageComponent extends ListPageComponent implements OnInit, 
   headerActionClicked(action: string) {
     switch(action) {
       case 'add':
-        this.svc.serviceType = '';
-        this.svc.openUpdate();
+        this.svc.openSelection();
         break;
       case 'edit':
-        this.svc.openUpdate();
+        this.svc.openAdvanced();
         break;
       case 'delete':
         const selectedItems = this.rowData.filter((row) => {
@@ -82,14 +81,13 @@ export class ServicesPageComponent extends ListPageComponent implements OnInit, 
     switch(event?.action) {
       case 'toggleAll':
       case 'toggleItem':
-        this.itemToggled(event.item)
+        this.itemToggled(event.item);
         break;
       case 'update':
-        this.svc.serviceType = 'advanced';
-        this.svc.openUpdate(event.item);
+        this.svc.openAdvanced(event.item.id);
         break;
       case 'create':
-        this.svc.openUpdate();
+        this.svc.openSelection();
         break;
       case 'delete':
         this.deleteItem(event.item)

--- a/projects/ziti-console-lib/src/lib/pages/services/services-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/services/services-page.service.ts
@@ -33,6 +33,8 @@ import {GrowlerService} from "../../features/messaging/growler.service";
 import {MatDialog} from "@angular/material/dialog";
 import {SettingsServiceClass} from "../../services/settings-service.class";
 import {ExtensionService, SHAREDZ_EXTENSION} from "../../features/extendable/extensions-noop.service";
+import {Router} from "@angular/router";
+import {TableCellNameComponent} from "../../features/data-table/cells/table-cell-name/table-cell-name.component";
 
 const CSV_COLUMNS = [
     {label: 'Name', path: 'name'},
@@ -73,7 +75,8 @@ export class ServicesPageService extends ListPageServiceClass {
         override csvDownloadService: CsvDownloadService,
         private growlerService: GrowlerService,
         private dialogForm: MatDialog,
-        @Inject(SHAREDZ_EXTENSION) private extService: ExtensionService
+        @Inject(SHAREDZ_EXTENSION) private extService: ExtensionService,
+        protected override router: Router
     ) {
         super(settings, filterService, csvDownloadService, extService);
     }
@@ -98,15 +101,16 @@ export class ServicesPageService extends ListPageServiceClass {
                 headerName: 'Name',
                 headerComponent: TableColumnDefaultComponent,
                 headerComponentParams: this.headerComponentParams,
+                cellRenderer: TableCellNameComponent,
+                cellRendererParams: { pathRoot: 'services/advanced/' },
                 onCellClicked: (data) => {
                     if (this.hasSelectedText()) {
                         return;
                     }
                     this.serviceType = 'advanced';
-                    this.openUpdate(data.data);
+                    this.openAdvanced(data.data.id);
                 },
                 resizable: true,
-                cellRenderer: this.nameColumnRenderer,
                 cellClass: 'nf-cell-vert-align tCol',
                 sortable: true,
                 filter: true,
@@ -124,7 +128,7 @@ export class ServicesPageService extends ListPageServiceClass {
                         return;
                     }
                     this.serviceType = '';
-                    this.openUpdate(data.data);
+                    this.openAdvanced(data.data.id);
                 },
                 resizable: true,
                 cellRenderer: this.rolesRenderer,
@@ -147,7 +151,7 @@ export class ServicesPageService extends ListPageServiceClass {
                         return;
                     }
                     this.serviceType = '';
-                    this.openUpdate(data.data);
+                    this.openAdvanced(data.data.id);
                 },
             }
         ];
@@ -216,6 +220,14 @@ export class ServicesPageService extends ListPageServiceClass {
             undefined,
             false
         );
+    }
+
+    public openSelection() {
+        this.router.navigateByUrl('/services/select');
+    }
+
+    public openAdvanced(id = '') {
+        this.router.navigateByUrl(`/services/advanced/${id}`);
     }
 
     public openUpdate(item?: any) {

--- a/projects/ziti-console-lib/src/lib/shared/list-page-service.class.ts
+++ b/projects/ziti-console-lib/src/lib/shared/list-page-service.class.ts
@@ -183,11 +183,11 @@ export abstract class ListPageServiceClass {
         return text?.length > 0;
     }
 
-    public openEditForm(itemId = '') {
+    public openEditForm(itemId = '', baseUrl?) {
         if (isEmpty(itemId)) {
             itemId = 'create';
         }
-        const baseUrl = this.getBaseURLPath();
+        baseUrl = baseUrl ? baseUrl : this.getBaseURLPath();
         this.router?.navigateByUrl(`${baseUrl}${itemId}`);
     }
 

--- a/projects/ziti-console-lib/src/public-api.ts
+++ b/projects/ziti-console-lib/src/public-api.ts
@@ -31,6 +31,7 @@ export * from './lib/services/deactivate-guard.service';
 export * from './lib/services/csv-download.service';
 export * from './lib/features/projectable-forms/configuration/configuration-form.component';
 export * from './lib/features/extendable/extendable.component';
+export * from './lib/features/card-list/card-list.component';
 export * from './lib/features/sidebars/side-toolbar/side-toolbar.component';
 export * from './lib/features/sidebars/side-navbar/side-navbar.component';
 export * from './lib/features/sidebars/side-banner/side-banner.component';
@@ -57,6 +58,7 @@ export * from './lib/features/projectable-forms/edge-router/edge-router-form.com
 export * from './lib/features/projectable-forms/edge-router/edge-router-form.service';
 export * from './lib/features/projectable-forms/service/service-form.component';
 export * from './lib/features/projectable-forms/service/service-form.service';
+export * from './lib/features/projectable-forms/service/simple-service/simple-service.component';
 export * from './lib/features/projectable-forms/service-policy/service-policy-form.service';
 export * from './lib/features/projectable-forms/service-policy/service-policy-form.component';
 export * from './lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.service';

--- a/server-edge.js
+++ b/server-edge.js
@@ -53,6 +53,7 @@ app.use(helmet(helmetOptions));
 app.use('/', express.static('dist/app-ziti-console'));
 app.use('/:name', express.static('dist/app-ziti-console'));
 app.use('/:name/:id', express.static('dist/app-ziti-console'));
+app.use('/:name/:type/:id', express.static('dist/app-ziti-console'));
 
 let maxAttempts = 100;
 StartServer(port);


### PR DESCRIPTION
Angular supports the opening of various pages/screens via "deep routes" or "deep linking", so that a specific entity can be loaded via an ID included in the URL path.

This will allow users to go to the url `/services/some-ziti-id`, and open the services edit page with the details of a specific identity already loaded on the page.

Also wrapped the "name" cell render, and the service type cards with an anchor tag to allow the "open in new tab" behavior via browser context menu.