### PR TITLE
Show login help text when entered controller URL is not reachable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "io.netfoundry.zac",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "io.netfoundry.zac",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -93,7 +93,7 @@
     },
     "dist/ziti-console-lib": {
       "name": "@openziti/ziti-console-lib",
-      "version": "0.0.0-watch+1733284524164",
+      "version": "0.0.0-watch+1734022433464",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/projects/app-ziti-console/src/app/login/controller-login.service.ts
+++ b/projects/app-ziti-console/src/app/login/controller-login.service.ts
@@ -109,7 +109,7 @@ export class ControllerLoginService extends LoginServiceClass {
                     }
                     this.settingsService.set(this.settingsService.settings)
                     this.growlerService.show(growlerData);
-                    throw({error: errorMessage});
+                    throw({error: errorMessage, controllerInvalid: err?.status === 0, statusText: err?.statusText});
                 })
             );
     }

--- a/projects/app-ziti-console/src/app/login/login.component.html
+++ b/projects/app-ziti-console/src/app/login/login.component.html
@@ -1,4 +1,4 @@
-<div class="loginForm" (keyup.enter)="next()">
+<div class="loginForm standard-form-fields" (keyup.enter)="next()">
     <div *ngIf="!isLoading">
         <div class="title">Ziti Admin Console</div>
         <div class="subtitle">Welcome, please login to continue</div>
@@ -6,10 +6,14 @@
         <ng-container *ngIf="edgeCreate; else userLogin">
             <lib-string-input [fieldName]="'Edge Controller Name'"
                         [(fieldValue)]="edgeName" [error]="edgeNameError"
-                        [placeholder]="'enter a name for your controller'"></lib-string-input>
+                        [placeholder]="'enter a name for your controller'"
+            ></lib-string-input>
             <lib-string-input [fieldName]="'URL'"
                         [(fieldValue)]="edgeUrl" [error]="edgeUrlError"
-                        [placeholder]="'e.g. http://10.0.0.1:1280'"></lib-string-input>
+                        [placeholder]="'e.g. http://10.0.0.1:1280'"
+                        [helpText]="helpText"
+                        [fieldClass]="controllerInvalid ? 'invalid' : ''"
+            ></lib-string-input>
             <div id="CreateArea" class="edgecreate buttons">
                 <div id="BackToLogin" *ngIf="edgeControllerList.length > 0" class="linkButton" (click)="reset()">Back To Login</div>
                 <button class="button" (click)="create()" [disabled]="!edgeName ||!edgeUrl">Set Controller</button>
@@ -24,6 +28,8 @@
                         [error]="edgeNameError"
                         [placeholder]="'Connect to a new Edge Controller'"
                         [valueList]="edgeControllerList"
+                        [helpText]="helpText"
+                        [fieldClass]="controllerInvalid ? 'invalid' : ''"
                         (fieldValueChange)="edgeChanged($event)"
             >
             </lib-selector-input>

--- a/projects/app-ziti-console/src/app/login/node-login.service.ts
+++ b/projects/app-ziti-console/src/app/login/node-login.service.ts
@@ -68,7 +68,8 @@ export class NodeLoginService extends LoginServiceClass {
             }),
             catchError((err: any) => {
                 const error = "Server Not Accessible";
-                if (err.code != "ECONNREFUSED") throw({error: err.code});
+                const controllerInvalid = err?.error && err?.error?.indexOf('Invalid Management Api') >= 0;
+                if (err.code != "ECONNREFUSED") throw({error: err.code, controllerInvalid: controllerInvalid});
                 throw({error: error});
             })
         );
@@ -96,6 +97,9 @@ export class NodeLoginService extends LoginServiceClass {
                 `Unable to login to selected edge controller`,
             );
             this.growlerService.show(growlerData);
+            const error = "Server Not Accessible";
+            const controllerUnreachable = body?.error?.indexOf('Invalid Management Api') >= 0;
+            throw({error: body?.error, controllerUnreachable: controllerUnreachable});
         }
         return of([body.success]);
     }

