### PR TITLE
Persist changes to config when editing in JSON view

### DIFF
--- a/projects/ziti-console-lib/package.json
+++ b/projects/ziti-console-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openziti/ziti-console-lib",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/openziti/ziti-console"

--- a/projects/ziti-console-lib/src/lib/features/config-editor/config-editor.component.html
+++ b/projects/ziti-console-lib/src/lib/features/config-editor/config-editor.component.html
@@ -1,5 +1,5 @@
-<div class="form-field-extended-fields" [hidden]="showJsonView">
+<div class="form-field-extended-fields" [hidden]="showJsonView" (mouseup)="formDataChangedDebounced($event)" (keyup)="formDataChangedDebounced($event)">
     <ng-container #dynamicform></ng-container>
 </div>
-<lib-json-view *ngIf="showJsonView && !hideConfigJSON" [(data)]="configData"></lib-json-view>
+<lib-json-view *ngIf="showJsonView && !hideConfigJSON" (dataChange)="jsonDataChangedDebounced($event)" [(data)]="configData"></lib-json-view>
 <lib-json-view *ngIf="showJsonView && hideConfigJSON" [(data)]="configData"></lib-json-view>

--- a/projects/ziti-console-lib/src/lib/features/config-editor/config-editor.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/config-editor/config-editor.component.ts
@@ -1,6 +1,6 @@
 import {Component, ComponentRef, EventEmitter, Input, OnInit, Output, ViewChild, ViewContainerRef} from '@angular/core';
 import {JsonEditorComponent, JsonEditorOptions} from "ang-jsoneditor";
-import {defer, isBoolean, isEmpty, isNil, keys} from "lodash";
+import {debounce, defer, delay, isBoolean, isEmpty, isNil, keys} from "lodash";
 import {SchemaService} from "../../services/schema.service";
 
 @Component({
@@ -57,6 +57,8 @@ export class ConfigEditorComponent implements OnInit {
     return this._schema;
   }
 
+  formDataChangedDebounced: any = debounce(this.formDataChanged.bind(this), 350);
+  jsonDataChangedDebounced: any = debounce(this.jsonDataChanged.bind(this), 350);
   @ViewChild("dynamicform", {read: ViewContainerRef}) dynamicForm!: ViewContainerRef;
   @ViewChild(JsonEditorComponent, {static: false}) editor!: JsonEditorComponent;
   constructor(private schemaSvc: SchemaService) {
@@ -64,6 +66,9 @@ export class ConfigEditorComponent implements OnInit {
 
   ngOnInit() {
     this.createForm();
+    defer(() => {
+      this.formDataChanged();
+    });
   }
 
   createForm() {
@@ -220,5 +225,17 @@ export class ConfigEditorComponent implements OnInit {
       }
     });
     return isValid;
+  }
+
+  formDataChanged() {
+    delay(() => {
+      this.getConfigDataFromForm();
+    }, 200);
+  }
+
+  jsonDataChanged(event) {
+    defer(() => {
+      this.configDataChange.emit(this.configData);
+    });
   }
 }

--- a/projects/ziti-console-lib/src/lib/features/json-view/json-view.component.html
+++ b/projects/ziti-console-lib/src/lib/features/json-view/json-view.component.html
@@ -1,2 +1,2 @@
-<div id="jsoneditor" [ngClass]="{'read-only': readOnly}" #editor (keyup.enter)="enterKeyPressed($event)"></div>
+<div id="jsoneditor" [ngClass]="{'read-only': readOnly}" #editor (keyup.enter)="enterKeyPressed($event)" (keyup)="jsonChanged($event)"></div>
 <div *ngIf="showCopy" class="icon-copy copy" (click)="copyToClipboad()"></div>

--- a/projects/ziti-console-lib/src/lib/features/json-view/json-view.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/json-view/json-view.component.ts
@@ -193,6 +193,10 @@ export class JsonViewComponent implements AfterViewInit, OnChanges {
     event.preventDefault();
   }
 
+  jsonChanged(event) {
+    this.dataChange.emit(this.data);
+  }
+
   copyToClipboad() {
     var clipData = JSON.stringify(JSON.parse(JSON.stringify(this.data)),null,2);
     navigator.clipboard.writeText(clipData);

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.html
@@ -76,6 +76,7 @@
                                 [(configData)]="formData.data"
                                 [showJsonView]="svc.configJsonView"
                                 [(configErrors)]="errors"
+                                (configDataChange)="dataChanged($event)"
                                 #configEditor
                         ></lib-config-editor>
                     </div>
@@ -90,7 +91,7 @@
                         <input class="form-field-input" [value]="apiCallURL" readonly/>
                         <div class="url-copy icon-copy copy" (click)="copyToClipboard(apiCallURL)"></div>
                     </div>
-                    <lib-json-view *ngIf="formData" [(data)]="apiData" [readOnly]="true" [showCopy]="true"></lib-json-view>
+                    <lib-json-view *ngIf="formData" [(data)]="_apiData" [readOnly]="true" [showCopy]="true"></lib-json-view>
                 </lib-form-field-container>
             </div>
         </div>

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.html
@@ -23,6 +23,7 @@
                         placeholder="Name this config"
                         [ngClass]="{error: errors['name']}"
                         [(ngModel)]="formData.name"
+                        (keyup)="apiData()"
                     >
                 </lib-form-field-container>
                 <lib-form-field-container [showHeader]="false">

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.ts
@@ -232,11 +232,16 @@ export class ConfigurationFormComponent extends ProjectableForm implements OnIni
             configTypeId: this.formData?.configTypeId || '',
             data: this.formData?.data || {},
         };
-        return data;
+        this._apiData = data;
+        return this._apiData;
     }
 
-    _apiData = {};
+    _apiData: any = {};
     set apiData(data) {
         this._apiData = data;
+    }
+
+    dataChanged(event) {
+        this._apiData.data = this.formData.data;
     }
 }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.ts
@@ -242,6 +242,6 @@ export class ConfigurationFormComponent extends ProjectableForm implements OnIni
     }
 
     dataChanged(event) {
-        this._apiData.data = this.formData.data;
+        this._apiData = cloneDeep(this.apiData);
     }
 }


### PR DESCRIPTION
* Added event listeners for key-up and mouse-up events to check for changes to the data model

closes #432