### PR TITLE
Allow for two-way async events

### DIFF
--- a/projects/app-ziti-console/src/app/examples/extension-service/example-extension.service.ts
+++ b/projects/app-ziti-console/src/app/examples/extension-service/example-extension.service.ts
@@ -13,8 +13,18 @@ export class ExampleExtensionService implements ExtensionService {
     ]
     closeAfterSave: boolean;
     closed: EventEmitter<any>;
-    extensionEvent: EventEmitter<ExtensionEvent> = new EventEmitter<ExtensionEvent>();
     formDataChanged: BehaviorSubject<any>;
+
+    async emitEvent<TData, TResult>(event: ExtensionEvent<TData, TResult>): Promise<TResult | undefined> {
+        // Handle extension events here. Example:
+        // switch (event.type) {
+        //   case 'tableDataUpdated':
+        //     return await this.processTableData(event.data) as TResult;
+        //   default:
+        //     return undefined;
+        // }
+        return undefined;
+    }
 
     extendOnInit(): void {
     }

--- a/projects/ziti-console-lib/src/lib/features/extendable/extensions-noop.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/extendable/extensions-noop.service.ts
@@ -29,23 +29,17 @@ export type ExtensionEventType =
 export interface ExtensionEvent<TData = any, TResult = any> {
   type: ExtensionEventType;
   data?: TData;
-  result?: TResult;
-  /**
-   * If set by a subscriber, callers can `await` this
-   * to get an async result (e.g. table preprocessing).
-   */
-  waitFor?: Promise<TResult>;
 }
 
 export interface ExtensionService {
   formDataChanged: BehaviorSubject<any>;
   closed: EventEmitter<any>;
-  extensionEvent?: EventEmitter<ExtensionEvent>;
   closeAfterSave: boolean;
   moreActions?: any[];
   listActions?: any[];
   consoleActionTriggered?: EventEmitter<any>;
   disabledComponents?: any[];
+  emitEvent?<TData, TResult>(event: ExtensionEvent<TData, TResult>): Promise<TResult | undefined>;
   extendOnInit(): void;
   extendAfterViewInits(extentionPoints: any): void;
   updateFormData(data: any): void;
@@ -62,12 +56,15 @@ export class ExtensionsNoopService implements ExtensionService {
   formDataChanged = new BehaviorSubject<any>({isEmpty: true});
   closed: EventEmitter<any> = new EventEmitter<any>();
   consoleActionTriggered: EventEmitter<any> = new EventEmitter<any>();
-  extensionEvent: EventEmitter<ExtensionEvent> = new EventEmitter<ExtensionEvent>();
   closeAfterSave = true;
   moreActions = [];
   disabledComponents = [];
 
   constructor() { }
+
+  async emitEvent<TData, TResult>(event: ExtensionEvent<TData, TResult>): Promise<TResult | undefined> {
+    return undefined;
+  }
 
   extendOnInit(): void {
   }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
@@ -207,7 +207,7 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
 
   roleAttributesChanged(roleAttributes: any[]) {
     this.formData.roleAttributes = roleAttributes;
-    this.extService.extensionEvent?.emit({
+    this.extService.emitEvent?.({
       type: 'attributesChanged',
       data: {
         entityType: 'identity',

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.component.ts
@@ -184,7 +184,7 @@ export class ServicePolicyFormComponent extends ProjectableForm implements OnIni
   }
 
   emitConflictInputChange(): void {
-    this.extService.extensionEvent?.emit({
+    this.extService.emitEvent?.({
       type: 'conflictInputChanged',
       data: {
         entityType: 'service-policy',

--- a/projects/ziti-console-lib/src/lib/pages/identities/identities-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/identities/identities-page.service.ts
@@ -374,20 +374,14 @@ export class IdentitiesPageService extends ListPageServiceClass {
             //pre-process data before rendering
             results.data = this.addActionsPerRow(results);
         }
-        if (this.extService?.extensionEvent) {
-            const event: any = {
-                type: 'tableDataUpdated',
-                data: {
-                    resourceType: this.resourceType,
-                    results,
-                },
-            };
-            this.extService.extensionEvent.emit(event);
+        if (this.extService?.emitEvent) {
             try {
-                if (event?.waitFor) {
-                    results = await event.waitFor;
-                } else if (event?.result !== undefined) {
-                    results = event.result;
+                const transformed = await this.extService.emitEvent({
+                    type: 'tableDataUpdated',
+                    data: { resourceType: this.resourceType, results },
+                });
+                if (transformed !== undefined) {
+                    results = transformed;
                 }
             } catch (_e) {
                 // keep original results on extension failure

--- a/projects/ziti-console-lib/src/lib/pages/service-policies/service-policies-page.service.ts
+++ b/projects/ziti-console-lib/src/lib/pages/service-policies/service-policies-page.service.ts
@@ -394,20 +394,14 @@ export class ServicePoliciesPageService extends ListPageServiceClass {
             //pre-process data before rendering
             results.data = this.addActionsPerRow(results);
         }
-        if (this.extService?.extensionEvent) {
-            const event: any = {
-                type: 'tableDataUpdated',
-                data: {
-                    resourceType: this.resourceType,
-                    results,
-                },
-            };
-            this.extService.extensionEvent.emit(event);
+        if (this.extService?.emitEvent) {
             try {
-                if (event?.waitFor) {
-                    results = await event.waitFor;
-                } else if (event?.result !== undefined) {
-                    results = event.result;
+                const transformed = await this.extService.emitEvent({
+                    type: 'tableDataUpdated',
+                    data: { resourceType: this.resourceType, results },
+                });
+                if (transformed !== undefined) {
+                    results = transformed;
                 }
             } catch (_e) {
                 // keep original results on extension failure


### PR DESCRIPTION
@vickynf This should allow ZAC and any extending applications to communicate with each other using the same shared event service.

Then, in the related PR in the extending application, you can change the "waitFor" logic from this:

```
this.extensionEvent.subscribe((event: any) => {
    if (event?.type !== 'tableDataUpdated') {
      return;
    }
    if (event?.data?.resourceType !== 'identities') {
      return;
    }
    event.waitFor = this.processIdentityTableData(event?.data?.results);
  });
```


to this:

```
async emitEvent<TData, TResult>(event: ExtensionEvent<TData, TResult>): Promise<TResult | undefined> {                                                                                                                                            
    if (event.type === 'tableDataUpdated' && event.data?.resourceType === 'identities') {                                                                                                                                                           
      return await this.processIdentityTableData(event.data.results) as TResult;                                                                                                                                                                    
    }                                                                                                                                                                                                                                               
    return undefined;                                       
  }
```