### PR TITLE
Enable "deep link" navigation for dynamic routes

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-name/table-cell-name.component.html
+++ b/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-name/table-cell-name.component.html
@@ -1,5 +1,5 @@
 <span class="cell-name-container">
-    <a href="./{{cellParams.pathRoot}}{{item.id}}" (click)="linkClicked($event)">
+    <a href="./{{cellParams.pathRoot}}/{{item.id}}" (click)="linkClicked($event)">
         <div class="col cell-name-renderer" data-id="{{item.id}}">
             <div *ngIf="cellParams.showIdentityIcons" class="cell-status-container">
                 <span class="circle {{item.hasApiSession}}" title="Api Session"></span>

--- a/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-name/table-cell-name.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/data-table/cells/table-cell-name/table-cell-name.component.ts
@@ -30,7 +30,7 @@ export class TableCellNameComponent  implements ICellRendererAngularComp {
   }
 
   linkClicked(event) {
-    this.router.navigateByUrl(`${this.cellParams.pathRoot}${this.item.id}`);
+    this.router.navigateByUrl(`${this.cellParams.pathRoot}/${this.item.id}`);
     event.stopPropagation();
     event.preventDefault();
   }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
@@ -283,7 +283,7 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
 
     canDeactivate() {
         if (this._dataChange) {
-            //return confirm('You have unsaved changes. Do you want to leave this page and discard your changes or stay on this page?');
+            return confirm('You have unsaved changes. Do you want to leave this page and discard your changes or stay on this page?');
         }
         return true;
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
@@ -34,7 +34,7 @@ import {GrowlerService} from "../messaging/growler.service";
 import {ExtensionService, SHAREDZ_EXTENSION} from "../extendable/extensions-noop.service";
 import {Identity} from "../../models/identity";
 import {ZITI_DATA_SERVICE, ZitiDataService} from "../../services/ziti-data.service";
-import {ActivatedRoute, Router} from "@angular/router";
+import {ActivatedRoute, NavigationEnd, Router} from "@angular/router";
 import {Subscription} from "rxjs";
 
 // @ts-ignore
@@ -70,6 +70,7 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
     initData: any = {};
     _dataChange = false;
     apiOptions = [{id: 'cli', label: 'Copy as CLI'}, {id: 'curl', label: 'Copy as CURL'}];
+    basePath = '';
 
     checkDataChangeDebounced = debounce(this.checkDataChange, 100, {maxWait: 100});
 
@@ -88,6 +89,17 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
                 const id = params['id'];
                 if (!isEmpty(id)) {
                     this.entityId = id;
+                }
+            })
+        );
+        this.subscription.add(
+            router.events.subscribe((event: any) => {
+                if (event => event instanceof NavigationEnd) {
+                    if (!event?.snapshot?.routeConfig?.path) {
+                        return;
+                    }
+                    const pathSegments = event.snapshot.routeConfig.path.split('/');
+                    this.basePath = pathSegments[0];
                 }
             })
         );
@@ -219,8 +231,7 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
     }
 
     returnToListPage() {
-        const baseUrl = this.getBaseURLPath();
-        this.router?.navigateByUrl(`${baseUrl}`);
+        this.router?.navigateByUrl(`${this.basePath}`);
     }
 
     ngDoCheck() {
@@ -272,7 +283,7 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
 
     canDeactivate() {
         if (this._dataChange) {
-            return confirm('You have unsaved changes. Do you want to leave this page and discard your changes or stay on this page?');
+            //return confirm('You have unsaved changes. Do you want to leave this page and discard your changes or stay on this page?');
         }
         return true;
     }
@@ -285,18 +296,5 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
         return this.zitiService.get(type, {}, []).then((results) => {
             return results.data;
         });
-    }
-
-    public getBaseURLPath() {
-        let path = '';
-        const urlSegments = window.location.pathname.split('/');
-        const baseSegments: string[] = slice(urlSegments, 0, urlSegments.length - 1);
-        baseSegments.forEach(segment => {
-            if (isEmpty(segment)) {
-                return;
-            }
-            path += `/${segment}`;
-        });
-        return path;
     }
 }

