### PR TITLE
Improve default behavior for JWT Signer "claims" property

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.html
@@ -52,7 +52,15 @@
                             {{ policy.name }}
                         </option>
                     </select>
-                    <input class="form-field-input" placeholder="Optional External ID" [(ngModel)]="formData.externalId"/>
+                    <div class="form-field-label-container" style="gap: var(--paddingMedium)">
+                        <div class="form-field-header">
+                            <div class="form-field-title-container">
+                                <span class="form-field-title">External ID</span>
+                            </div>
+                            <span class="form-field-label">OPTIONAL</span>
+                        </div>
+                        <input class="form-field-input" placeholder="Optional External ID" [(ngModel)]="formData.externalId"/>
+                    </div>
                 </lib-form-field-container>
                 <lib-form-field-toggle [(toggleOn)]="showMore" (toggleOnChange)="showMoreChanged($event)" style="margin: 0px 10px"></lib-form-field-toggle>
                 <div [hidden]="!showMore" class="form-group-column">

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/jwt-signer/jwt-signer-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/jwt-signer/jwt-signer-form.component.html
@@ -59,7 +59,7 @@
                                         matTooltipPosition="below"
                                 ></div>
                             </div>
-                            <input class="form-field-input" placeholder="Enter claims property" [(ngModel)]="formData.claimsProperty"/>
+                            <input class="form-field-input" placeholder="Enter claims property" [(ngModel)]="formData.claimsProperty" (keyup)="checkExternalIdToggle()" [ngClass]="{error: errors['claimsProperty']}"/>
                         </div>
                         <div class="form-field-label-container">
                             <div class="form-field-header">
@@ -91,52 +91,51 @@
                         </div>
                     </div>
                 </lib-form-field-container>
+                <lib-form-field-container
+                        [showHeader]="false"
+                >
+                    <div class="form-field-label-container">
+                        <div class="form-field-title-container">
+                            <span class="form-field-title">Client ID</span>
+                            <div
+                                    class="form-field-info infoicon"
+                                    matTooltip="The client id to use when authenticating to the IDP"
+                                    matTooltipPosition="below"
+                            ></div>
+                        </div>
+                        <input class="form-field-input" placeholder="Enter client ID" [(ngModel)]="formData.clientId"/>
+                    </div>
+                    <div class="form-field-label-container">
+                        <div class="form-field-title-container">
+                            <span class="form-field-title">External Auth Url</span>
+                            <div
+                                    class="form-field-info infoicon"
+                                    matTooltip="The URL that users are directed to, to obtain a JWT"
+                                    matTooltipPosition="below"
+                            ></div>
+                        </div>
+                        <input class="form-field-input" placeholder="Enter external auth URL" [(ngModel)]="formData.externalAuthUrl"/>
+                    </div>
+                    <div class="form-field-label-container">
+                        <div class="form-field-title-container">
+                            <span class="form-field-title">Scopes</span>
+                            <div
+                                    class="form-field-info infoicon"
+                                    matTooltip="Enter as a comma or space seperated list of claims/permissions"
+                                    matTooltipPosition="below"
+                            ></div>
+                        </div>
+                        <p-chips (keyup)="scopesOnKeyup($event)"
+                                 [(ngModel)]="formData.scopes"
+                                 [allowDuplicate]="false"
+                                 placeholder="Enter scopes"
+                                 [addOnBlur]="true"
+                                 separator=",">
+                        </p-chips>
+                    </div>
+                </lib-form-field-container>
                 <lib-form-field-toggle [(toggleOn)]="showMore" (toggleOnChange)="showMoreChanged($event)" style="margin: 0px 10px"></lib-form-field-toggle>
                 <div [hidden]="!showMore" class="form-group-column">
-                    <lib-form-field-container
-                            [showHeader]="false"
-                            class="form-field-advanced"
-                    >
-                        <div class="form-field-label-container">
-                            <div class="form-field-title-container">
-                                <span class="form-field-title">Client ID</span>
-                                <div
-                                        class="form-field-info infoicon"
-                                        matTooltip="The client id to use when authenticating to the IDP"
-                                        matTooltipPosition="below"
-                                ></div>
-                            </div>
-                            <input class="form-field-input" placeholder="Enter client ID" [(ngModel)]="formData.clientId"/>
-                        </div>
-                        <div class="form-field-label-container">
-                            <div class="form-field-title-container">
-                                <span class="form-field-title">External Auth Url</span>
-                                <div
-                                        class="form-field-info infoicon"
-                                        matTooltip="The URL that users are directed to, to obtain a JWT"
-                                        matTooltipPosition="below"
-                                ></div>
-                            </div>
-                            <input class="form-field-input" placeholder="Enter external auth URL" [(ngModel)]="formData.externalAuthUrl"/>
-                        </div>
-                        <div class="form-field-label-container">
-                            <div class="form-field-title-container">
-                                <span class="form-field-title">Scopes</span>
-                                <div
-                                        class="form-field-info infoicon"
-                                        matTooltip="Enter as a comma or space seperated list of claims/permissions"
-                                        matTooltipPosition="below"
-                                ></div>
-                            </div>
-                            <p-chips (keyup)="scopesOnKeyup($event)"
-                                     [(ngModel)]="formData.scopes"
-                                     [allowDuplicate]="false"
-                                     placeholder="Enter scopes"
-                                     [addOnBlur]="true"
-                                     separator=",">
-                            </p-chips>
-                        </div>
-                    </lib-form-field-container>
                     <lib-form-field-container
                             [title]="'Custom Tags'"
                             [label]="'OPTIONAL'"

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/jwt-signer/jwt-signer-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/jwt-signer/jwt-signer-form.component.ts
@@ -106,6 +106,14 @@ export class JwtSignerFormComponent extends ProjectableForm implements OnInit, O
         }
     }
 
+    checkExternalIdToggle() {
+        if (isEmpty(this.formData.claimsProperty)) {
+            this.formData.useExternalId = false;
+        } else {
+            this.formData.useExternalId = true;
+        }
+    }
+
     override clear() {
         this.formData.configTypeId = '';
         this.clearForm();
@@ -162,6 +170,10 @@ export class JwtSignerFormComponent extends ProjectableForm implements OnInit, O
             this.errors.certPem = true;
             this.errors.jwksEndpoint = true;
             labels.push('Cert PEM or JWKS Endpoint');
+        }
+        if (this.formData.useExternalId && isEmpty(this.formData.claimsProperty)) {
+            this.errors.claimsProperty = true;
+            labels.push('Claims Property');
         }
         if (!isEmpty(this.errors)) {
             let missingFields = labels.join(', ');
@@ -274,6 +286,9 @@ export class JwtSignerFormComponent extends ProjectableForm implements OnInit, O
 
     toggleUseExternalId() {
         this.formData.useExternalId = !this.formData.useExternalId;
+        if (!this.formData.useExternalId) {
+            this.errors.claimsProperty = false;
+        }
     }
 
     radioKeyDownHandler(event: any) {

--- a/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
+++ b/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
@@ -1248,6 +1248,7 @@ p-dropdown {
           background-position: center right 10px;
           background-repeat: no-repeat;
           background-size: 18px;
+          background-color: transparent;
           min-height: var(--defaultInputHeight);
           font-family: 'Open Sans', Arial, sans-serif;
           font-size: 14px;


### PR DESCRIPTION
* If saved without entering a value in the field, "claims" input should be 'red' with an error
* If anything is entered into claims, the toggle should toggle to "on". If deleted all the content it should toggle to 'off'
![jwt-signer](https://github.com/user-attachments/assets/86c8c2a0-ad01-4dcf-962a-761c096ef8d0)
