### PR TITLE
visualizer to depend on router connection status. not on apisession state.

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.helper.ts
+++ b/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.helper.ts
@@ -324,8 +324,9 @@ export class IdentityServicePathHelper {
             node.id = ePoint.id;
             node.name = ePoint.name;
             node.type = 'Identity';
-            node.apiSession = ePoint.hasApiSession === false ? 'No' : 'Yes';
+           // node.apiSession = ePoint.hasApiSession === false ? 'No' : 'Yes';
             node.routerConnection = ePoint.hasEdgeRouterConnection === false ? 'No' : 'Yes';
+            node.apiSession = node.routerConnection;
             node.os = ePoint.envInfo? ePoint.envInfo.os : '';
             node.mfaEnabled = ePoint.isMfaEnabled;
             node.status = ePoint.envInfo && ePoint.envInfo.os !== null ? 'Registered' : 'Un-Registered';
@@ -363,8 +364,8 @@ export class IdentityServicePathHelper {
                 linkstate = 0;
             } else if (endpointNode.status === 'Un-Registered') {
                 linkstate = -1;
-            } else if (endpointNode.apiSession === 'No') {
-                linkstate = 0;
+         //   } else if (endpointNode.apiSession === 'No') {
+          //      linkstate = 0;
             } else if (endpointNode.routerConnection === 'No') {
                 linkstate = -1;
             } else if (routerNode.online === 'Yes' && endpointNode.routerConnection === 'Yes') {
@@ -381,7 +382,7 @@ export class IdentityServicePathHelper {
                 linkstate = -1;
             } else if (endpointNode.apiSession === 'No') {
                 linkstate = 0;
-            } else if (endpointNode.status === 'Registered' && endpointNode.apiSession === 'Yes') {
+            } else if (endpointNode.status === 'Registered' && endpointNode.routerConnection === 'Yes') {
                 linkstate = 1;
             } else {
                 linkstate = 0;


### PR DESCRIPTION
previous:  The identity will determine the apiSession, router connection status to form the link between the identity and the router. 
New change: In HA setup, the identity determines the only router connection status to form links between the identity and the router.   So, we can find all links in the green state.

Errored links in Visualizer before Code Fix:
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/fb7b7b80-2d76-4f47-a854-b7683c377f11" />






Visualizer after code fix:

<img width="1259" alt="image" src="https://github.com/user-attachments/assets/23da2fd4-a166-48ed-a5d0-515761604720" />

