### PR TITLE
Fix filtering of configs based on config type when editing a service

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
@@ -186,7 +186,8 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
         label: this.svc.selectedConfigTypeId,
         filterName: 'Config Type',
         type: 'TEXTINPUT',
-        verb: '='
+        verb: '=',
+        rawFilter: true
       });
     }
     this.svc.getConfigs(filters,1);
@@ -213,7 +214,8 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
         label: this.svc.selectedConfigTypeId,
         filterName: 'Config Type',
         type: 'TEXTINPUT',
-        verb: '='
+        verb: '=',
+        rawFilter: true
       });
     }
     this.svc.getConfigs(filters,1);
@@ -234,7 +236,8 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
         label: this.svc.selectedConfigTypeId,
         filterName: 'Config Type',
         type: 'TEXTINPUT',
-        verb: '='
+        verb: '=',
+        rawFilter: true
       });
     }
     this.svc.getConfigs(filters,1).then(() => {

--- a/projects/ziti-console-lib/src/lib/services/node-data.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/node-data.service.ts
@@ -321,7 +321,11 @@ export class NodeDataService extends ZitiDataService {
             let filterVal = '';
             switch (filter.type) {
                 case 'TEXTINPUT':
-                    filterVal = `${filter.columnId} contains "${filter.value}"`;
+                    const verb = filter.verb ? filter.verb : 'contains';
+                    filterVal = `${filter.columnId} ${verb} "${filter.value}"`;
+                    if (filter.rawFilter) {
+                        paging.rawFilter = true;
+                    }
                     break;
                 case 'SELECT':
                 case 'COMBO':


### PR DESCRIPTION
Use the "raw filter" option, which allows filtering of data via columns other than the "name" column, when running ZAC via the node proxy server

closes #550 