### PR TITLE
Enable the opening of the service policies create/edit forms via deep linking

### DIFF
--- a/projects/app-ziti-console/src/app/app-routing.module.ts
+++ b/projects/app-ziti-console/src/app/app-routing.module.ts
@@ -33,7 +33,8 @@ import {
   CardListComponent,
   ServiceFormComponent,
   SimpleServiceComponent,
-  ConfigurationFormComponent
+  ConfigurationFormComponent,
+  ServicePolicyFormComponent
 } from "ziti-console-lib";
 import {environment} from "./environments/environment";
 import {URLS} from "./app-urls.constants";
@@ -167,6 +168,12 @@ const routes: Routes = [
   {
     path: 'service-policies',
     component: ServicePoliciesPageComponent,
+    canActivate: mapToCanActivate([AuthenticationGuard]),
+    runGuardsAndResolvers: 'always',
+  },
+  {
+    path: 'service-policies/:id',
+    component: ServicePolicyFormComponent,
     canActivate: mapToCanActivate([AuthenticationGuard]),
     runGuardsAndResolvers: 'always',
   },

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.component.html
@@ -31,8 +31,8 @@
                     <lib-tag-selector
                             [(selectedRoleAttributes)]="selectedServiceRoleAttributes"
                             [(selectedNamedAttributes)]="selectedServiceNamedAttributes"
-                            [availableRoleAttributes]="serviceRoleAttributes"
-                            [availableNamedAttributes]="serviceNamedAttributes"
+                            [availableRoleAttributes]="svc.serviceRoleAttributes"
+                            [availableNamedAttributes]="svc.serviceNamedAttributes"
                             (selectedNamedAttributesChange)="svc.getAssociatedServicesByAttribute(selectedServiceRoleAttributes, selectedServiceNamedAttributes)"
                             (selectedRoleAttributesChange)="svc.getAssociatedServicesByAttribute(selectedServiceRoleAttributes, selectedServiceNamedAttributes)"
                             [placeholder]="'Select service attributes'"
@@ -47,8 +47,8 @@
                     <lib-tag-selector
                             [(selectedRoleAttributes)]="selectedIdentityRoleAttributes"
                             [(selectedNamedAttributes)]="selectedIdentityNamedAttributes"
-                            [availableRoleAttributes]="identityRoleAttributes"
-                            [availableNamedAttributes]="identityNamedAttributes"
+                            [availableRoleAttributes]="svc.identityRoleAttributes"
+                            [availableNamedAttributes]="svc.identityNamedAttributes"
                             (selectedNamedAttributesChange)="svc.getAssociatedIdentitiesByAttribute(selectedIdentityRoleAttributes, selectedIdentityNamedAttributes)"
                             (selectedRoleAttributesChange)="svc.getAssociatedIdentitiesByAttribute(selectedIdentityRoleAttributes, selectedIdentityNamedAttributes)"
                             [placeholder]="'Select identity attributes'"
@@ -63,8 +63,8 @@
                     <lib-tag-selector
                             [(selectedRoleAttributes)]="selectedPostureRoleAttributes"
                             [(selectedNamedAttributes)]="selectedPostureNamedAttributes"
-                            [(selectedRoleAttributes)]="postureRoleAttributes"
-                            [availableNamedAttributes]="postureNamedAttributes"
+                            [(selectedRoleAttributes)]="svc.postureRoleAttributes"
+                            [availableNamedAttributes]="svc.postureNamedAttributes"
                             (selectedNamedAttributesChange)="svc.getAssociatedPostureChecksByAttribute(selectedPostureRoleAttributes, selectedPostureNamedAttributes)"
                             (selectedRoleAttributesChange)="svc.getAssociatedPostureChecksByAttribute(selectedPostureRoleAttributes, selectedPostureNamedAttributes)"
                             [placeholder]="'Select posture check attributes'"

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.service.ts
@@ -28,6 +28,14 @@ export class ServicePolicyFormService {
     identityNamedAttributesMap: any = {};
     postureNamedAttributesMap: any = {};
 
+    identityNamedAttributes: any = [];
+    serviceNamedAttributes: any = [];
+    postureNamedAttributes: any = [];
+
+    serviceRoleAttributes: any = [];
+    identityRoleAttributes: any = [];
+    postureRoleAttributes: any = [];
+
     constructor(
         @Inject(SETTINGS_SERVICE) public settingsService: SettingsService,
         @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
@@ -221,5 +229,52 @@ export class ServicePolicyFormService {
             return '@' + namedAttributeMap[attr];
         })
         return [...prependedRoleAttributes, ...prependedNamedAttributes];
+    }
+
+    public getServiceRoleAttributes() {
+        return this.zitiService.get('service-role-attributes', {}, []).then((result) => {
+            this.serviceRoleAttributes = result.data;
+            return result;
+        });
+    }
+
+    public getIdentityNamedAttributes() {
+        return this.zitiService.get('identities', {rawFilter: true, filter: '', sort: 'name', order: 'asc', total: -1, page: 1}, []).then((result) => {
+            const namedAttributes = result.data.map((identity) => {
+                this.identityNamedAttributesMap[identity.name] = identity.id;
+                return identity.name;
+            });
+            this.identityNamedAttributes = namedAttributes;
+            return namedAttributes;
+        });
+    }
+
+    public getServiceNamedAttributes() {
+        return this.zitiService.get('services', {rawFilter: true, filter: '', sort: 'name', order: 'asc', total: -1, page: 1}, []).then((result) => {
+            const namedAttributes = result.data.map((service) => {
+                this.serviceNamedAttributesMap[service.name] = service.id;
+                return service.name;
+            });
+            this.serviceNamedAttributes = namedAttributes;
+            return namedAttributes;
+        });
+    }
+
+    public getIdentityRoleAttributes() {
+        return this.zitiService.get('identity-role-attributes', {}, []).then((result) => {
+            this.identityRoleAttributes = result.data;
+            return result;
+        });
+    }
+
+    public getPostureNamedAttributes() {
+        return this.zitiService.get('posture-checks', {}, []).then((result) => {
+            const namedAttributes = result.data.map((postureCheck) => {
+                this.postureNamedAttributesMap[postureCheck.name] = postureCheck.id;
+                return postureCheck.name;
+            });
+            this.postureNamedAttributes = namedAttributes;
+            return namedAttributes;
+        });
     }
 }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
