### PR TITLE
Release 3.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io.netfoundry.zac",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "Ziti Administration Console",
   "main": "server.js",
   "type": "module",

--- a/projects/ziti-console-lib/package.json
+++ b/projects/ziti-console-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openziti/ziti-console-lib",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/openziti/ziti-console"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,19 @@
+# app-ziti-console-v3.8.3
+# ziti-console-lib-v0.8.3
+## Bug Fixes
+* [Issue #625](https://github.com/openziti/ziti-console/issues/625) - Specify a list of pre-defined edge controllers when running the node server
+* [Issue #624](https://github.com/openziti/ziti-console/issues/624) - Remove file upload utility and node service
+
+# Notes:
+* This release will require all users deploying ZAC via the NodeJS server to specify a pre-defined list of ziti edge controller URL's in order to connect to a controller
+* To do this, users must define an environment variable called ZAC_CONTROLLER_URLS. For example:
+* It must be a comma seperated list of URLS. For example:
+*
+* On Mac/Linux: `export ZAC_CONTROLLER_URLS=https://localhost:1280,https://example.domain.io:443`
+* 
+* On Windows: `set ZAC_CONTROLLER_URLS=https://localhost:1280,https://example.domain.io:443`
+
+
 # app-ziti-console-v3.8.0
 # ziti-console-lib-v0.8.2
 ## Feature/Improvements

--- a/release-notes.md
+++ b/release-notes.md
@@ -5,13 +5,13 @@
 * [Issue #624](https://github.com/openziti/ziti-console/issues/624) - Remove file upload utility and node service
 
 # Notes:
-* This release will require all users deploying ZAC via the NodeJS server to specify a pre-defined list of ziti edge controller URL's in order to connect to a controller
-* To do this, users must define an environment variable called ZAC_CONTROLLER_URLS. For example:
-* It must be a comma seperated list of URLS. For example:
-*
-* On Mac/Linux: `export ZAC_CONTROLLER_URLS=https://localhost:1280,https://example.domain.io:443`
-* 
-* On Windows: `set ZAC_CONTROLLER_URLS=https://localhost:1280,https://example.domain.io:443`
+This release will require all users deploying ZAC via the NodeJS server to specify a pre-defined list of ziti edge controller URL's in order to connect to a controller. To do this, users must define an environment variable called ZAC_CONTROLLER_URLS. It must be a comma seperated list of URLS. For example:
+
+On Mac/Linux:
+`export ZAC_CONTROLLER_URLS=https://localhost:1280,https://example.domain.io:443`
+
+On Windows:
+`set ZAC_CONTROLLER_URLS=https://localhost:1280,https://example.domain.io:443`
 
 
 # app-ziti-console-v3.8.0


### PR DESCRIPTION
## Bug Fixes
* [Issue #625](https://github.com/openziti/ziti-console/issues/625) - Specify a list of pre-defined edge controllers when running the node server
* [Issue #624](https://github.com/openziti/ziti-console/issues/624) - Remove file upload utility and node service

# Notes:
This release will require all users deploying ZAC via the NodeJS server to specify a pre-defined list of ziti edge controller URL's in order to connect to a controller. To do this, users must define an environment variable called ZAC_CONTROLLER_URLS. It must be a comma seperated list of URLS. For example:

  On Mac/Linux:
    `export ZAC_CONTROLLER_URLS=https://localhost:1280,https://example.domain.io:443`

  On Windows:
    `set ZAC_CONTROLLER_URLS=https://localhost:1280,https://example.domain.io:443`