### PR TITLE
Simple service form is limited to only 30 identities

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
@@ -182,7 +182,14 @@ export class SimpleServiceComponent extends ProjectableForm {
       sort: 'name',
       order: 'asc'
     };
-    this.zitiService.get('identities', paging, []).then((result) => {
+    const filterObj: FilterObj = {
+      filterName: 'name',
+      columnId: 'name',
+      value: filter || '%',
+      label: '',
+      type: 'TEXTINPUT',
+    };
+    this.zitiService.get('identities', paging, [filterObj]).then((result) => {
       const namedAttributes = result.data.map((identity) => {
         this.identitiesNameIdMap[identity.name] = identity.id;
         return identity.name;


### PR DESCRIPTION
* Enabled type ahead server-side filtering for tag selector
closes #492 