@@ -242,6 +242,7 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
     }
     if (serviceId) {
       this.closeModal(true, true);
+      this.returnToListPage();
     }
   }
 

--- a/projects/ziti-console-lib/src/lib/pages/service-policies/service-policies-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/service-policies/service-policies-page.component.html
@@ -18,21 +18,4 @@
     >
     </lib-data-table>
 </div>
-<lib-side-modal [(open)]="svc.sideModalOpen" [showClose]="false">
-    <lib-service-policy-form
-            *ngIf="svc.sideModalOpen"
-            [formData]="svc.selectedServicePolicy"
-            [serviceRoleAttributes]="svc.serviceRoleAttributes"
-            [serviceNamedAttributes]="svc.serviceNamedAttributes"
-            [serviceNamedAttributesMap]="svc.serviceNamedAttributesMap"
-            [identityRoleAttributes]="svc.identityRoleAttributes"
-            [identityNamedAttributes]="svc.identityNamedAttributes"
-            [identityNamedAttributesMap]="svc.identityNamedAttributesMap"
-            [postureRoleAttributes]="svc.postureRoleAttributes"
-            [postureNamedAttributes]="svc.postureNamedAttributes"
-            [postureNamedAttributesMap]="svc.postureNamedAttributesMap"
-            (close)="closeModal($event)"
-            (dataChange)="dataChanged($event)">
-    </lib-service-policy-form>
-</lib-side-modal>
 <lib-loading-indicator *ngIf="isLoading" [isLoading]="isLoading"></lib-loading-indicator>

