### PR TITLE
Release 4.1.0: Need to use "partial" compilation mode when publishing the shared library with angular 20

### DIFF
--- a/projects/ziti-console-lib/tsconfig.lib.json
+++ b/projects/ziti-console-lib/tsconfig.lib.json
@@ -10,7 +10,7 @@
     "esModuleInterop": true
   },
   "angularCompilerOptions": {
-    "compilationMode": "full"
+    "compilationMode": "partial"
   },
   "exclude": [
     "**/*.spec.ts"

--- a/projects/ziti-console-lib/tsconfig.lib.prod.json
+++ b/projects/ziti-console-lib/tsconfig.lib.prod.json
@@ -6,6 +6,6 @@
     "esModuleInterop": true
   },
   "angularCompilerOptions": {
-    "compilationMode": "full"
+    "compilationMode": "partial"
   }
 }


### PR DESCRIPTION

  - Full mode: Library is fully compiled - good for applications but not for publishable libraries
  - Partial mode: Library is partially compiled - allows consuming applications to complete the compilation with their own Angular version