### PR TITLE
adding .trim to get rid of excessive whitespaces on form names - closes #424

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.component.ts
@@ -151,7 +151,7 @@ export class EdgeRouterPolicyFormComponent extends ProjectableForm implements On
   }
 
   async save(event?) {
-    this.formData.name.trim();
+    this.formData.name = this.formData.name.trim();
     const isValid = this.validate();
     const isExtValid = await this.extService.validateData();
     if(!isValid || !isExtValid) {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.component.ts
@@ -151,6 +151,7 @@ export class EdgeRouterPolicyFormComponent extends ProjectableForm implements On
   }
 
   async save(event?) {
+    this.formData.name.trim();
     const isValid = this.validate();
     const isExtValid = await this.extService.validateData();
     if(!isValid || !isExtValid) {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.ts
@@ -144,6 +144,7 @@ export class EdgeRouterFormComponent extends ProjectableForm implements OnInit, 
   async save(event?) {
     const isValid = this.validate();
     const isExtValid = await this.extService.validateData();
+    this.formData.name = this.formData.name.trim()
     if(!isValid || !isExtValid) {
       return;
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
@@ -258,6 +258,7 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
   }
 
   save(event?) {
+    this.formData.name = this.formData.name.trim();
     if(!this.validate()) {
       return;
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.component.ts
@@ -168,6 +168,7 @@ export class ServicePolicyFormComponent extends ProjectableForm implements OnIni
   }
 
   async save(event?) {
+    this.formData.name = this.formData.name.trim();
     const isValid = this.validate();
     const isExtValid = await this.extService.validateData();
     if(!isValid || !isExtValid) {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
@@ -213,6 +213,9 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
   }
 
   async save(event?) {
+    debugger;
+    console.log(this.formData);
+    this.formData.name = this.formData.name.trim();
     const isValid = this.svc.validate();
     const isExtValid = await this.extService.validateData();
     const isEdit = !isEmpty(this.formData.id);

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
@@ -238,6 +238,7 @@ export class SimpleServiceComponent extends ProjectableForm {
   }
 
   async save(refresh?) {
+    this.serviceApiData.name = this.serviceApiData.name.trim();
     if (!this.validate()) {
       return;
     }

--- a/projects/ziti-console-lib/src/lib/version.ts
+++ b/projects/ziti-console-lib/src/lib/version.ts
@@ -1,3 +1,3 @@
 export const VERSION = {
-    "version": "3.2.3"
+    "version": "3.4.1"
 };


### PR DESCRIPTION
Adding trim function to get rid of whitespace on form names. Closes #424 