### PR TITLE
Enable the opening of the edge router policies create/edit forms via deep linking

### DIFF
--- a/projects/app-ziti-console/src/app/app-routing.module.ts
+++ b/projects/app-ziti-console/src/app/app-routing.module.ts
@@ -34,7 +34,8 @@ import {
   ServiceFormComponent,
   SimpleServiceComponent,
   ConfigurationFormComponent,
-  ServicePolicyFormComponent
+  ServicePolicyFormComponent,
+  EdgeRouterPolicyFormComponent
 } from "ziti-console-lib";
 import {environment} from "./environments/environment";
 import {URLS} from "./app-urls.constants";
@@ -180,6 +181,12 @@ const routes: Routes = [
   {
     path: 'router-policies',
     component: EdgeRouterPoliciesPageComponent,
+    canActivate: mapToCanActivate([AuthenticationGuard]),
+    runGuardsAndResolvers: 'always',
+  },
+  {
+    path: 'router-policies/:id',
+    component: EdgeRouterPolicyFormComponent,
     canActivate: mapToCanActivate([AuthenticationGuard]),
     runGuardsAndResolvers: 'always',
   },

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.component.html
@@ -31,8 +31,8 @@
                     <lib-tag-selector
                             [(selectedRoleAttributes)]="selectedEdgeRouterRoleAttributes"
                             [(selectedNamedAttributes)]="selectedEdgeRouterNamedAttributes"
-                            [availableRoleAttributes]="edgeRouterRoleAttributes"
-                            [availableNamedAttributes]="edgeRouterNamedAttributes"
+                            [availableRoleAttributes]="svc.edgeRouterRoleAttributes"
+                            [availableNamedAttributes]="svc.edgeRouterNamedAttributes"
                             (selectedNamedAttributesChange)="svc.getAssociatedEdgeRoutersByAttribute(selectedEdgeRouterRoleAttributes, selectedEdgeRouterNamedAttributes)"
                             (selectedRoleAttributesChange)="svc.getAssociatedEdgeRoutersByAttribute(selectedEdgeRouterRoleAttributes, selectedEdgeRouterNamedAttributes)"
                             [placeholder]="'Select edge router attributes'"
@@ -47,8 +47,8 @@
                     <lib-tag-selector
                             [(selectedRoleAttributes)]="selectedIdentityRoleAttributes"
                             [(selectedNamedAttributes)]="selectedIdentityNamedAttributes"
-                            [availableRoleAttributes]="identityRoleAttributes"
-                            [availableNamedAttributes]="identityNamedAttributes"
+                            [availableRoleAttributes]="svc.identityRoleAttributes"
+                            [availableNamedAttributes]="svc.identityNamedAttributes"
                             (selectedNamedAttributesChange)="svc.getAssociatedIdentitiesByAttribute(selectedIdentityRoleAttributes, selectedIdentityNamedAttributes)"
                             (selectedRoleAttributesChange)="svc.getAssociatedIdentitiesByAttribute(selectedIdentityRoleAttributes, selectedIdentityNamedAttributes)"
                             [placeholder]="'Select identity attributes'"

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.service.ts
@@ -25,6 +25,12 @@ export class EdgeRouterPolicyFormService {
     edgeRouterNamedAttributesMap: any = {};
     identityNamedAttributesMap: any = {};
 
+    identityNamedAttributes: any = [];
+    edgeRouterNamedAttributes: any = [];
+
+    edgeRouterRoleAttributes: any = [];
+    identityRoleAttributes: any = [];
+
     constructor(
         @Inject(SETTINGS_SERVICE) public settingsService: SettingsService,
         @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
@@ -148,6 +154,42 @@ export class EdgeRouterPolicyFormService {
             });
             this.associatedIdentityNames = [...this.associatedIdentityNames, ...namedAttributes];
             this.associatedIdentityNames = sortedUniq(this.associatedIdentityNames);
+        });
+    }
+
+    public getEdgeRouterRoleAttributes() {
+        return this.zitiService.get('edge-router-role-attributes', {}, []).then((result) => {
+            this.edgeRouterRoleAttributes = result.data;
+            return result;
+        });
+    }
+
+    public getIdentityNamedAttributes() {
+        return this.zitiService.get('identities', {}, []).then((result) => {
+            const namedAttributes = result.data.map((identity) => {
+                this.identityNamedAttributesMap[identity.name] = identity.id;
+                return identity.name;
+            });
+            this.identityNamedAttributes = namedAttributes;
+            return namedAttributes;
+        });
+    }
+
+    public getEdgeRouterNamedAttributes() {
+        return this.zitiService.get('edge-routers', {}, []).then((result) => {
+            const namedAttributes = result.data.map((router) => {
+                this.edgeRouterNamedAttributesMap[router.name] = router.id;
+                return router.name;
+            });
+            this.edgeRouterNamedAttributes = namedAttributes;
+            return namedAttributes;
+        });
+    }
+
+    public getIdentityRoleAttributes() {
+        return this.zitiService.get('identity-role-attributes', {}, []).then((result) => {
+            this.identityRoleAttributes = result.data;
+            return result;
         });
     }
 

--- a/projects/ziti-console-lib/src/lib/pages/edge-router-policies/edge-router-policies-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/edge-router-policies/edge-router-policies-page.component.html
@@ -18,18 +18,4 @@
     >
     </lib-data-table>
 </div>