--- a/projects/app-ziti-console/src/app/services/node-settings.service.ts
+++ b/projects/app-ziti-console/src/app/services/node-settings.service.ts
@@ -102,7 +102,7 @@ export class NodeSettingsService extends SettingsServiceClass {
     override controllerSave(name, controllerURL) {
         const nodeServerURL = window.location.origin;
         const apiURL = nodeServerURL + '/api/controllerSave';
-        this.httpClient.post(
+        return this.httpClient.post(
             apiURL,
             { url: controllerURL, name: name },
             {
@@ -119,6 +119,7 @@ export class NodeSettingsService extends SettingsServiceClass {
                     result.error,
                 );
                 this.growlerService.show(growlerData);
+                return result;
             } else {
                 this.settings.selectedEdgeController = controllerURL;
                 this.settings.edgeControllers = result.edgeControllers;

--- a/projects/ziti-console-lib/package.json
+++ b/projects/ziti-console-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openziti/ziti-console-lib",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/openziti/ziti-console"

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/selector/selector-input.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/selector/selector-input.component.scss
@@ -4,6 +4,7 @@
   label {
     margin-bottom: 0px;
     margin-top: 0px;
+    width: fit-content;
   }
 
   input.error {
@@ -13,4 +14,11 @@
   div.error {
     color:red
   }
+}
+
+.label-container {
+  display: flex;
+  gap: 5px;
+  margin-bottom: 5px;
+  margin-top: 10px;
 }

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/string/string-input.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/string/string-input.component.scss
@@ -4,6 +4,7 @@
   label {
     margin-bottom: 0px;
     margin-top: 0px;
+    width: fit-content;
   }
 
   input.error {
@@ -13,4 +14,11 @@
   div.error {
     color:red
   }
+}
+
+.label-container {
+  display: flex;
+  gap: 5px;
+  margin-bottom: 5px;
+  margin-top: 10px;
 }

--- a/projects/ziti-console-lib/src/lib/features/dynamic-widgets/string/string-input.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/dynamic-widgets/string/string-input.component.ts
@@ -6,7 +6,16 @@ import {debounce} from "lodash";
   selector: 'lib-string-input',
   template: `
       <div [ngClass]="fieldClass + (!_isValid ? 'invalid' : '')" class="string-input-container">
-          <label for="schema_{{parentage?parentage+'_':''}}{{_idName}}"  [ngStyle]="{'color': labelColor}">{{_fieldName}}</label>
+          <div class="label-container">
+              <label for="schema_{{parentage?parentage+'_':''}}{{_idName}}"  [ngStyle]="{'color': labelColor}">{{_fieldName}}</label>
+              <div
+                  *ngIf="helpText"
+                  class="form-field-info infoicon"
+                  matTooltip="{{helpText}}"
+                  matTooltipPosition="above"
+                  matTooltipClass="wide-tooltip"
+              ></div>
+          </div>
           <input id="schema_{{parentage?parentage+'_':''}}{{_idName}}"
                  type="text" class="jsonEntry"
                  [ngClass]="{'error': error}"
@@ -23,6 +32,7 @@ export class StringInputComponent {
         this._fieldName = name;
         this._idName = name.replace(/\s/g, '').toLowerCase();
     }
+    @Input() helpText;
     @Input() fieldValue = '';
     @Input() placeholder = '';
     @Input() parentage: string[] = [];

--- a/projects/ziti-console-lib/src/lib/services/schema.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/schema.service.ts
@@ -426,8 +426,8 @@ export class SchemaService {
         const val = list?.length > 0 ? list[0] : '';
         let componentRef = view.createComponent(SelectorInputComponent);
         componentRef.setInput('fieldName', this.getLabel(key));
+        componentRef.setInput('placeholder', `select ${key}`);
         if (parentage && !_.isEmpty(parentage)) componentRef.setInput('parentage', parentage);
-        componentRef.setInput('fieldValue', val);
         componentRef.setInput('valueList', list);
         componentRef.setInput('labelColor', this.lColorArray[nestLevel]);
         return componentRef;

--- a/projects/ziti-console-lib/src/lib/services/settings-service.class.ts
+++ b/projects/ziti-console-lib/src/lib/services/settings-service.class.ts
@@ -135,7 +135,7 @@ export abstract class SettingsServiceClass {
         if (name.trim().length == 0 || url.trim().length == 0) {
             growler.error("Name and URL required");
         } else {
-            this.controllerSave(name, url);
+            return this.controllerSave(name, url);
         }
     }
 }

--- a/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
+++ b/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
@@ -120,6 +120,28 @@ input {
     flex-direction: row;
     flex-wrap: nowrap;
   }
+
+  .ag-cell-wrapper {
+    &.ag-checkbox-cell {
+      .ag-checkbox-input-wrapper {
+        display: none;
+        border-radius: 30px;
+        overflow: hidden;
+        &.ag-checked {
+          display: block;
+        }
+        &:after {
+          overflow: hidden;
+          color: var(--green);
+          font-size: 17px;
+          border-radius: 30px;
+        }
+        &.ag-disabled {
+          opacity: .8;
+        }
+      }
+    }
+  }
 }
 
 .header-text-container.text-input-filter {
@@ -193,6 +215,14 @@ input {
     }
   }
 }
+
+.wide-tooltip {
+  .mdc-tooltip__surface {
+    white-space: pre-line;
+    max-width: 300px;
+  }
+}
+
 
 .mat-mdc-dialog-container {
   .mat-mdc-dialog-surface {
@@ -1048,6 +1078,15 @@ lib-tag-selector {
 
   .form-field-title {
     color: var(--offWhite);
+  }
+}
+
+.loginForm {
+  .invalid {
+    select,
+    input {
+      border-color: var(--red) !important;
+    }
   }
 }
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,8 @@
+# ziti-console-lib-v0.6.5
+## Feature/Improvements
+* [Issue #568](https://github.com/openziti/ziti-console/issues/568) - Show login help text when entered controller URL is not reachable
+
+
 # app-ziti-console-v3.6.3
 # ziti-console-lib-v0.6.4
 ## Feature/Improvements

--- a/server.js
+++ b/server.js
@@ -594,7 +594,7 @@ app.post("/api/controllerSave", function(request, response) {
 			if (err) {
 				log("Add Controller Error");
 				log(err);
-				response.json( {error: "Edge Controller not Online", errorObj: err} );
+				response.json( {error: "Edge controller is not online, or is not reachable.", errorObj: err} );
 			} else {
 				try {
 					var results = JSON.parse(body);

--- a/server.js
+++ b/server.js
@@ -594,7 +594,7 @@ app.post("/api/controllerSave", function(request, response) {
 			if (err) {
 				log("Add Controller Error");
 				log(err);
-				response.json( {error: "Edge controller is not online, or is not reachable.", errorObj: err} );
+				response.json( {error: "Edge controller is not online or is not reachable.", errorObj: err} );
 			} else {
 				try {
 					var results = JSON.parse(body);


### PR DESCRIPTION
* When users attempt to login to a controller that is not reachable via the hosted ZAC location, show a help text icon indicating what the potential issue may be.

closes #568 

<img width="1983" alt="Screen Shot 2024-12-13 at 8 43 02 AM" src="https://github.com/user-attachments/assets/64ce5000-4cea-4b6e-a122-b27d4e65d88b" />
