### PR TITLE
"Create and attach" button label should just say "attach" when adding existing config to a service

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/config-editor/config-editor.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/config-editor/config-editor.component.ts
@@ -204,6 +204,7 @@ export class ConfigEditorComponent implements OnInit {
   }
 
   validateConfig(schema?, showGrowler = true) {
+    this.configData = this.removeUndefinedProperties(this.configData);
     let validationErrors;
     let valid = true;
     if (schema) {
@@ -301,5 +302,22 @@ export class ConfigEditorComponent implements OnInit {
       this.configDataChange.emit(this.configData);
       this.updateFormView(this.items, this.configData);
     });
+  }
+
+  removeUndefinedProperties(data) {
+    if (Array.isArray(data)) {
+      return data
+          .map(item => this.removeUndefinedProperties(item))
+          .filter(item => item !== undefined);
+    } else if (typeof data === 'object' && data !== null) {
+      // Handle objects
+      return Object.fromEntries(
+          Object.entries(data)
+              .filter(([_, value]) => value !== undefined)
+              .map(([key, value]) => [key, this.removeUndefinedProperties(value)])
+      );
+    }
+    // Return primitive values as is
+    return data;
   }
 }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.html
@@ -71,7 +71,7 @@
                                     [filter]="true"
                                     [showClear]="true"
                                     [disabled]="!svc.selectedConfigTypeId || svc.selectedConfigTypeId === ''"
-                                    (change)="configChanged($event)"
+                                    (onChange)="configChanged($event)"
                                     [(ngModel)]="svc.selectedConfigId"
                             >
                                 <ng-template pTemplate="filter" let-options="options">

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
@@ -538,6 +538,7 @@ export class ServiceFormService {
             //this.createForm(dynamicForm);
             this.saveDisabled = true;
         } else if (this.selectedConfigId) {
+            attachLabel = 'Attach to Service';
             this.filteredConfigs.forEach((config) => {
                 if (this.selectedConfigId === config.id) {
                     selectedConfig = config;


### PR DESCRIPTION
* Also fixes issue where "undefined" config properties are registering as invalid. Instead we should strip them from the model before validating