--- a/projects/ziti-console-lib/src/lib/pages/configurations/configurations-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/configurations/configurations-page.service.ts
@@ -75,7 +75,7 @@ export class ConfigurationsPageService extends ListPageServiceClass {
                 headerComponent: TableColumnDefaultComponent,
                 headerComponentParams: this.headerComponentParams,
                 cellRenderer: TableCellNameComponent,
-                cellRendererParams: { pathRoot: 'configs/' },
+                cellRendererParams: { pathRoot: this.basePath },
                 onCellClicked: (data) => {
                     if (this.hasSelectedText()) {
                         return;

--- a/projects/ziti-console-lib/src/lib/pages/edge-router-policies/edge-router-policies-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/edge-router-policies/edge-router-policies-page.service.ts
@@ -242,7 +242,7 @@ export class EdgeRouterPoliciesPageService extends ListPageServiceClass {
                 headerComponent: TableColumnDefaultComponent,
                 headerComponentParams: this.headerComponentParams,
                 cellRenderer: TableCellNameComponent,
-                cellRendererParams: { pathRoot: 'router-policies/' },
+                cellRendererParams: { pathRoot: this.basePath },
                 onCellClicked: (data) => {
                     if (this.hasSelectedText()) {
                         return;

--- a/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.service.ts
@@ -165,7 +165,7 @@ export class EdgeRoutersPageService extends ListPageServiceClass {
                 headerComponent: TableColumnDefaultComponent,
                 headerComponentParams: this.headerComponentParams,
                 cellRenderer: TableCellNameComponent,
-                cellRendererParams: { pathRoot: this.getBaseURLPath(), showRouterIcons: true },
+                cellRendererParams: { pathRoot: this.basePath, showRouterIcons: true },
                 onCellClicked: (data) => {
                     if (this.hasSelectedText()) {
                         return;

--- a/projects/ziti-console-lib/src/lib/pages/identities/identities-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/identities/identities-page.service.ts
@@ -184,7 +184,7 @@ export class IdentitiesPageService extends ListPageServiceClass {
                 headerComponent: TableColumnDefaultComponent,
                 headerComponentParams: this.headerComponentParams,
                 cellRenderer: TableCellNameComponent,
-                cellRendererParams: { pathRoot: this.getBaseURLPath(), showIdentityIcons: true },
+                cellRendererParams: { pathRoot: this.basePath, showIdentityIcons: true },
                 onCellClicked: (data) => {
                     if (this.hasSelectedText()) {
                         return;

--- a/projects/ziti-console-lib/src/lib/pages/service-edge-router-policies/service-edge-router-policies-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/service-edge-router-policies/service-edge-router-policies-page.service.ts
@@ -210,7 +210,7 @@ export class ServiceEdgeRouterPoliciesPageService extends ListPageServiceClass {
                 headerComponent: TableColumnDefaultComponent,
                 headerComponentParams: this.headerComponentParams,
                 cellRenderer: TableCellNameComponent,
-                cellRendererParams: { pathRoot: 'service-router-policies/' },
+                cellRendererParams: { pathRoot: this.basePath },
                 onCellClicked: (data) => {
                     if (this.hasSelectedText()) {
                         return;

--- a/projects/ziti-console-lib/src/lib/pages/service-policies/service-policies-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/service-policies/service-policies-page.service.ts
@@ -242,7 +242,7 @@ export class ServicePoliciesPageService extends ListPageServiceClass {
                 headerComponent: TableColumnDefaultComponent,
                 headerComponentParams: this.headerComponentParams,
                 cellRenderer: TableCellNameComponent,
-                cellRendererParams: { pathRoot: 'service-policies/' },
+                cellRendererParams: { pathRoot: this.basePath },
                 onCellClicked: (data) => {
                     if (this.hasSelectedText()) {
                         return;

--- a/projects/ziti-console-lib/src/lib/pages/services/services-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/services/services-page.service.ts
@@ -68,6 +68,8 @@ export class ServicesPageService extends ListPageServiceClass {
     ]
 
     resourceType = 'services';
+    override basePath = '/services/advanced';
+
     constructor(
         @Inject(SETTINGS_SERVICE) settings: SettingsServiceClass,
         filterService: DataTableFilterService,
@@ -102,7 +104,7 @@ export class ServicesPageService extends ListPageServiceClass {
                 headerComponent: TableColumnDefaultComponent,
                 headerComponentParams: this.headerComponentParams,
                 cellRenderer: TableCellNameComponent,
-                cellRendererParams: { pathRoot: 'services/advanced/' },
+                cellRendererParams: { pathRoot: '/services/advanced' },
                 onCellClicked: (data) => {
                     if (this.hasSelectedText()) {
                         return;

--- a/projects/ziti-console-lib/src/lib/shared/list-page-service.class.ts
+++ b/projects/ziti-console-lib/src/lib/shared/list-page-service.class.ts
@@ -28,7 +28,7 @@ import {CsvDownloadService} from "../services/csv-download.service";
 import {SettingsServiceClass} from "../services/settings-service.class";
 import {ExtensionService, SHAREDZ_EXTENSION} from "../features/extendable/extensions-noop.service";
 import moment from "moment/moment";
-import {Router} from "@angular/router";
+import {NavigationEnd, Router} from "@angular/router";
 
 export abstract class ListPageServiceClass {
 
@@ -37,6 +37,8 @@ export abstract class ListPageServiceClass {
     abstract validate: ValidatorCallback;
     abstract openUpdate(entity?: any);
     abstract resourceType: string;
+
+    basePath: string = '';
 
     headerComponentParams = {
         filterType: 'TEXTINPUT',
@@ -116,6 +118,15 @@ export abstract class ListPageServiceClass {
                 }
             }
         });
+        router.events.subscribe((event: any) => {
+            if (event => event instanceof NavigationEnd) {
+                if (!event?.snapshot?.routeConfig?.path) {
+                    return;
+                }
+                const pathSegments = event.snapshot.routeConfig.path.split('/');
+                this.basePath = pathSegments[0];
+            }
+        });
     }
 
     initMenuActions() {
@@ -183,22 +194,11 @@ export abstract class ListPageServiceClass {
         return text?.length > 0;
     }
 
-    public openEditForm(itemId = '', baseUrl?) {
+    public openEditForm(itemId = '', basePath?) {
         if (isEmpty(itemId)) {
             itemId = 'create';
         }
-        baseUrl = baseUrl ? baseUrl : this.getBaseURLPath();
-        this.router?.navigateByUrl(`${baseUrl}${itemId}`);
-    }
-
-    public getBaseURLPath() {
-        let path = '';
-        window.location.pathname.split('/').forEach(segment => {
-            if (isEmpty(segment)) {
-                return;
-            }
-            path += `${segment}/`;
-        });
-        return path;
+        basePath = basePath ? basePath : this.basePath;
+        this.router?.navigateByUrl(`${basePath}${itemId}`);
     }
 }


### PR DESCRIPTION
* Added router event listeners to the list-page.class and projectable-form.class to determine what the basePath is of the page/form

* This will allow the deep-linking behavior to work for ZAC when it's hosted at any `baseHref`

closes #436 