-<lib-side-modal [(open)]="svc.sideModalOpen" [showClose]="false">
-    <lib-edge-router-policy-form
-            *ngIf="svc.sideModalOpen"
-            [formData]="svc.selectedEdgeRouterPolicy"
-            [edgeRouterRoleAttributes]="svc.routerRoleAttributes"
-            [edgeRouterNamedAttributes]="svc.routerNamedAttributes"
-            [edgeRouterNamedAttributesMap]="svc.routerNamedAttributesMap"
-            [identityRoleAttributes]="svc.identityRoleAttributes"
-            [identityNamedAttributes]="svc.identityNamedAttributes"
-            [identityNamedAttributesMap]="svc.identityNamedAttributesMap"
-            (close)="closeModal($event)"
-            (dataChange)="dataChanged($event)">
-    </lib-edge-router-policy-form>
-</lib-side-modal>
 <lib-loading-indicator *ngIf="isLoading" [isLoading]="isLoading"></lib-loading-indicator>

--- a/projects/ziti-console-lib/src/lib/pages/edge-router-policies/edge-router-policies-page.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/edge-router-policies/edge-router-policies-page.component.ts
@@ -60,10 +60,10 @@ export class EdgeRouterPoliciesPageComponent extends ListPageComponent implement
     switch(action) {
       case 'add':
         this.svc.serviceType = '';
-        this.svc.openUpdate();
+        this.svc.openEditForm();
         break;
       case 'edit':
-        this.svc.openUpdate();
+        this.svc.openEditForm();
         break;
       case 'delete':
         const selectedItems = this.rowData.filter((row) => {
@@ -84,10 +84,10 @@ export class EdgeRouterPoliciesPageComponent extends ListPageComponent implement
         break;
       case 'update':
         this.svc.serviceType = 'advanced';
-        this.svc.openUpdate(event.item);
+        this.svc.openEditForm(event.item.id);
         break;
       case 'create':
-        this.svc.openUpdate();
+        this.svc.openEditForm();
         break;
       case 'delete':
         this.deleteItem(event.item)

--- a/projects/ziti-console-lib/src/lib/pages/edge-router-policies/edge-router-policies-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/edge-router-policies/edge-router-policies-page.service.ts
@@ -33,6 +33,8 @@ import {GrowlerService} from "../../features/messaging/growler.service";
 import {MatDialog} from "@angular/material/dialog";
 import {SettingsServiceClass} from "../../services/settings-service.class";
 import {ExtensionService, SHAREDZ_EXTENSION} from "../../features/extendable/extensions-noop.service";
+import {ActivatedRoute, Router} from "@angular/router";
+import {TableCellNameComponent} from "../../features/data-table/cells/table-cell-name/table-cell-name.component";
 
 const CSV_COLUMNS = [
     {label: 'Name', path: 'name'},
@@ -92,9 +94,10 @@ export class EdgeRouterPoliciesPageService extends ListPageServiceClass {
         override csvDownloadService: CsvDownloadService,
         private growlerService: GrowlerService,
         private dialogForm: MatDialog,
-        @Inject(SHAREDZ_EXTENSION) private extService: ExtensionService
+        @Inject(SHAREDZ_EXTENSION) private extService: ExtensionService,
+        protected override router: Router
     ) {
-        super(settings, filterService, csvDownloadService, extService);
+        super(settings, filterService, csvDownloadService, extService, router);
         this.filterService.filtersChanged.subscribe(filters => {
             let routerFilter, identityFilter, postureFilter;
             filters.forEach((filter) => {
@@ -238,15 +241,16 @@ export class EdgeRouterPoliciesPageService extends ListPageServiceClass {
                 headerName: 'Name',
                 headerComponent: TableColumnDefaultComponent,
                 headerComponentParams: this.headerComponentParams,
+                cellRenderer: TableCellNameComponent,
+                cellRendererParams: { pathRoot: 'router-policies/' },
                 onCellClicked: (data) => {
                     if (this.hasSelectedText()) {
                         return;
                     }
                     this.serviceType = 'advanced';
-                    this.openUpdate(data.data);
+                    this.openEditForm(data.data.id);
                 },
                 resizable: true,
-                cellRenderer: this.nameColumnRenderer,
                 cellClass: 'nf-cell-vert-align tCol',
                 sortable: true,
                 filter: true,
@@ -265,7 +269,7 @@ export class EdgeRouterPoliciesPageService extends ListPageServiceClass {
                         return;
                     }
                     this.serviceType = '';
-                    this.openUpdate(data.data);
+                    this.openEditForm(data.data.id);
                 },
                 resizable: true,
                 cellRenderer: this.rolesRenderer,
@@ -284,7 +288,7 @@ export class EdgeRouterPoliciesPageService extends ListPageServiceClass {
                         return;
                     }
                     this.serviceType = '';
-                    this.openUpdate(data.data);
+                    this.openEditForm(data.data.id);
                 },
                 resizable: true,
                 cellRenderer: this.rolesRenderer,
@@ -303,7 +307,7 @@ export class EdgeRouterPoliciesPageService extends ListPageServiceClass {
                         return;
                     }
                     this.serviceType = '';
-                    this.openUpdate(data.data);
+                    this.openEditForm(data.data.id);
                 },
                 resizable: true,
                 cellRenderer: (row) => {
@@ -328,7 +332,7 @@ export class EdgeRouterPoliciesPageService extends ListPageServiceClass {
                         return;
                     }
                     this.serviceType = '';
-                    this.openUpdate(data.data);
+                    this.openEditForm(data.data.id);
                 },
                 hide: true
             }


### PR DESCRIPTION
Angular supports the opening of various pages/screens via "deep routes" or "deep linking", so that a specific entity can be loaded via an ID included in the URL path.

This will allow users to go to the url `/router-policies/some-ziti-id`, and open the router policies edit page with the details of a specific identity already loaded on the page.

Also wrapped the "name" cell render, and the service type cards with an anchor tag to allow the "open in new tab" behavior via browser context menu.