### PR TITLE
Refactor Dockerfile for improved clarity and consistency

### DIFF
--- a/docker-images/ziti-console-assets/Dockerfile
+++ b/docker-images/ziti-console-assets/Dockerfile
@@ -1,28 +1,33 @@
-# this Dockerfile builds openziti/ziti-console-assets
-
+# Use ARG for flexible Node.js version selection
 ARG NODE_VERSION=20
 
+# Builder Stage
 FROM node:${NODE_VERSION}-bookworm-slim AS builder
 
+# Set the base href for the application
 ARG BASE_HREF=/zac/
 
 WORKDIR /usr/src/app
 
+# Install Angular CLI
 RUN npm install -g @angular/cli@16.0.0-next.0
 
+# Copy project files into the container
 COPY . .
 
+# Use cache for node_modules and Angular build cache
 RUN --mount=type=cache,target=/usr/src/app/node_modules \
     --mount=type=cache,target=/usr/src/app/.angular/cache \
     npm install --omit=optional && \
     ng build ziti-console --base-href ${BASE_HREF} --configuration "production"
 
-ARG NODE_VERSION=${NODE_VERSION}
-
+# Final Stage
 FROM node:${NODE_VERSION}-bookworm-slim
 
 WORKDIR /usr/src/app
 
+# Copy the built Angular application from the builder stage
 COPY --from=builder /usr/src/app/dist/app-ziti-console ./dist/app-ziti-console
 
-CMD ["echo", "deployment guide https://openziti.io/docs/guides/deployments/docker/console"]
+# Default command for the container
+CMD ["echo", "Deployment guide: https://openziti.io/docs/guides/deployments/docker/console"]


### PR DESCRIPTION
This Dockerfile is now more organized and consistent, with clear comments for each step. It uses the NODE_VERSION argument in both stages to ensure version consistency and retains caching for faster builds. The command remains as a deployment guide, but can be replaced with the actual server start command when needed. This setup optimizes both the build and runtime stages for efficient Docker containerization.