### PR TITLE
Fix services showing up in the "Associated Identities" section of Service Policy details page

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.service.ts
@@ -125,7 +125,7 @@ export class ServicePolicyFormService {
             this.associatedServiceNames = [...this.associatedServiceNames, ...namedAttributes];
             this.associatedServiceNames = sortBy(this.associatedServiceNames);
             this.associatedServiceNames = sortedUniq(this.associatedServiceNames);
-            this.associatedIdentityNames = this.associatedServiceNames.filter(item => item !== undefined);
+            this.associatedServiceNames = this.associatedServiceNames.filter(item => item !== undefined);
             return this.associatedServices;
         });
     }

--- a/projects/ziti-console-lib/src/lib/pages/auth-policies/auth-policies-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/auth-policies/auth-policies-page.service.ts
@@ -86,7 +86,7 @@ export class AuthPoliciesPageService extends ListPageServiceClass {
                 cellRenderer: TableCellNameComponent,
                 cellRendererParams: { pathRoot: this.basePath, cellNamePreCheck: (data) => {
                     this.checkDefaultAuthPolicy(data).then((result) => {
-                        if (!result) {
+                        if (!result?.confirmed) {
                             return;
                         }
                         this.openEditForm(data?.id);
@@ -97,7 +97,7 @@ export class AuthPoliciesPageService extends ListPageServiceClass {
                         return;
                     }
                     this.checkDefaultAuthPolicy(data?.data).then((result: any) => {
-                        if (!result) {
+                        if (!result?.confirmed) {
                             return;
                         }
                         this.openEditForm(data?.data?.id);


### PR DESCRIPTION

* Also fixed issue with default auth policy warning not preventing opening of edit page when cancel action is performed

closes #745