### PR TITLE
fix for router hosted service link status(#487)

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.helper.ts
+++ b/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.helper.ts
@@ -263,12 +263,11 @@ export class IdentityServicePathHelper {
                 lnk.targetName = group4Nodes[k0].name;
                 lnk.weight = 1;
                 const foundNd = rootOb.nodes.find( function (rnd) {
-                   // if (rnd.id === group3Nodes[k1].id) {
-                        return rnd.id === group3Nodes[k1].id;
-                   // }
+                     return rnd.id === group3Nodes[k1].id;
                 });
+
                 if (foundNd.type.includes('Router')) {
-                    lnk.status = foundNd.status === 'PROVISIONED' && foundNd.online === 'Yes' ? 1 : 0;
+                    lnk.status =  foundNd.online === 'Yes' ? 1 : 0;
                 } else {
                     lnk.status = getServiceToEndpointLinkState(group3Nodes[k1], group4Nodes[k0]);
                     lnk.weight = getWeight(lnk.status);


### PR DESCRIPTION
The code fix for the link status issue for a link created between the service and router. 

The fix was tested in a simplified docker-compose network setup:
<img width="945" alt="image" src="https://github.com/user-attachments/assets/7068dbac-bfcf-42a3-b202-7c6d4432345d">
