### PR TITLE
Enable the opening of the configs create/edit forms via deep linking

### DIFF
--- a/projects/app-ziti-console/src/app/app-routing.module.ts
+++ b/projects/app-ziti-console/src/app/app-routing.module.ts
@@ -32,7 +32,8 @@ import {
   EdgeRouterFormComponent,
   CardListComponent,
   ServiceFormComponent,
-  SimpleServiceComponent
+  SimpleServiceComponent,
+  ConfigurationFormComponent
 } from "ziti-console-lib";
 import {environment} from "./environments/environment";
 import {URLS} from "./app-urls.constants";
@@ -142,6 +143,12 @@ const routes: Routes = [
   {
     path: 'configs',
     component: ConfigurationsPageComponent,
+    canActivate: mapToCanActivate([AuthenticationGuard]),
+    runGuardsAndResolvers: 'always',
+  },
+  {
+    path: 'configs/:id',
+    component: ConfigurationFormComponent,
     canActivate: mapToCanActivate([AuthenticationGuard]),
     runGuardsAndResolvers: 'always',
   },

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.ts
@@ -30,10 +30,12 @@ import {GrowlerService} from "../../messaging/growler.service";
 import {ExtensionService, SHAREDZ_EXTENSION} from "../../extendable/extensions-noop.service";
 import {ConfigEditorComponent} from "../../config-editor/config-editor.component";
 
-import {cloneDeep, defer, isEmpty} from 'lodash';
+import {cloneDeep, defer, isEmpty, unset} from 'lodash';
 import {GrowlerModel} from "../../messaging/growler.model";
 import {SETTINGS_SERVICE, SettingsService} from "../../../services/settings.service";
 import {ZITI_DATA_SERVICE, ZitiDataService} from "../../../services/ziti-data.service";
+import {ActivatedRoute, Router} from "@angular/router";
+import {Config} from "../../../models/config";
 
 @Component({
     selector: 'lib-configuration',
@@ -59,6 +61,9 @@ export class ConfigurationFormComponent extends ProjectableForm implements OnIni
     settings: any = {};
     selectedConfigTypeId = '';
 
+    override entityType = 'configs';
+    override entityClass = Config;
+
     @ViewChild("configEditor", {read: ConfigEditorComponent}) configEditor!: ConfigEditorComponent;
     constructor(
         public svc: ConfigurationService,
@@ -67,8 +72,10 @@ export class ConfigurationFormComponent extends ProjectableForm implements OnIni
         @Inject(SHAREDZ_EXTENSION) extService: ExtensionService,
         @Inject(SETTINGS_SERVICE) public settingsService: SettingsService,
         @Inject(ZITI_DATA_SERVICE) override zitiService: ZitiDataService,
+        protected override router: Router,
+        protected override route: ActivatedRoute,
     ) {
-        super(growlerService, extService, zitiService);
+        super(growlerService, extService, zitiService, router, route);
     }
 
     override ngOnInit(): void {
@@ -76,6 +83,9 @@ export class ConfigurationFormComponent extends ProjectableForm implements OnIni
         this.settingsService.settingsChange.subscribe((results:any) => {
             this.settings = results;
         });
+    }
+
+    override entityUpdated() {
         if (isEmpty(this.formData?.data)) {
             this.formData.data = {};
         }
@@ -118,7 +128,7 @@ export class ConfigurationFormComponent extends ProjectableForm implements OnIni
                 this.save(event);
                 break;
             case 'close':
-                this.closeModal(true);
+                this.returnToListPage();
                 break;
             case 'toggle-view':
                 this.formView = event.data;

--- a/projects/ziti-console-lib/src/lib/pages/configurations/configurations-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/configurations/configurations-page.component.html
@@ -17,13 +17,4 @@
                     (gridReady)="gridReady($event)"
     >
     </lib-data-table>
-
-    <lib-side-modal [(open)]="svc.sideModalOpen" [showClose]="false">
-        <lib-configuration
-                *ngIf="svc.sideModalOpen"
-                [formData]="svc.selectedConfig"
-                (close)="closeModal($event)"
-                (dataChange)="dataChanged($event)">
-        </lib-configuration>
-    </lib-side-modal>
 </div>

--- a/projects/ziti-console-lib/src/lib/pages/configurations/configurations-page.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/configurations/configurations-page.component.ts
@@ -47,19 +47,16 @@ export class ConfigurationsPageComponent extends ListPageComponent implements On
     override ngOnInit() {
         this.tabs = this.tabNames.getTabs('services');
         this.svc.refreshData = this.refreshData;
-        this.svc.getConfigTypes().then((result) => {
-            console.log(result);
-        });
         super.ngOnInit();
     }
 
     headerActionClicked(action: string) {
         switch (action) {
             case 'add':
-                this.svc.openUpdate();
+                this.svc.openEditForm();
                 break;
             case 'edit':
-                this.svc.openUpdate(action);
+                this.svc.openEditForm();
                 break;
             case 'delete':
                 const selectedItems = this.rowData.filter((row) => {
@@ -79,10 +76,10 @@ export class ConfigurationsPageComponent extends ListPageComponent implements On
                 this.itemToggled(event.item)
                 break;
             case 'update':
-                this.svc.openUpdate(event.item);
+                this.svc.openEditForm(event.item?.id);
                 break;
             case 'create':
-                this.svc.openUpdate();
+                this.svc.openEditForm();
                 break;
             case 'delete':
                 this.deleteItem(event.item)

--- a/projects/ziti-console-lib/src/lib/pages/configurations/configurations-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/configurations/configurations-page.service.ts
@@ -28,6 +28,8 @@ import {SETTINGS_SERVICE, SettingsService} from "../../services/settings.service
 import {CsvDownloadService} from "../../services/csv-download.service";
 import {ExtensionService, SHAREDZ_EXTENSION} from "../../features/extendable/extensions-noop.service";
 import {Service} from "../../models/service";
+import {TableCellNameComponent} from "../../features/data-table/cells/table-cell-name/table-cell-name.component";
+import {Router} from "@angular/router";
 
 @Injectable({
     providedIn: 'root'
@@ -50,9 +52,10 @@ export class ConfigurationsPageService extends ListPageServiceClass {
         @Inject(SETTINGS_SERVICE) settings: SettingsService,
         filterService: DataTableFilterService,
         csvDownloadService: CsvDownloadService,
-        @Inject(SHAREDZ_EXTENSION) extService: ExtensionService
+        @Inject(SHAREDZ_EXTENSION) extService: ExtensionService,
+        protected override router: Router
     ) {
-        super(settings, filterService, csvDownloadService, extService);
+        super(settings, filterService, csvDownloadService, extService, router);
     }
 
     initTableColumns(): any {
@@ -71,12 +74,13 @@ export class ConfigurationsPageService extends ListPageServiceClass {
                 headerName: 'Name',
                 headerComponent: TableColumnDefaultComponent,
                 headerComponentParams: this.headerComponentParams,
-                cellRenderer: this.nameColumnRenderer,
+                cellRenderer: TableCellNameComponent,
+                cellRendererParams: { pathRoot: 'configs/' },
                 onCellClicked: (data) => {
                     if (this.hasSelectedText()) {
                         return;
                     }
-                    this.openUpdate(data.data);
+                    this.openEditForm(data?.data?.id);
                 },
                 resizable: true,
                 cellClass: 'nf-cell-vert-align tCol',

--- a/projects/ziti-console-lib/src/lib/pages/services/services-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/services/services-page.service.ts
@@ -78,7 +78,7 @@ export class ServicesPageService extends ListPageServiceClass {
         @Inject(SHAREDZ_EXTENSION) private extService: ExtensionService,
         protected override router: Router
     ) {
-        super(settings, filterService, csvDownloadService, extService);
+        super(settings, filterService, csvDownloadService, extService, router);
     }
 
     validate = (formData): Promise<CallbackResults> => {


### PR DESCRIPTION
Angular supports the opening of various pages/screens via "deep routes" or "deep linking", so that a specific entity can be loaded via an ID included in the URL path.

This will allow users to go to the url `/configs/some-ziti-id`, and open the configs edit page with the details of a specific identity already loaded on the page.

Also wrapped the "name" cell render, and the service type cards with an anchor tag to allow the "open in new tab" behavior via browser context menu.