### PR TITLE
Specify a list of pre-defined edge controllers when running the node server

### DIFF
--- a/projects/app-ziti-console/src/app/login/controller-login.service.ts
+++ b/projects/app-ziti-console/src/app/login/controller-login.service.ts
@@ -47,6 +47,7 @@ export class ControllerLoginService extends LoginServiceClass {
     }
 
     checkOriginForController(): Promise<any> {
+        this.checkingControllerOrigin = true;
         const controllerUrl = window.location.origin;
         return this.settingsService.initApiVersions(controllerUrl).then((result) => {
             if (isNil(result) || isEmpty(result)) {
@@ -56,6 +57,8 @@ export class ControllerLoginService extends LoginServiceClass {
             }
         }).catch((result) => {
             return false;
+        }).finally(() => {
+            this.checkingControllerOrigin = false;
         });
     }
 

--- a/projects/app-ziti-console/src/app/login/login.component.html
+++ b/projects/app-ziti-console/src/app/login/login.component.html
@@ -15,11 +15,11 @@
         >
         </lib-selector-input>
         <div *ngIf="showNoControllers"class="no-controllers-warning">
-            <span><b>No Controllers Available</b></span>
+            <span class="warning-title"><b>No Controllers Available</b></span>
             <span>You must set at least one controller URL, prior to starting the ZAC node server</span>
             <span>Set an environment variable named <b class="env-var-text">ZAC_CONTROLLER_URLS</b> before starting the server</span>
-            <span>It must be a comma seperated list of 1 or more URLs. For Example:</span>
-            <code>ZAC_CONTROLLER_URLS=https://localhost:1280,https://somedomain.io:443</code>
+            <span>It must be a comma seperated list of 1 or more URLs.</span>
+            <code>ZAC_CONTROLLER_URLS=https://localhost:1280,https://example.domain.io:443</code>
         </div>
         <label for="Username" class="userlogin open" [ngClass]="{'login-disabled': showNoControllers}">Username</label>
         <input

--- a/projects/app-ziti-console/src/app/login/login.component.html
+++ b/projects/app-ziti-console/src/app/login/login.component.html
@@ -3,7 +3,7 @@
         <div class="title">Ziti Admin Console</div>
         <div class="subtitle">Welcome, please login to continue</div>
         <lib-selector-input
-            *ngIf="!svc.originIsController"
+            *ngIf="!svc.originIsController && !showNoControllers"
             [fieldName]="'Edge Controller'"
             [(fieldValue)]="selectedEdgeController"
             [error]="edgeNameError"
@@ -14,30 +14,39 @@
             (fieldValueChange)="edgeChanged($event)"
         >
         </lib-selector-input>
-        <label for="Username" class="userlogin open">Username</label>
+        <div *ngIf="showNoControllers"class="no-controllers-warning">
+            <span><b>No Controllers Available</b></span>
+            <span>You must set at least one controller URL, prior to starting the ZAC node server</span>
+            <span>Set an environment variable named <b class="env-var-text">ZAC_CONTROLLER_URLS</b> before starting the server</span>
+            <span>It must be a comma seperated list of 1 or more URLs. For Example:</span>
+            <code>ZAC_CONTROLLER_URLS=https://localhost:1280,https://somedomain.io:443</code>
+        </div>
+        <label for="Username" class="userlogin open" [ngClass]="{'login-disabled': showNoControllers}">Username</label>
         <input
             id="Username"
             name="username"
             type="text"
             autocomplete="on"
             required
+            [ngClass]="{'login-disabled': showNoControllers}"
             [placeholder]="'enter username of controller'"
             (change)="usernameChange($event)"
             (keyup)="usernameChange($event)"
         >
-        <label for="Password" class="userlogin open">Password</label>
+        <label for="Password" class="userlogin open" [ngClass]="{'login-disabled': showNoControllers}">Password</label>
         <input
             id="Password"
             name="password"
             type="password"
             autocomplete="on"
             required
+            [ngClass]="{'login-disabled': showNoControllers}"
             [placeholder]="'enter password of controller'"
             (change)="passwordChange($event)"
             (keyup)="passwordChange($event)"
         >
         <div class="buttons">
-            <button class="button" (click)="login()">Login</button>
+            <button class="button" (click)="login()" [ngClass]="{'login-disabled': showNoControllers}">Login</button>
         </div>
     </div>
 </div>

--- a/projects/app-ziti-console/src/app/login/login.component.html
+++ b/projects/app-ziti-console/src/app/login/login.component.html
@@ -18,7 +18,7 @@
             <span class="warning-title"><b>No Controllers Available</b></span>
             <span>You must set at least one controller URL, prior to starting the ZAC node server</span>
             <span>Set an environment variable named <b class="env-var-text">ZAC_CONTROLLER_URLS</b> before starting the server</span>
-            <span>It must be a comma seperated list of 1 or more URLs.</span>
+            <span>It must be a comma seperated list of 1 or more URLs. For Example:</span>
             <code>ZAC_CONTROLLER_URLS=https://localhost:1280,https://example.domain.io:443</code>
         </div>
         <label for="Username" class="userlogin open" [ngClass]="{'login-disabled': showNoControllers}">Username</label>

--- a/projects/app-ziti-console/src/app/login/login.component.html
+++ b/projects/app-ziti-console/src/app/login/login.component.html
@@ -2,63 +2,43 @@
     <div *ngIf="!isLoading">
         <div class="title">Ziti Admin Console</div>
         <div class="subtitle">Welcome, please login to continue</div>
-
-        <ng-container *ngIf="edgeCreate; else userLogin">
-            <lib-string-input [fieldName]="'Edge Controller Name'"
-                        [(fieldValue)]="edgeName" [error]="edgeNameError"
-                        [placeholder]="'enter a name for your controller'"
-            ></lib-string-input>
-            <lib-string-input [fieldName]="'URL'"
-                        [(fieldValue)]="edgeUrl" [error]="edgeUrlError"
-                        [placeholder]="'e.g. http://10.0.0.1:1280'"
-                        [helpText]="helpText"
-                        [fieldClass]="controllerInvalid ? 'invalid' : ''"
-            ></lib-string-input>
-            <div id="CreateArea" class="edgecreate buttons">
-                <div id="BackToLogin" *ngIf="edgeControllerList.length > 0" class="linkButton" (click)="reset()">Back To Login</div>
-                <button class="button" (click)="create()" [disabled]="!edgeName ||!edgeUrl">Set Controller</button>
-            </div>
-        </ng-container>
-
-        <ng-template #userLogin>
-                <lib-selector-input
-                    *ngIf="!svc.originIsController"
-                    [fieldName]="'Edge Controller'"
-                    [(fieldValue)]="selectedEdgeController"
-                    [error]="edgeNameError"
-                    [placeholder]="'Connect to a new Edge Controller'"
-                    [valueList]="edgeControllerList"
-                    [helpText]="helpText"
-                    [fieldClass]="controllerInvalid ? 'invalid' : ''"
-                    (fieldValueChange)="edgeChanged($event)"
-                >
-                </lib-selector-input>
-                <label for="Username" class="userlogin open">Username</label>
-                <input
-                    id="Username"
-                    name="username"
-                    type="text"
-                    autocomplete="on"
-                    required
-                    [placeholder]="'enter username of controller'"
-                    (change)="usernameChange($event)"
-                    (keyup)="usernameChange($event)"
-                >
-                <label for="Password" class="userlogin open">Password</label>
-                <input
-                    id="Password"
-                    name="password"
-                    type="password"
-                    autocomplete="on"
-                    required
-                    [placeholder]="'enter password of controller'"
-                    (change)="passwordChange($event)"
-                    (keyup)="passwordChange($event)"
-                >
-                <div class="buttons">
-                    <button class="button" (click)="login()">Login</button>
-                </div>
-        </ng-template>
+        <lib-selector-input
+            *ngIf="!svc.originIsController"
+            [fieldName]="'Edge Controller'"
+            [(fieldValue)]="selectedEdgeController"
+            [error]="edgeNameError"
+            [placeholder]="'Select an Edge Controller'"
+            [valueList]="edgeControllerList"
+            [helpText]="helpText"
+            [fieldClass]="controllerInvalid ? 'invalid' : ''"
+            (fieldValueChange)="edgeChanged($event)"
+        >
+        </lib-selector-input>
+        <label for="Username" class="userlogin open">Username</label>
+        <input
+            id="Username"
+            name="username"
+            type="text"
+            autocomplete="on"
+            required
+            [placeholder]="'enter username of controller'"
+            (change)="usernameChange($event)"
+            (keyup)="usernameChange($event)"
+        >
+        <label for="Password" class="userlogin open">Password</label>
+        <input
+            id="Password"
+            name="password"
+            type="password"
+            autocomplete="on"
+            required
+            [placeholder]="'enter password of controller'"
+            (change)="passwordChange($event)"
+            (keyup)="passwordChange($event)"
+        >
+        <div class="buttons">
+            <button class="button" (click)="login()">Login</button>
+        </div>
     </div>
 </div>
 <lib-loading-indicator *ngIf="isLoading" [isLoading]="isLoading"></lib-loading-indicator>

--- a/projects/app-ziti-console/src/app/login/login.component.scss
+++ b/projects/app-ziti-console/src/app/login/login.component.scss
@@ -24,3 +24,41 @@ select {
 select, input {
   max-width: 37.5rem;
 }
+
+.no-controllers-warning {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gapSmall);
+  background-color: var(--lightRed);
+  border-radius: 6.4px;
+  border-left-color: var(--red);
+  border-left-style: solid;
+  border-left-width: 5px;
+  box-shadow: rgba(0, 0, 0, 0.2) 0px 10px 10px 0px;
+  box-sizing: border-box;
+  color: var(--tableText);
+  font-family: sans-serif;
+  font-weight: 400;
+  margin-top: var(--marginXL);
+  margin-bottom: var(--marginXL);
+  padding: var(--paddingXL);
+  text-rendering: optimizelegibility;
+  width: fit-content;
+  height: fit-content;
+
+  .env-var-text {
+    color: var(--tableText);
+  }
+
+  code {
+    color: var(--tableText);
+    background-color: var(--stroke);
+    padding: var(--paddingSmall);
+    border-radius: .2rem;
+  }
+}
+
+.login-disabled {
+  opacity: .5;
+  pointer-events: none;
+}

--- a/projects/app-ziti-console/src/app/login/login.component.scss
+++ b/projects/app-ziti-console/src/app/login/login.component.scss
@@ -43,8 +43,13 @@ select, input {
   margin-bottom: var(--marginXL);
   padding: var(--paddingXL);
   text-rendering: optimizelegibility;
+  min-width: 37.5rem;
   width: fit-content;
   height: fit-content;
+
+  .warning-title {
+    font-size: 1rem;
+  }
 
   .env-var-text {
     color: var(--tableText);
@@ -55,6 +60,7 @@ select, input {
     background-color: var(--stroke);
     padding: var(--paddingSmall);
     border-radius: .2rem;
+    width: fit-content;
   }
 }
 

--- a/projects/app-ziti-console/src/app/login/login.component.ts
+++ b/projects/app-ziti-console/src/app/login/login.component.ts
@@ -34,7 +34,6 @@ export class LoginComponent implements OnInit, OnDestroy {
     password = '';
     edgeName: string = '';
     edgeUrl: string = '';
-    edgeCreate = false;
     userLogin = false;
     selectedEdgeController: any;
     controllerHostname = '';
@@ -55,6 +54,8 @@ export class LoginComponent implements OnInit, OnDestroy {
     ngOnInit() {
         if (this.svc.originIsController !== false && this.svc.originIsController !== true) {
             this.checkOriginForController();
+        } else {
+            this.initSettings();
         }
         if (this.settingsService.hasSession()) {
             this.router.navigate(['/dashboard']);
@@ -71,7 +72,6 @@ export class LoginComponent implements OnInit, OnDestroy {
             this.svc.originIsController = result;
             if (this.svc.originIsController) {
                 this.svc.originIsController = true;
-                this.edgeCreate = false;
                 this.selectedEdgeController = window.location.origin;
                 this.controllerHostname = window.location.hostname;
                 this.settingsService.addContoller(this.controllerHostname, this.selectedEdgeController);
@@ -119,11 +119,7 @@ export class LoginComponent implements OnInit, OnDestroy {
         }
     }
     next() {
-        if (this.edgeCreate) {
-            this.create();
-        } else {
-            this.login();
-        }
+        this.login();
     }
 
     create() {
@@ -150,7 +146,6 @@ export class LoginComponent implements OnInit, OnDestroy {
     reset() {
         this.edgeNameError = '';
         this.edgeUrlError = '';
-        this.edgeCreate = false;
         this.userLogin = true;
     }
 
@@ -160,12 +155,8 @@ export class LoginComponent implements OnInit, OnDestroy {
         if (this.selectedEdgeController) {
             this.edgeName = ''
             this.edgeUrl = ''
-            this.edgeCreate = false;
             this.userLogin = true;
             this.settingsService.initApiVersions(this.selectedEdgeController)
-        } else {
-            this.edgeCreate = true;
-            this.userLogin = false;
         }
         this.settingsService.settings.selectedEdgeController = this.selectedEdgeController;
     }
@@ -183,7 +174,6 @@ export class LoginComponent implements OnInit, OnDestroy {
             });
             this.reset();
         } else {
-            this.edgeCreate = true;
             this.userLogin = false;
         }
         const serviceUrl = localStorage.getItem("ziti-serviceUrl-value");

--- a/projects/app-ziti-console/src/app/login/login.component.ts
+++ b/projects/app-ziti-console/src/app/login/login.component.ts
@@ -201,4 +201,8 @@ export class LoginComponent implements OnInit, OnDestroy {
     passwordChange(event) {
         this.password = event.currentTarget.value;
     }
+
+    get showNoControllers() {
+        return this.edgeControllerList.length===0 && !this.svc.originIsController && !this.svc.checkingControllerOrigin
+    }
 }

--- a/projects/ziti-console-lib/src/lib/services/login-service.class.ts
+++ b/projects/ziti-console-lib/src/lib/services/login-service.class.ts
@@ -11,6 +11,7 @@ export const ZAC_LOGIN_SERVICE = new InjectionToken<any>('ZAC_LOGIN_SERVICE');
 
 export abstract class LoginServiceClass {
 
+    public checkingControllerOrigin = false;
     public originIsController;
     public loginDialogOpen = false;
     public isCertBasedAuth = false;

--- a/server.js
+++ b/server.js
@@ -619,12 +619,8 @@ app.post("/api/settings", function(rewwquest, response) {
  */
 app.post("/api/controllerSave", function(request, response) {
 	var name = request.body.name.trim().replace(/[^a-zA-Z0-9 \-]/g, '');
-	var url = request.body.url.trim();
-	url = url.split('#').join('').split('?').join('');
-	if (url.endsWith('/')) url = url.substr(0, url.length-1);
 	var errors = [];
 	if (name.length==0) errors[errors.length] = "name";
-	if (url.length==0) errors[errors.length] = "url";
 	if (errors.length>0) {
 		response.json({ errors: errors });
 	} else {
@@ -634,18 +630,11 @@ app.post("/api/controllerSave", function(request, response) {
 			if (settings.edgeControllers[i].url==url) {
 				found = true;
 				settings.edgeControllers[i].name = name;
-				settings.edgeControllers[i].url = url;
 				break;
 			}
 		}
 		if (!found) {
-			var isDefault = false;
-			if (settings.edgeControllers.length==0) isDefault = true;
-			settings.edgeControllers[settings.edgeControllers.length] = {
-				name: name,
-				url: url,
-				default: isDefault
-			};
+			log("Controller not found in pre-defined list. Ignoring..: "+request.body);
 		}
 		fs.writeFileSync(__dirname+settingsPath+'/settings.json', JSON.stringify(settings));
 		response.json({edgeControllers: settings.edgeControllers});

--- a/server.js
+++ b/server.js
@@ -57,22 +57,20 @@ const processControllerUrls = (urlString) => {
 	}
 	const urls = urlString.split(',').map(url => url.trim());
 	const validUrls = urls.map(url => {
-		// If the URL doesn't have a protocol, prepend 'https://'
+		// If the controller URL doesn't have a protocol, prepend 'https://'
 		if (!/^https?:\/\//i.test(url)) {
 			url = 'https://' + url;
 		}
 		try {
-			// Validate the URL using the URL constructor
 			const validatedUrl = new URL(url);
 			const ctrlUrl = validatedUrl.toString().replace(/\/$/, '');
 			const setting = { name: ctrlUrl, url: ctrlUrl, default: false };
-			return setting; // Return the fully qualified URL (including the protocol)
+			return setting;
 		} catch (error) {
-			// If URL is invalid, log an error and return null or handle as needed
-			console.error(`Invalid URL: ${url}`);
+			log(`Invalid URL: ${url}`);
 			return null;
 		}
-	}).filter(Boolean) || []; // Remove any null values (invalid URLs)
+	}).filter(Boolean) || [];
 	return validUrls;
 };
 


### PR DESCRIPTION
Require available edge controllers to be pre-defined using environment variable `ZAC_CONTROLLER_URLS`

Removed the option to add controller url via the console/node API

closes #625 