### PR TITLE
prune and ignore hard-coded lib version.ts file

### DIFF
--- a/docker-images/zac/Dockerfile
+++ b/docker-images/zac/Dockerfile
@@ -6,10 +6,8 @@ RUN npm install -g @angular/cli@16.0.0-next.0
 
 COPY package*.json ./
 COPY version.js ./
-COPY ./projects/ziti-console-lib/src/lib/version.ts ./projects/ziti-console-lib/src/lib/
-RUN npm install --omit=optional
-
 COPY . .
+RUN npm install --omit=optional
 RUN ng build ziti-console-lib
 RUN ng build ziti-console-node
 

--- a/docker-images/ziti-console-assets/Dockerfile
+++ b/docker-images/ziti-console-assets/Dockerfile
@@ -10,12 +10,8 @@ WORKDIR /usr/src/app
 
 RUN npm install -g @angular/cli@16.0.0-next.0
 
-COPY package*.json ./
-COPY version.js ./
-COPY ./projects/ziti-console-lib/src/lib/version.ts ./projects/ziti-console-lib/src/lib/
-RUN npm install --omit=optional
-
 COPY . .
+RUN npm install --omit=optional
 RUN ng build ziti-console-lib
 RUN ng build ziti-console --base-href ${BASE_HREF} --configuration "production"
 
@@ -26,4 +22,3 @@ WORKDIR /usr/src/app
 COPY --from=builder /usr/src/app/dist/app-ziti-console ./dist/app-ziti-console
 
 CMD ["echo", "deployment guide https://openziti.io/docs/guides/deployments/docker/console"]
-

--- a/projects/ziti-console-lib/src/lib/.gitignore
+++ b/projects/ziti-console-lib/src/lib/.gitignore
@@ -1,0 +1,1 @@
+/version.ts

--- a/projects/ziti-console-lib/src/lib/version.ts
+++ b/projects/ziti-console-lib/src/lib/version.ts
@@ -1,3 +1,0 @@
-export const VERSION = {
-    "version": "3.4.3"
-};


### PR DESCRIPTION
1. prune and ignore hard-coded lib version.ts file
1. reorder Dockerfile builds to use current version instead of hard-coded version.ts file