### PR TITLE
Correctly show associated entities when using the #all attribute

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.service.ts
@@ -109,15 +109,24 @@ export class EdgeRouterPolicyFormService {
             this.associatedEdgeRouterNames = [...namedAttributes];
             return;
         }
-        const filters = [
-            {
-                columnId: "roleAttributes",
-                filterName: "Edge Router Attributes",
-                label: "",
-                type: "ATTRIBUTE",
-                value: roleAttributes
+        let hasAll = false;
+        roleAttributes.forEach((attr) => {
+            if (attr === 'all') {
+                hasAll = true;
             }
-        ];
+        });
+        let filters = [];
+        if (!hasAll) {
+            filters = [
+                {
+                    columnId: "roleAttributes",
+                    filterName: "Edge Router Attributes",
+                    label: "",
+                    type: "ATTRIBUTE",
+                    value: roleAttributes
+                }
+            ];
+        }
         const paging = this.zitiService.DEFAULT_PAGING;
         paging.noSearch = false;
         this.zitiService.get('edge-routers', paging, filters).then((result: any) => {
@@ -136,15 +145,24 @@ export class EdgeRouterPolicyFormService {
             this.associatedIdentityNames = [...namedAttributes];
             return;
         }
-        const filters = [
-            {
-                columnId: "roleAttributes",
-                filterName: "Identity Attributes",
-                label: "",
-                type: "ATTRIBUTE",
-                value: roleAttributes
+        let hasAll = false;
+        roleAttributes.forEach((attr) => {
+            if (attr === 'all') {
+                hasAll = true;
             }
-        ];
+        });
+        let filters = [];
+        if (!hasAll) {
+            filters = [
+                {
+                    columnId: "roleAttributes",
+                    filterName: "Identity Attributes",
+                    label: "",
+                    type: "ATTRIBUTE",
+                    value: roleAttributes
+                }
+            ];
+        }
         const paging = this.zitiService.DEFAULT_PAGING;
         paging.noSearch = false;
         this.zitiService.get('identities', paging, filters).then((result: any) => {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.service.ts
@@ -109,24 +109,7 @@ export class EdgeRouterPolicyFormService {
             this.associatedEdgeRouterNames = [...namedAttributes];
             return;
         }
-        let hasAll = false;
-        roleAttributes.forEach((attr) => {
-            if (attr === 'all') {
-                hasAll = true;
-            }
-        });
-        let filters = [];
-        if (!hasAll) {
-            filters = [
-                {
-                    columnId: "roleAttributes",
-                    filterName: "Edge Router Attributes",
-                    label: "",
-                    type: "ATTRIBUTE",
-                    value: roleAttributes
-                }
-            ];
-        }
+        const filters = this.zitiService.getRoleFilter(roleAttributes);
         const paging = this.zitiService.DEFAULT_PAGING;
         paging.noSearch = false;
         this.zitiService.get('edge-routers', paging, filters).then((result: any) => {
@@ -145,24 +128,7 @@ export class EdgeRouterPolicyFormService {
             this.associatedIdentityNames = [...namedAttributes];
             return;
         }
-        let hasAll = false;
-        roleAttributes.forEach((attr) => {
-            if (attr === 'all') {
-                hasAll = true;
-            }
-        });
-        let filters = [];
-        if (!hasAll) {
-            filters = [
-                {
-                    columnId: "roleAttributes",
-                    filterName: "Identity Attributes",
-                    label: "",
-                    type: "ATTRIBUTE",
-                    value: roleAttributes
-                }
-            ];
-        }
+        const filters = this.zitiService.getRoleFilter(roleAttributes);
         const paging = this.zitiService.DEFAULT_PAGING;
         paging.noSearch = false;
         this.zitiService.get('identities', paging, filters).then((result: any) => {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service-edge-router-policy/service-edge-router-policy-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service-edge-router-policy/service-edge-router-policy-form.service.ts
@@ -91,24 +91,7 @@ export class ServiceEdgeRouterPolicyFormService {
             this.associatedEdgeRouterNames = [...namedAttributes];
             return;
         }
-        let hasAll = false;
-        roleAttributes.forEach((attr) => {
-            if (attr === 'all') {
-                hasAll = true;
-            }
-        });
-        let filters = [];
-        if (!hasAll) {
-            filters = [
-                {
-                    columnId: "roleAttributes",
-                    filterName: "Edge Router Attributes",
-                    label: "",
-                    type: "ATTRIBUTE",
-                    value: roleAttributes
-                }
-            ];
-        }
+        const filters = this.zitiService.getRoleFilter(roleAttributes);
         const paging = this.zitiService.DEFAULT_PAGING;
         paging.noSearch = false;
         this.zitiService.get('edge-routers', paging, filters).then((result: any) => {
@@ -127,24 +110,7 @@ export class ServiceEdgeRouterPolicyFormService {
             this.associatedServiceNames = [...namedAttributes];
             return;
         }
-        let hasAll = false;
-        roleAttributes.forEach((attr) => {
-            if (attr === 'all') {
-                hasAll = true;
-            }
-        });
-        let filters = [];
-        if (!hasAll) {
-            filters = [
-                {
-                    columnId: "roleAttributes",
-                    filterName: "Service Attributes",
-                    label: "",
-                    type: "ATTRIBUTE",
-                    value: roleAttributes
-                }
-            ];
-        }
+        const filters = this.zitiService.getRoleFilter(roleAttributes);
         const paging = this.zitiService.DEFAULT_PAGING;
         paging.noSearch = false;
         this.zitiService.get('services', paging, filters).then((result: any) => {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service-edge-router-policy/service-edge-router-policy-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service-edge-router-policy/service-edge-router-policy-form.service.ts
@@ -91,15 +91,24 @@ export class ServiceEdgeRouterPolicyFormService {
             this.associatedEdgeRouterNames = [...namedAttributes];
             return;
         }
-        const filters = [
-            {
-                columnId: "roleAttributes",
-                filterName: "Edge Router Attributes",
-                label: "",
-                type: "ATTRIBUTE",
-                value: roleAttributes
+        let hasAll = false;
+        roleAttributes.forEach((attr) => {
+            if (attr === 'all') {
+                hasAll = true;
             }
-        ];
+        });
+        let filters = [];
+        if (!hasAll) {
+            filters = [
+                {
+                    columnId: "roleAttributes",
+                    filterName: "Edge Router Attributes",
+                    label: "",
+                    type: "ATTRIBUTE",
+                    value: roleAttributes
+                }
+            ];
+        }
         const paging = this.zitiService.DEFAULT_PAGING;
         paging.noSearch = false;
         this.zitiService.get('edge-routers', paging, filters).then((result: any) => {
@@ -118,15 +127,24 @@ export class ServiceEdgeRouterPolicyFormService {
             this.associatedServiceNames = [...namedAttributes];
             return;
         }
-        const filters = [
-            {
-                columnId: "roleAttributes",
-                filterName: "Service Attributes",
-                label: "",
-                type: "ATTRIBUTE",
-                value: roleAttributes
+        let hasAll = false;
+        roleAttributes.forEach((attr) => {
+            if (attr === 'all') {
+                hasAll = true;
             }
-        ];
+        });
+        let filters = [];
+        if (!hasAll) {
+            filters = [
+                {
+                    columnId: "roleAttributes",
+                    filterName: "Service Attributes",
+                    label: "",
+                    type: "ATTRIBUTE",
+                    value: roleAttributes
+                }
+            ];
+        }
         const paging = this.zitiService.DEFAULT_PAGING;
         paging.noSearch = false;
         this.zitiService.get('services', paging, filters).then((result: any) => {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.service.ts
@@ -123,24 +123,7 @@ export class ServicePolicyFormService {
             this.associatedServiceNames = [...namedAttributes];
             return;
         }
-        let hasAll = false;
-        roleAttributes.forEach((attr) => {
-            if (attr === 'all') {
-                hasAll = true;
-            }
-        });
-        let filters = [];
-        if (!hasAll) {
-            filters = [
-                {
-                    columnId: "roleAttributes",
-                    filterName: "Service Attributes",
-                    label: "",
-                    type: "ATTRIBUTE",
-                    value: roleAttributes
-                }
-            ];
-        }
+        const filters = this.zitiService.getRoleFilter(roleAttributes);
         const paging = this.zitiService.DEFAULT_PAGING;
         paging.noSearch = false;
         this.zitiService.get('services', paging, filters).then((result: any) => {
@@ -159,24 +142,7 @@ export class ServicePolicyFormService {
             this.associatedIdentityNames = [...namedAttributes];
             return;
         }
-        let hasAll = false;
-        roleAttributes.forEach((attr) => {
-            if (attr === 'all') {
-                hasAll = true;
-            }
-        });
-        let filters = [];
-        if (!hasAll) {
-            filters = [
-                {
-                    columnId: "roleAttributes",
-                    filterName: "Identity Attributes",
-                    label: "",
-                    type: "ATTRIBUTE",
-                    value: roleAttributes
-                }
-            ];
-        }
+        const filters = this.zitiService.getRoleFilter(roleAttributes);
         const paging = this.zitiService.DEFAULT_PAGING;
         paging.noSearch = false;
         this.zitiService.get('identities', paging, filters).then((result: any) => {
@@ -195,24 +161,7 @@ export class ServicePolicyFormService {
             this.associatedPostureCheckNames = [...namedAttributes];
             return;
         }
-        let hasAll = false;
-        roleAttributes.forEach((attr) => {
-            if (attr === 'all') {
-                hasAll = true;
-            }
-        });
-        let filters = [];
-        if (!hasAll) {
-            filters = [
-                {
-                    columnId: "roleAttributes",
-                    filterName: "Posture Check Attributes",
-                    label: "",
-                    type: "ATTRIBUTE",
-                    value: roleAttributes
-                }
-            ];
-        }
+        const filters = this.zitiService.getRoleFilter(roleAttributes);
         const paging = this.zitiService.DEFAULT_PAGING;
         paging.noSearch = false;
         this.zitiService.get('posture-checks', paging, filters).then((result: any) => {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.service.ts
@@ -123,15 +123,24 @@ export class ServicePolicyFormService {
             this.associatedServiceNames = [...namedAttributes];
             return;
         }
-        const filters = [
-            {
-                columnId: "roleAttributes",
-                filterName: "Service Attributes",
-                label: "",
-                type: "ATTRIBUTE",
-                value: roleAttributes
+        let hasAll = false;
+        roleAttributes.forEach((attr) => {
+            if (attr === 'all') {
+                hasAll = true;
             }
-        ];
+        });
+        let filters = [];
+        if (!hasAll) {
+            filters = [
+                {
+                    columnId: "roleAttributes",
+                    filterName: "Service Attributes",
+                    label: "",
+                    type: "ATTRIBUTE",
+                    value: roleAttributes
+                }
+            ];
+        }
         const paging = this.zitiService.DEFAULT_PAGING;
         paging.noSearch = false;
         this.zitiService.get('services', paging, filters).then((result: any) => {
@@ -150,15 +159,24 @@ export class ServicePolicyFormService {
             this.associatedIdentityNames = [...namedAttributes];
             return;
         }
-        const filters = [
-            {
-                columnId: "roleAttributes",
-                filterName: "Identity Attributes",
-                label: "",
-                type: "ATTRIBUTE",
-                value: roleAttributes
+        let hasAll = false;
+        roleAttributes.forEach((attr) => {
+            if (attr === 'all') {
+                hasAll = true;
             }
-        ];
+        });
+        let filters = [];
+        if (!hasAll) {
+            filters = [
+                {
+                    columnId: "roleAttributes",
+                    filterName: "Identity Attributes",
+                    label: "",
+                    type: "ATTRIBUTE",
+                    value: roleAttributes
+                }
+            ];
+        }
         const paging = this.zitiService.DEFAULT_PAGING;
         paging.noSearch = false;
         this.zitiService.get('identities', paging, filters).then((result: any) => {
@@ -177,15 +195,24 @@ export class ServicePolicyFormService {
             this.associatedPostureCheckNames = [...namedAttributes];
             return;
         }
-        const filters = [
-            {
-                columnId: "roleAttributes",
-                filterName: "Posture Check Attributes",
-                label: "",
-                type: "ATTRIBUTE",
-                value: roleAttributes
+        let hasAll = false;
+        roleAttributes.forEach((attr) => {
+            if (attr === 'all') {
+                hasAll = true;
             }
-        ];
+        });
+        let filters = [];
+        if (!hasAll) {
+            filters = [
+                {
+                    columnId: "roleAttributes",
+                    filterName: "Posture Check Attributes",
+                    label: "",
+                    type: "ATTRIBUTE",
+                    value: roleAttributes
+                }
+            ];
+        }
         const paging = this.zitiService.DEFAULT_PAGING;
         paging.noSearch = false;
         this.zitiService.get('posture-checks', paging, filters).then((result: any) => {

--- a/projects/ziti-console-lib/src/lib/services/ziti-data.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/ziti-data.service.ts
@@ -23,7 +23,7 @@ import {HttpClient} from "@angular/common/http";
 import {FilterObj} from "../features/data-table/data-table-filter.service";
 import { LoginServiceClass } from './login-service.class';
 
-import {cloneDeep} from "lodash";
+import {cloneDeep, isEmpty, sortedUniq} from "lodash";
 
 export const ZITI_DATA_SERVICE = new InjectionToken<ZitiDataService>('ZITI_DATA_SERVICE');
 
@@ -62,4 +62,26 @@ export abstract class ZitiDataService {
   abstract resetEnrollment(id: string, date: string): Promise<any>;
   abstract reissueEnrollment(id: string, date: string): Promise<any>;
   abstract schema(data: any): Promise<any>;
+
+  getRoleFilter(roleAttributes) {
+    let hasAll = false;
+    roleAttributes.forEach((attr) => {
+      if (attr === 'all') {
+        hasAll = true;
+      }
+    });
+    let filters = [];
+    if (!hasAll) {
+      filters = [
+        {
+          columnId: "roleAttributes",
+          filterName: "Attributes",
+          label: "",
+          type: "ATTRIBUTE",
+          value: roleAttributes
+        }
+      ];
+    }
+    return filters;
+  }
 }

--- a/projects/ziti-console-lib/src/lib/shared/list-page-service.class.ts
+++ b/projects/ziti-console-lib/src/lib/shared/list-page-service.class.ts
@@ -199,6 +199,6 @@ export abstract class ListPageServiceClass {
             itemId = '/create';
         }
         basePath = basePath ? basePath : this.basePath;
-        this.router?.navigateByUrl(`${basePath}${itemId}`);
+        this.router?.navigateByUrl(`${basePath}/${itemId}`);
     }
 }


### PR DESCRIPTION
closes #452 