--- a/projects/ziti-console-lib/src/lib/pages/service-policies/service-policies-page.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/service-policies/service-policies-page.component.ts
@@ -61,10 +61,10 @@ export class ServicePoliciesPageComponent extends ListPageComponent implements O
     switch(action) {
       case 'add':
         this.svc.serviceType = '';
-        this.svc.openUpdate();
+        this.svc.openEditForm();
         break;
       case 'edit':
-        this.svc.openUpdate();
+        this.svc.openEditForm();
         break;
       case 'delete':
         const selectedItems = this.rowData.filter((row) => {
@@ -85,10 +85,10 @@ export class ServicePoliciesPageComponent extends ListPageComponent implements O
         break;
       case 'update':
         this.svc.serviceType = 'advanced';
-        this.svc.openUpdate(event.item);
+        this.svc.openEditForm(event.item.id);
         break;
       case 'create':
-        this.svc.openUpdate();
+        this.svc.openEditForm();
         break;
       case 'delete':
         this.deleteItem(event.item)

--- a/projects/ziti-console-lib/src/lib/pages/service-policies/service-policies-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/service-policies/service-policies-page.service.ts
@@ -33,6 +33,8 @@ import {GrowlerService} from "../../features/messaging/growler.service";
 import {MatDialog} from "@angular/material/dialog";
 import {SettingsServiceClass} from "../../services/settings-service.class";
 import {ExtensionService, SHAREDZ_EXTENSION} from "../../features/extendable/extensions-noop.service";
+import {Router} from "@angular/router";
+import {TableCellNameComponent} from "../../features/data-table/cells/table-cell-name/table-cell-name.component";
 
 const CSV_COLUMNS = [
     {label: 'Name', path: 'name'},
@@ -92,9 +94,10 @@ export class ServicePoliciesPageService extends ListPageServiceClass {
         override csvDownloadService: CsvDownloadService,
         private growlerService: GrowlerService,
         private dialogForm: MatDialog,
-        @Inject(SHAREDZ_EXTENSION) private extService: ExtensionService
+        @Inject(SHAREDZ_EXTENSION) private extService: ExtensionService,
+        protected override router: Router
     ) {
-        super(settings, filterService, csvDownloadService, extService);
+        super(settings, filterService, csvDownloadService, extService, router);
         this.filterService.filtersChanged.subscribe(filters => {
             let serviceFilter, identityFilter, postureFilter;
             filters.forEach((filter) => {
@@ -238,15 +241,16 @@ export class ServicePoliciesPageService extends ListPageServiceClass {
                 headerName: 'Name',
                 headerComponent: TableColumnDefaultComponent,
                 headerComponentParams: this.headerComponentParams,
+                cellRenderer: TableCellNameComponent,
+                cellRendererParams: { pathRoot: 'service-policies/' },
                 onCellClicked: (data) => {
                     if (this.hasSelectedText()) {
                         return;
                     }
                     this.serviceType = 'advanced';
-                    this.openUpdate(data.data);
+                    this.openEditForm(data?.data.id);
                 },
                 resizable: true,
-                cellRenderer: this.nameColumnRenderer,
                 cellClass: 'nf-cell-vert-align tCol',
                 sortable: true,
                 filter: true,
@@ -265,7 +269,7 @@ export class ServicePoliciesPageService extends ListPageServiceClass {
                         return;
                     }
                     this.serviceType = '';
-                    this.openUpdate(data.data);
+                    this.openEditForm(data.data.id);
                 },
                 resizable: true,
                 cellRenderer: this.rolesRenderer,
@@ -284,7 +288,7 @@ export class ServicePoliciesPageService extends ListPageServiceClass {
                         return;
                     }
                     this.serviceType = '';
-                    this.openUpdate(data.data);
+                    this.openEditForm(data.data.id);
                 },
                 resizable: true,
                 cellRenderer: this.rolesRenderer,
@@ -303,7 +307,7 @@ export class ServicePoliciesPageService extends ListPageServiceClass {
                         return;
                     }
                     this.serviceType = '';
-                    this.openUpdate(data.data);
+                    this.openEditForm(data.data.id);
                 },
                 resizable: true,
                 cellRenderer: this.rolesRenderer,
@@ -322,7 +326,7 @@ export class ServicePoliciesPageService extends ListPageServiceClass {
                         return;
                     }
                     this.serviceType = '';
-                    this.openUpdate(data.data);
+                    this.openEditForm(data.data.id);
                 },
                 resizable: true,
                 cellRenderer: (row) => {
@@ -342,7 +346,7 @@ export class ServicePoliciesPageService extends ListPageServiceClass {
                         return;
                     }
                     this.serviceType = '';
-                    this.openUpdate(data.data);
+                    this.openEditForm(data.data.id);
                 },
                 resizable: true,
                 cellRenderer: (row) => {
@@ -367,7 +371,7 @@ export class ServicePoliciesPageService extends ListPageServiceClass {
                         return;
                     }
                     this.serviceType = '';
-                    this.openUpdate(data.data);
+                    this.openEditForm(data.data.id);
                 },
                 hide: true
             }


### PR DESCRIPTION
Angular supports the opening of various pages/screens via "deep routes" or "deep linking", so that a specific entity can be loaded via an ID included in the URL path.

This will allow users to go to the url `/service-policies/some-ziti-id`, and open the service policies edit page with the details of a specific identity already loaded on the page.

Also wrapped the "name" cell render, and the service type cards with an anchor tag to allow the "open in new tab" behavior via browser context menu.