### PR TITLE
Update inital data model when editing a simple service

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
@@ -218,6 +218,11 @@ export class SimpleServiceComponent extends ProjectableForm {
         const policiesPromise = this.getAssocaitedPolicies();
         Promise.all([configsPromise, policiesPromise]).finally(() => {
           this.dataInit = true;
+          this.initServiceApiData = cloneDeep(this.serviceApiData);
+          this.initInterceptConfigApiData = cloneDeep(this.interceptConfigApiData);
+          this.initHostConfigApiData = cloneDeep(this.hostConfigApiData);
+          this.initDialPolicyApiData = cloneDeep(this.dialPolicyApiData);
+          this.initBindPolicyApiData = cloneDeep(this.bindPolicyApiData);
         });
       }
     });


### PR DESCRIPTION
This will prevent the "Page has changes" warning from displaying incorrectly

relates to #717