### PR TITLE
Enhance readonly functionality across components

### DIFF
--- a/projects/app-ziti-console/src/app/app.module.ts
+++ b/projects/app-ziti-console/src/app/app.module.ts
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-import {NgModule, APP_INITIALIZER} from '@angular/core';
+import {Injector, NgModule, APP_INITIALIZER} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 
 import {AppComponent} from './app.component';
@@ -50,7 +50,8 @@ import {
     SERVICE_POLICY_EXTENSION_SERVICE,
     EDGE_ROUTER_POLICY_EXTENSION_SERVICE,
     SERVICE_EDGE_ROUTER_POLICY_EXTENSION_SERVICE,
-    DEFAULT_APP_CONFIG
+    DEFAULT_APP_CONFIG,
+    ManagementPermissionsService,
 } from "ziti-console-lib";
 
 import {AppRoutingModule} from "./app-routing.module";
@@ -83,9 +84,15 @@ if (environment.nodeIntegration) {
     apiInterceptor = ZitiApiInterceptor;
 }
 
-// Factory function to initialize settings service before app starts
-export function initializeApp(settingsService: any) {
-    return () => settingsService.init();
+/**
+ * Load persisted settings, then construct ManagementPermissionsService so it subscribes to
+ * settings and fetches current-identity on cold start (not only when a list/form page loads).
+ */
+export function initializeApp(settingsService: any, injector: Injector) {
+    return () =>
+        settingsService.init().then(() => {
+            injector.get(ManagementPermissionsService);
+        });
 }
 
 @NgModule({ declarations: [
@@ -106,7 +113,7 @@ export function initializeApp(settingsService: any) {
         {
             provide: APP_INITIALIZER,
             useFactory: initializeApp,
-            deps: [SETTINGS_SERVICE],
+            deps: [SETTINGS_SERVICE, Injector],
             multi: true
         },
         { provide: ZITI_DOMAIN_CONTROLLER, useClass: SimpleZitiDomainControllerService },

--- a/projects/ziti-console-lib/src/lib/features/chips-input/chips-input.component.html
+++ b/projects/ziti-console-lib/src/lib/features/chips-input/chips-input.component.html
@@ -1,38 +1,42 @@
 <div
   class="p-inputtext p-chips-multiple-container"
-  [class.p-focus]="focused"
+  [class.p-focus]="focused && !disabled"
   [class.error]="invalid"
   (click)="focusInput()"
   >
   @for (chip of value; track chip; let i = $index) {
-    <div class="p-chips-token">
+    <div class="p-chips-token" [class.p-chips-token-readonly]="disabled">
       <span class="p-chips-token-label">{{ chip }}</span>
-      <span
-        class="p-chips-token-icon"
-        role="button"
-        tabindex="0"
-        aria-label="Remove"
-        (click)="removeAtIndex(i, $event)"
-        (keydown.enter)="removeAtIndex(i, $event)"
-        (keydown.space)="removeAtIndex(i, $event)"
-        >
-        ×
-      </span>
+      @if (!disabled) {
+        <span
+          class="p-chips-token-icon"
+          role="button"
+          tabindex="0"
+          aria-label="Remove"
+          (click)="removeAtIndex(i, $event)"
+          (keydown.enter)="removeAtIndex(i, $event)"
+          (keydown.space)="removeAtIndex(i, $event)"
+          >
+          ×
+        </span>
+      }
     </div>
   }
 
-  <div class="p-chips-input-token">
-    <input
-      #chipInput
-      type="text"
-      [attr.id]="inputId || null"
-      [disabled]="disabled"
-      [placeholder]="placeholder"
-      (keydown)="onKeydown($event)"
-      (paste)="onPaste($event)"
-      (focus)="onFocus()"
-      (blur)="handleBlur($event)"
-      (keyup)="keyup.emit($event)"
-      />
-  </div>
+  @if (!disabled) {
+    <div class="p-chips-input-token">
+      <input
+        #chipInput
+        type="text"
+        [attr.id]="inputId || null"
+        [disabled]="disabled"
+        [placeholder]="placeholder"
+        (keydown)="onKeydown($event)"
+        (paste)="onPaste($event)"
+        (focus)="onFocus()"
+        (blur)="handleBlur($event)"
+        (keyup)="keyup.emit($event)"
+        />
+    </div>
+  }
 </div>

--- a/projects/ziti-console-lib/src/lib/features/chips-input/chips-input.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/chips-input/chips-input.component.scss
@@ -37,6 +37,23 @@
   background-color: var(--lightRed, #fee2e2) !important;
 }
 
+:host(.chips-input-disabled) {
+  cursor: default;
+  background-color: var(--stroke, #cbd5e1);
+  color: var(--tableText, #334155);
+}
+
+:host(.chips-input-disabled.p-focus) {
+  border-color: var(--stroke, #cbd5e1);
+}
+
+.p-chips-token.p-chips-token-readonly {
+  background: var(--navigation, #fff);
+  color: var(--text, #111827);
+  border: var(--inputBorderWidth, 1px) solid var(--stroke, #cbd5e1);
+  font-weight: 500;
+}
+
 .p-inputtext.p-chips-multiple-container {
   width: 100%;
   padding: 0;

--- a/projects/ziti-console-lib/src/lib/features/chips-input/chips-input.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/chips-input/chips-input.component.ts
@@ -22,8 +22,9 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
   ],
   host: {
     class: 'p-chips p-component p-input-wrapper',
-    '[class.p-focus]': 'focused',
-    '[class.error]': 'invalid'
+    '[class.p-focus]': 'focused && !disabled',
+    '[class.error]': 'invalid',
+    '[class.chips-input-disabled]': 'disabled',
   },
   standalone: false
 })
@@ -41,7 +42,7 @@ export class ChipsInputComponent implements ControlValueAccessor {
   @Output() onBlur = new EventEmitter<FocusEvent>();
   @Output() keyup = new EventEmitter<KeyboardEvent>();
 
-  @ViewChild('chipInput', { static: true }) chipInput!: ElementRef<HTMLInputElement>;
+  @ViewChild('chipInput', { static: false }) chipInput?: ElementRef<HTMLInputElement>;
 
   value: string[] = [];
   disabled = false;

--- a/projects/ziti-console-lib/src/lib/features/config-editor/config-editor.component.html
+++ b/projects/ziti-console-lib/src/lib/features/config-editor/config-editor.component.html
@@ -1,9 +1,9 @@
-<div class="form-field-extended-fields" [hidden]="showJsonView" (mouseup)="formDataChangedDebounced($event)" (keyup)="formDataChangedDebounced($event)" (clickOutside)="formDataChangedDebounced($event)">
+<div class="form-field-extended-fields" [class.config-editor-readonly]="readOnly" [hidden]="showJsonView" (mouseup)="formDataChangedDebounced($event)" (keyup)="formDataChangedDebounced($event)" (clickOutside)="formDataChangedDebounced($event)">
   <ng-container #dynamicform></ng-container>
 </div>
 @if (showJsonView && !hideConfigJSON) {
-  <lib-json-view (dataChange)="jsonDataChangedDebounced($event)" [(data)]="configData"></lib-json-view>
+  <lib-json-view (dataChange)="jsonDataChangedDebounced($event)" [(data)]="configData" [readOnly]="readOnly"></lib-json-view>
 }
 @if (showJsonView && hideConfigJSON) {
-  <lib-json-view [(data)]="configData"></lib-json-view>
+  <lib-json-view [(data)]="configData" [readOnly]="readOnly"></lib-json-view>
 }

--- a/projects/ziti-console-lib/src/lib/features/config-editor/config-editor.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/config-editor/config-editor.component.scss
@@ -1,0 +1,4 @@
+.config-editor-readonly {
+    pointer-events: none;
+    opacity: 0.96;
+}

--- a/projects/ziti-console-lib/src/lib/features/config-editor/config-editor.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/config-editor/config-editor.component.ts
@@ -30,6 +30,9 @@ export class ConfigEditorComponent implements OnInit, AfterViewInit {
   ]
   hideConfigJSON = false;
 
+  /** When true, block edits to embedded config form and JSON editor (e.g. global admin_readonly). */
+  @Input() readOnly = false;
+
   @Input() configErrors: any = {};
   @Output() configErrorsChange = new EventEmitter<any>();
 

--- a/projects/ziti-console-lib/src/lib/features/custom-tags/custom-tags.component.html
+++ b/projects/ziti-console-lib/src/lib/features/custom-tags/custom-tags.component.html
@@ -1,8 +1,10 @@
-<div id="TagExtended" (clickOutside)="validate($event)">
-  <div class="add-button-container add-vlan-button add-config-open" (click)="addTag($event)">
-    <div class="icon-add addIcon"></div>
-    <span class="add-icon-label">New Tag</span>
-  </div>
+<div id="TagExtended" (clickOutside)="validate($event)" [class.custom-tags-readonly]="readOnly">
+  @if (!readOnly) {
+    <div class="add-button-container add-vlan-button add-config-open" (click)="addTag($event)">
+      <div class="icon-add addIcon"></div>
+      <span class="add-icon-label">New Tag</span>
+    </div>
+  }
   @if (tagsArray.length >= 1) {
     <div class="grid tags">
       <label>Name</label><label>Value</label>
@@ -16,27 +18,31 @@
     }
     @for (tag of tagsArray; track tag) {
       <div class="grid tags">
-        <input
-          maxlength="100"
-          placeholder="enter tag name..."
-          [(ngModel)]="tag['name']"
+          <input
+            maxlength="100"
+            placeholder="enter tag name..."
+            [(ngModel)]="tag['name']"
           [ngClass]="{invalid: tag.errors.name}"
-          (keyup.enter)="enterKeyPressed($event)"
-          (keyup)="tagNameChanged(tag, $event)"
-          (change)="validate($event)"
-          >
-        <input
-          placeholder="enter tag value..."
-          type="text"
-          maxlength="100"
-          [(ngModel)]="tag['value']"
-          (keyup.enter)="enterKeyPressed($event)"
-          (keyup)="tagValueChanged(tag, $event)"
-          (change)="validate($event)"
-          >
-        <div class="tag-actions">
-          <div class="removeIcon icon-clear" (click)="removeTag(tag.name)"></div>
-        </div>
+            (keyup.enter)="enterKeyPressed($event)"
+            (keyup)="tagNameChanged(tag, $event)"
+            (change)="validate($event)"
+            [disabled]="readOnly"
+            >
+          <input
+            placeholder="enter tag value..."
+            type="text"
+            maxlength="100"
+            [(ngModel)]="tag['value']"
+            (keyup.enter)="enterKeyPressed($event)"
+            (keyup)="tagValueChanged(tag, $event)"
+            (change)="validate($event)"
+            [disabled]="readOnly"
+            >
+          @if (!readOnly) { 
+          <div class="tag-actions">
+            <div class="removeIcon icon-clear" (click)="removeTag(tag.name)"></div>
+          </div>
+          }
       </div>
     }
   </div>

--- a/projects/ziti-console-lib/src/lib/features/custom-tags/custom-tags.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/custom-tags/custom-tags.component.ts
@@ -26,6 +26,8 @@ import {forEach, isEmpty, map, unset, debounce, cloneDeep, set} from "lodash";
 export class CustomTagsComponent implements OnInit, OnChanges {
 
   @Input() tags: any = {};
+  /** View-only: no add/remove/edit; show name/value as text (e.g. global admin_readonly). */
+  @Input() readOnly = false;
   @Output() tagsChange: EventEmitter<any> = new EventEmitter<any>();
 
   tagsArray: any = [];
@@ -74,6 +76,9 @@ export class CustomTagsComponent implements OnInit, OnChanges {
   }
 
   addTag(event?) {
+    if (this.readOnly) {
+      return;
+    }
     this.validate();
     set(this.tagsArray, `[${this.tagsArray.length - 1}].showNewTag`, false);
     const newTag = cloneDeep(this.newTag);
@@ -84,6 +89,9 @@ export class CustomTagsComponent implements OnInit, OnChanges {
   }
 
   removeTag(tagName: string) {
+    if (this.readOnly) {
+      return;
+    }
     unset(this.tags, tagName);
     this.updateTagsArray({});
     set(this.tagsArray, `[${this.tagsArray.length - 1}].showNewTag`, true);

--- a/projects/ziti-console-lib/src/lib/features/data-table/data-table.component.html
+++ b/projects/ziti-console-lib/src/lib/features/data-table/data-table.component.html
@@ -163,6 +163,7 @@
     [isLoading]="isLoading"
     [typeName]="this.entityTypeLabel"
     [hasAdd]="showNoItemsAdd"
+    [readonly]="noItemsReadonly"
   ></lib-no-items>
 }
 @if (showTagSelector) {

--- a/projects/ziti-console-lib/src/lib/features/data-table/data-table.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/data-table/data-table.component.ts
@@ -82,6 +82,8 @@ export class DataTableComponent implements OnChanges, OnInit {
   @Input() noItemsClass: any = 'background-image: url("assets/svgs/No_Clients.svg")';
   @Input() entityTypeName = 'Identities';
   @Input() showNoItemsAdd = true;
+  /** When true, empty-state copy does not prompt to add (e.g. admin_readonly / no create permission). */
+  @Input() noItemsReadonly = false;
   @Input() currentPage = 1;
   @Input() noItemsImage = 'nodata';
   @Input() rowHeight = this.remToPx(3.125);

--- a/projects/ziti-console-lib/src/lib/features/filter-select/filter-select.component.html
+++ b/projects/ziti-console-lib/src/lib/features/filter-select/filter-select.component.html
@@ -1,7 +1,7 @@
 <mat-form-field class="lib-filter-select" subscriptSizing="dynamic">
   <mat-select
     [id]="id"
-    [disabled]="disabled"
+    [disabled]="selectDisabled"
     [placeholder]="placeholder"
     [value]="value"
     [panelClass]="resolvedPanelClass"
@@ -68,7 +68,7 @@
     }
   </mat-select>
 
-  @if (showClear && !disabled && !isValueEmpty) {
+  @if (showClear && !selectDisabled && !isValueEmpty) {
     <button
       mat-icon-button
       matSuffix

--- a/projects/ziti-console-lib/src/lib/features/filter-select/filter-select.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/filter-select/filter-select.component.ts
@@ -68,6 +68,9 @@ export class FilterSelectComponent implements ControlValueAccessor, OnDestroy {
     @ContentChild(FilterSelectOptionTemplateDirective) optionTemplate?: FilterSelectOptionTemplateDirective;
     @ContentChild(FilterSelectTriggerTemplateDirective) triggerTemplate?: FilterSelectTriggerTemplateDirective;
 
+    /** Combined with ControlValueAccessor disabled state (e.g. disable mat-select when parent form is read-only). */
+    @Input() disableControl = false;
+
     value: any = undefined;
     disabled = false;
 
@@ -221,6 +224,9 @@ export class FilterSelectComponent implements ControlValueAccessor, OnDestroy {
         return option?.[this.optionValue];
     }
 
+    get selectDisabled(): boolean {
+        return this.disabled || this.disableControl;
+    }
+
     trackByOption = (_: number, option: any) => this.getOptionValue(option);
 }
-

--- a/projects/ziti-console-lib/src/lib/features/json-view/json-view.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/json-view/json-view.component.ts
@@ -195,6 +195,9 @@ export class JsonViewComponent implements AfterViewInit, OnChanges {
         this.initEditor();
       }
     }
+    if (changes['readOnly'] && this.editorInit && this.editor?.updateProps) {
+      void this.editor.updateProps({ readOnly: this.readOnly });
+    }
   }
 
   public validate(newData: any = undefined) {

--- a/projects/ziti-console-lib/src/lib/features/list-page-features/list-page-header/list-page-header.component.html
+++ b/projects/ziti-console-lib/src/lib/features/list-page-features/list-page-header/list-page-header.component.html
@@ -9,11 +9,11 @@
       <div class="tab" [ngClass]="{selected: tabSelected(tab)}" [routerLink]="tab.url" [hidden]="tab.hidden">{{tab.label}}</div>
     }
   </div>
-  @if (showAdd) {
+  @if (showAdd && !blockCreate) {
     <div [ngClass]="{hideAction: hideAction}" (click)="clickAction('add')"
     class="action icon-plus icon-add" data-action="add"></div>
   }
-  @if (!showAdd) {
+  @if (!showAdd && !blockDelete) {
     <div [ngClass]="{hideAction: hideAction}" (click)="clickAction('delete')"
     class="action icon-minus icon-delete" data-action="delete"></div>
   }

--- a/projects/ziti-console-lib/src/lib/features/list-page-features/list-page-header/list-page-header.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/list-page-features/list-page-header/list-page-header.component.ts
@@ -27,6 +27,10 @@ export class ListPageHeaderComponent {
     @Input() tabs!: any[];
     @Input() showAdd = true;
     @Input() hideAction = false;
+    /** When true, hide the create (+) control even if showAdd is true. */
+    @Input() blockCreate = false;
+    /** When true, hide the bulk delete (-) control when rows are selected. */
+    @Input() blockDelete = false;
     @Output() actionClicked = new EventEmitter<string>();
 
     clickAction(value: string) {

--- a/projects/ziti-console-lib/src/lib/features/no-items/no-items.component.html
+++ b/projects/ziti-console-lib/src/lib/features/no-items/no-items.component.html
@@ -3,7 +3,7 @@
         <div [ngStyle]="background" class="icon"></div>
         <div class="title">
             This network currently has no {{ typeName }} to display.<br/>
-            <span [hidden]="!hasAdd"
+            <span [hidden]="!hasAdd || readonly"
         >Tap on the <span class="addExample"></span> to add one.</span
         >
         </div>

--- a/projects/ziti-console-lib/src/lib/features/no-items/no-items.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/no-items/no-items.component.ts
@@ -6,6 +6,7 @@ import {Component, EventEmitter, Input, OnChanges, Output} from '@angular/core';
     styleUrls: ['./no-items.component.scss'],
     standalone: false
 })
+
 export class NoItemsComponent implements OnChanges {
   @Input() image = 'No_Gateways';
   @Input() typeName = '';
@@ -13,12 +14,12 @@ export class NoItemsComponent implements OnChanges {
   @Input() hasAdd = true;
   @Input() hiddenResults = false;
   @Input() isLoading = false;
+  @Input() readonly = false;
   background;
   @Output() clickEmit = new EventEmitter<any>();
   @Output() refresh = new EventEmitter<any>();
 
-  constructor() {
-  }
+  constructor() {}
 
   ngOnChanges() {
     this.background = {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/api-session/api-session-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/api-session/api-session-form.component.html
@@ -9,6 +9,7 @@
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
     [showHeaderButton]="false"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="edge-router-form-container projectable-form-container">
     @if (formView === 'simple') {
@@ -73,7 +74,7 @@
     @if (formView === 'raw') {
       <div class="form-group-column">
         @if (formData) {
-          <lib-json-view [(data)]="formData"></lib-json-view>
+          <lib-json-view [(data)]="formData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
         }
       </div>
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/auth-policy/auth-policy-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/auth-policy/auth-policy-form.component.html
@@ -10,8 +10,10 @@
     [moreActions]="moreActions"
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
-    [saveDisabled]="svc.saveDisabled || formDataInvalid"
+    [saveDisabled]="svc.saveDisabled || formDataInvalid || formPermissionSaveDisabled"
+    [saveTooltip]="formPermissionSaveTooltip"
     [class.is-scrolled]="isScrolled"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="jwt-signer-form-container projectable-form-container" #formContainer>
     <div class="projectable-form-main-column form-group-row" [hidden]="formView !== 'simple'">
@@ -20,7 +22,14 @@
           [title]="'Name'"
           [label]="'Required'"
           >
-          <input class="form-field-input read-only" [(ngModel)]="formData.name" [ngClass]="{error: errors['name']}" placeholder="Name this Auth Policy"/>
+            <input
+              class="form-field-input"
+              [(ngModel)]="formData.name"
+              [ngClass]="{error: errors['name']}"
+              placeholder="Name this Auth Policy"
+              #nameFieldInput
+              [disabled]="useStrictReadonlyForm"
+              />
         </lib-form-field-container>
         <lib-form-field-container
           [title]="'Primary Authentication'"
@@ -37,8 +46,8 @@
                 ></div>
               </div>
               <div
-                (click)="toggleCertAllowed()"
-                [ngClass]="{ on: formData.primary.cert.allowed }"
+                (click)="!useStrictReadonlyForm && toggleCertAllowed()"
+                [ngClass]="{ on: formData.primary.cert.allowed, 'toggle-readonly': useStrictReadonlyForm }"
                 class="toggle"
                 >
                 <span [hidden]="!formData.primary.cert.allowed" class="on-label">YES</span>
@@ -133,6 +142,8 @@
                 ></div>
               </div>
               <lib-tag-selector
+                [disableField]="useStrictReadonlyForm"
+                [disableCreate]="useStrictReadonlyForm"
                 [(selectedNamedAttributes)]="allowedJwtSignerAttributes"
                 [availableNamedAttributes]="svc.jwtSignerNamedAttributes"
                 [placeholder]="'Select which External JWT Signers to allow'"
@@ -240,7 +251,7 @@
             [label]="'OPTIONAL'"
             class="form-field-advanced"
             >
-            <lib-custom-tags [(tags)]="formData.tags"></lib-custom-tags>
+            <lib-custom-tags [(tags)]="formData.tags" [readOnly]="useStrictReadonlyForm"></lib-custom-tags>
           </lib-form-field-container>
         </div>
       </div>
@@ -297,6 +308,7 @@
               (selectionChange)="secondaryJwtSignerChanged($event)"
               (filterChange)="jwtSignersFilterChangedDebounced($event)"
               [(ngModel)]="formData.secondary.requireExtJwtSigner"
+              [disabled]="useStrictReadonlyForm"
             ></lib-filter-select>
           </div>
         </lib-form-field-container>
@@ -319,7 +331,7 @@
     @if (formView === 'raw') {
       <div class="form-group-column">
         @if (formData) {
-          <lib-json-view [(data)]="formData"></lib-json-view>
+          <lib-json-view [(data)]="formData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
         }
       </div>
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/auth-policy/auth-policy-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/auth-policy/auth-policy-form.component.ts
@@ -147,6 +147,9 @@ export class AuthPolicyFormComponent extends ProjectableForm implements OnInit, 
     }
 
     async save(event?: any) {
+        if (!this.canSaveByPermissions()) {
+            return;
+        }
         if(!this.validate()) {
             return;
         }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/certificate-authority/certificate-authority-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/certificate-authority/certificate-authority-form.component.html
@@ -9,33 +9,45 @@
     [moreActions]="moreActions"
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
-    [saveDisabled]="svc.saveDisabled || formDataInvalid"
+    [saveDisabled]="svc.saveDisabled || formDataInvalid || formPermissionSaveDisabled"
+    [saveTooltip]="formPermissionSaveTooltip"
     [badges]="badges"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="jwt-signer-form-container projectable-form-container">
     <div class="projectable-form-main-column form-group-row" [hidden]="formView !== 'simple'">
       <div class="form-group-column three-fifths">
         <lib-form-field-container
           [title]="'Name'"
-          [label]="'Required'"
+          [label]="useStrictReadonlyForm ? '' : 'REQUIRED'"
           >
-          <input class="form-field-input read-only" [(ngModel)]="formData.name" [ngClass]="{error: errors['name']}" placeholder="Name this Certificate Authority"/>
+          @if (!useStrictReadonlyForm) {
+            <input class="form-field-input read-only" [(ngModel)]="formData.name" [ngClass]="{error: errors['name']}" placeholder="Name this Certificate Authority"/>
+          } @else {
+            <div class="form-field-readonly-value">{{ formData.name }}</div>
+          }
         </lib-form-field-container>
         <lib-form-field-container
           [title]="'Identity Name Format'"
           [contentStyle]="'z-index: 99999999'"
-          [label]="'OPTIONAL'"
+          [label]="useStrictReadonlyForm ? '' : 'OPTIONAL'"
           [helpText]="'The identity name format used to name automatically enrolling identities. Defaults to [caName]-[commonName]'"
           >
-          <input class="form-field-input read-only" [(ngModel)]="formData.identityNameFormat" [ngClass]="{error: errors['identityNameFormat']}" placeholder="Defaults to [caName]-[commonName]"/>
+          @if (!useStrictReadonlyForm) {
+            <input class="form-field-input read-only" [(ngModel)]="formData.identityNameFormat" [ngClass]="{error: errors['identityNameFormat']}" placeholder="Defaults to [caName]-[commonName]"/>
+          } @else {
+            <div class="form-field-readonly-value">{{ formData.identityNameFormat }}</div>
+          }
         </lib-form-field-container>
         <lib-form-field-container
           [title]="'Identity Roles'"
           [contentStyle]="'z-index: 99999999'"
-          [label]="'OPTIONAL'"
+          [label]="useStrictReadonlyForm ? '' : 'OPTIONAL'"
           [helpText]="'The identity roles to give to automatically enrolling identities'"
           >
           <lib-tag-selector
+            [disableField]="useStrictReadonlyForm"
+            [disableCreate]="useStrictReadonlyForm"
             [(selectedRoleAttributes)]="formData.identityRoles"
             [availableRoleAttributes]="identityRoleAttributes"
             [placeholder]="'Type to filter and enter to assign'"
@@ -241,7 +253,7 @@
             [label]="'OPTIONAL'"
             class="form-field-advanced"
             >
-            <lib-custom-tags [(tags)]="formData.tags"></lib-custom-tags>
+            <lib-custom-tags [(tags)]="formData.tags" [readOnly]="useStrictReadonlyForm"></lib-custom-tags>
           </lib-form-field-container>
         </div>
       </div>
@@ -276,7 +288,7 @@
     @if (formView === 'raw') {
       <div class="form-group-column">
         @if (formData) {
-          <lib-json-view [(data)]="formData"></lib-json-view>
+          <lib-json-view [(data)]="formData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
         }
       </div>
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/certificate-authority/certificate-authority-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/certificate-authority/certificate-authority-form.component.ts
@@ -151,6 +151,9 @@ export class CertificateAuthorityFormComponent extends ProjectableForm implement
     }
 
     async save(event?: any) {
+        if (!this.canSaveByPermissions()) {
+            return;
+        }
         if(!this.validate()) {
             return;
         }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/certificate-authority/verify-certificate/verify-certificate.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/certificate-authority/verify-certificate/verify-certificate.component.html
@@ -9,9 +9,11 @@
     [moreActions]="formData.moreActions"
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
-    [saveDisabled]="svc.saveDisabled || formDataInvalid"
+    [saveDisabled]="svc.saveDisabled || formDataInvalid || formPermissionSaveDisabled"
+    [saveTooltip]="formPermissionSaveTooltip"
     [showHeaderToggle]="false"
     [actionButtonText]="'Verify'"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="verify-certificate-container projectable-form-container">
     <div class="projectable-form-main-column form-group-row" [hidden]="formView !== 'simple'">
@@ -35,7 +37,7 @@
         </lib-form-field-container>
         <lib-form-field-container
           [title]="'Certificate'"
-          [label]="'REQUIRED'"
+          [label]="useStrictReadonlyForm ? '' : 'REQUIRED'"
           >
           @if (errors['certPem']) {
             <span class="cert-error-text error-text">{{certErrorMessage}}</span>
@@ -60,7 +62,9 @@
         </lib-form-field-container>
         <div class="buttons-container buttons">
           <div class="linkButton cancel" (click)="returnToListPage()">Oops, no get me out of here</div>
-          <div class=" save-button button save confirm" (click)="save($event)">Verify</div>
+          @if (!useStrictReadonlyForm) {
+            <div class=" save-button button save confirm" (click)="save($event)">Verify</div>
+          }
         </div>
       </div>
     </div>

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/certificate-authority/verify-certificate/verify-certificate.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/certificate-authority/verify-certificate/verify-certificate.component.ts
@@ -142,6 +142,9 @@ export class VerifyCertificateComponent extends ProjectableForm implements OnIni
     }
 
     async save(event?: any) {
+        if (!this.canSaveByPermissions()) {
+            return;
+        }
         if(!this.validate()) {
             return;
         }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/config-type/config-type-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/config-type/config-type-form.component.html
@@ -10,25 +10,28 @@
     [moreActions]="moreActions"
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
-    [saveDisabled]="saveDisabled"
-    [saveTooltip]="saveButtonTooltip"
+    [saveDisabled]="saveDisabled || formPermissionSaveDisabled"
+    [saveTooltip]="formPermissionSaveDisabled ? formPermissionSaveTooltip : saveButtonTooltip"
     [class.is-scrolled]="isScrolled"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="config-form-container projectable-form-container" #formContainer>
     <div class="projectable-form-main-column form-group-row" [hidden]="formView !== 'simple'">
       <div class="form-group-column three-fifths">
-        <lib-form-field-container [title]="'Config Name'" [label]="'Required'">
-          <input
-            id="ConfigName"
-            type="text"
-            maxlength="500"
-            placeholder="Name this config"
-            [ngClass]="{error: errors['name']}"
-            [(ngModel)]="formData.name"
-            >
+        <lib-form-field-container [title]="'Config Name'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'">
+            <input
+              class="form-field-input"
+              id="ConfigName"
+              type="text"
+              maxlength="500"
+              placeholder="Name this config"
+              [ngClass]="{error: errors['name']}"
+              [(ngModel)]="formData.name"
+              [disabled]="useStrictReadonlyForm"
+              >
         </lib-form-field-container>
-        <lib-form-field-container [title]="'Schema'" [label]="'Required'" class="schema-json-editor">
-          <lib-json-view [(data)]="formData.schema" [jsonInvalid]="errors['schema']"></lib-json-view>
+        <lib-form-field-container [title]="'Schema'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'" class="schema-json-editor">
+          <lib-json-view [(data)]="formData.schema" [jsonInvalid]="errors['schema']" [readOnly]="useStrictReadonlyForm"></lib-json-view>
         </lib-form-field-container>
         <lib-form-field-toggle [(toggleOn)]="showMore" (toggleOnChange)="showMoreChanged($event)" style="margin: 0px 10px"></lib-form-field-toggle>
         <div [hidden]="!showMore" class="form-group-column">
@@ -38,7 +41,7 @@
               [label]="'OPTIONAL'"
               class="form-field-advanced"
               >
-              <lib-custom-tags [(tags)]="formData.tags"></lib-custom-tags>
+              <lib-custom-tags [(tags)]="formData.tags" [readOnly]="useStrictReadonlyForm"></lib-custom-tags>
             </lib-form-field-container>
           }
         </div>
@@ -63,7 +66,7 @@
     @if (formView === 'raw') {
       <div class="form-group-column">
         @if (formData) {
-          <lib-json-view [(data)]="formData"></lib-json-view>
+          <lib-json-view [(data)]="formData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
         }
       </div>
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/config-type/config-type-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/config-type/config-type-form.component.ts
@@ -184,6 +184,9 @@ export class ConfigTypeFormComponent extends ProjectableForm implements OnInit, 
     }
 
     async save(event?: any) {
+        if (!this.canSaveByPermissions()) {
+            return;
+        }
         this.errors = {};
         if (!this.validate()) {
             this.isLoading = false;

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.html
@@ -10,15 +10,17 @@
     [moreActions]="moreActions"
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
-    [saveDisabled]="svc.saveDisabled || formDataInvalid"
-    [saveTooltip]="saveButtonTooltip"
+    [saveDisabled]="svc.saveDisabled || formDataInvalid || formPermissionSaveDisabled"
+    [saveTooltip]="formPermissionSaveDisabled ? formPermissionSaveTooltip : saveButtonTooltip"
     [class.is-scrolled]="isScrolled"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="config-form-container projectable-form-container" #formContainer>
     <div class="projectable-form-main-column form-group-row" [hidden]="formView !== 'simple'">
       <div class="form-group-column three-fifths">
-        <lib-form-field-container [title]="'Config Name'" [label]="'Required'">
+        <lib-form-field-container [title]="'Config Name'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'">
           <input
+            class="form-field-input"
             id="ConfigName"
             type="text"
             maxlength="500"
@@ -26,10 +28,11 @@
             [ngClass]="{error: errors['name']}"
             [(ngModel)]="formData.name"
             (keyup)="apiData()"
+            [disabled]="useStrictReadonlyForm"
             >
         </lib-form-field-container>
         <lib-form-field-container [showHeader]="false">
-          <div class="config-title-row">
+            <div class="config-title-row">
             <span class="form-field-title">Configuration Data</span>
             <div class="form-header-toggle-container">
               <span
@@ -67,6 +70,7 @@
               [(ngModel)]="formData.configTypeId"
               (change)="getSchema()"
               [ngClass]="{disabled: isEditing, error: errors['configTypeId']}"
+              [disabled]="useStrictReadonlyForm || isEditing"
               >
               <option value="">Select A Type...</option>
               @for (config of options; track config) {
@@ -81,6 +85,7 @@
               [(configData)]="formData.data"
               [showJsonView]="svc.configJsonView"
               [(configErrors)]="errors"
+              [readOnly]="useStrictReadonlyForm"
               (configDataChange)="dataChanged($event)"
               #configEditor
             ></lib-config-editor>
@@ -94,7 +99,7 @@
               [label]="'OPTIONAL'"
               class="form-field-advanced"
               >
-              <lib-custom-tags [(tags)]="formData.tags"></lib-custom-tags>
+              <lib-custom-tags [(tags)]="formData.tags" [readOnly]="useStrictReadonlyForm"></lib-custom-tags>
             </lib-form-field-container>
           }
         </div>
@@ -119,7 +124,7 @@
     @if (formView === 'raw') {
       <div class="form-group-column">
         @if (formData) {
-          <lib-json-view [(data)]="formData"></lib-json-view>
+          <lib-json-view [(data)]="formData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
         }
       </div>
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/configuration/configuration-form.component.ts
@@ -204,6 +204,9 @@ export class ConfigurationFormComponent extends ProjectableForm implements OnIni
     }
 
     async save(event?: any) {
+        if (!this.canSaveByPermissions()) {
+            return;
+        }
         this.errors = {};
         this.isLoading = true;
         try {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.component.html
@@ -10,20 +10,24 @@
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
     [class.is-scrolled]="isScrolled"
+    [saveDisabled]="formPermissionSaveDisabled"
+    [saveTooltip]="formPermissionSaveTooltip"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="edge-router-policy-form-container projectable-form-container" #formContainer>
     @if (formView === 'simple') {
       <div class="projectable-form-main-column form-group-row">
         <div class="form-group-column three-fifths">
-          <lib-form-field-container [title]="'Edge Router Policy Name'" [label]="'REQUIRED'">
-            <input
-              class="form-field-input"
-              placeholder="Name this edge router policy"
-              [ngClass]="{error: errors['name']}"
-              [(ngModel)]="formData.name"
-              autofocus
-              #nameFieldInput
-              />
+          <lib-form-field-container [title]="'Edge Router Policy Name'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'">
+              <input
+                class="form-field-input"
+                placeholder="Name this edge router policy"
+                [ngClass]="{error: errors['name']}"
+                [(ngModel)]="formData.name"
+                autofocus
+                #nameFieldInput
+                [disabled]="useStrictReadonlyForm"
+                />
           </lib-form-field-container>
           <lib-form-field-container
             [title]="'Select Edge Router Attributes'"
@@ -32,6 +36,8 @@
             [helpText]="'Choose which edge router to associate to this policy by picking from the list of available attributes'"
             >
             <lib-tag-selector
+              [disableField]="useStrictReadonlyForm"
+              [disableCreate]="useStrictReadonlyForm"
               [(selectedRoleAttributes)]="selectedEdgeRouterRoleAttributes"
               [(selectedNamedAttributes)]="selectedEdgeRouterNamedAttributes"
               [availableRoleAttributes]="svc.edgeRouterRoleAttributes"
@@ -48,6 +54,8 @@
             [helpText]="'Choose which identities to associate to this policy by picking from the list of available attributes'"
             >
             <lib-tag-selector
+              [disableField]="useStrictReadonlyForm"
+              [disableCreate]="useStrictReadonlyForm"
               [(selectedRoleAttributes)]="selectedIdentityRoleAttributes"
               [(selectedNamedAttributes)]="selectedIdentityNamedAttributes"
               [availableRoleAttributes]="svc.identityRoleAttributes"
@@ -66,6 +74,7 @@
               (change)="updateAssociations()"
               id="PolicySemantic"
               class="form-field-dropdown"
+              [disabled]="useStrictReadonlyForm"
               >
               <option value="AnyOf">AnyOf</option>
               <option value="AllOf">AllOf</option>
@@ -79,7 +88,7 @@
                 [label]="'OPTIONAL'"
                 class="form-field-advanced"
                 >
-                <lib-custom-tags [(tags)]="formData.tags"></lib-custom-tags>
+                <lib-custom-tags [(tags)]="formData.tags" [readOnly]="useStrictReadonlyForm"></lib-custom-tags>
               </lib-form-field-container>
             }
           </div>
@@ -127,7 +136,7 @@
     @if (formView === 'raw') {
       <div class="form-group-column">
         @if (formData) {
-          <lib-json-view [(data)]="formData"></lib-json-view>
+          <lib-json-view [(data)]="formData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
         }
       </div>
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router-policy/edge-router-policy-form.component.ts
@@ -194,6 +194,9 @@ export class EdgeRouterPolicyFormComponent extends ProjectableForm implements On
   }
 
   async save(event?) {
+    if (!this.canSaveByPermissions()) {
+      return;
+    }
     this.formData.name = this.formData.name.trim();
     const isValid = this.validate();
     const isExtValid = await this.extService.validateData();

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.html
@@ -10,20 +10,24 @@
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
     [class.is-scrolled]="isScrolled"
+    [saveDisabled]="formPermissionSaveDisabled"
+    [saveTooltip]="formPermissionSaveTooltip"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="edge-router-form-container projectable-form-container" #formContainer>
     @if (formView === 'simple') {
       <div class="projectable-form-main-column form-group-row">
         <div class="form-group-column three-fifths">
-          <lib-form-field-container [title]="'Edge Router Name'" [label]="'REQUIRED'">
-            <input
-              class="form-field-input"
-              placeholder="Name this edge router"
-              [ngClass]="{error: errors['name']}"
-              [(ngModel)]="formData.name"
-              autofocus
-              #nameFieldInput
-              />
+          <lib-form-field-container [title]="'Edge Router Name'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'">
+              <input
+                class="form-field-input"
+                placeholder="Name this edge router"
+                [ngClass]="{error: errors['name']}"
+                [(ngModel)]="formData.name"
+                autofocus
+                #nameFieldInput
+                [disabled]="useStrictReadonlyForm"
+                />
           </lib-form-field-container>
           <lib-form-field-container
             [title]="'Select or create Edge Router attributes'"
@@ -32,6 +36,8 @@
             [helpText]="'Attributes are tags applied to an resource. Apply the same tag to other Edge Routers to form a group of Edge Routers.'"
             >
             <lib-tag-selector
+              [disableField]="useStrictReadonlyForm"
+              [disableCreate]="useStrictReadonlyForm"
               [(selectedRoleAttributes)]="formData.roleAttributes"
               [availableRoleAttributes]="edgeRouterRoleAttributes"
               [placeholder]="'Add attributes to group Edge Routers'"
@@ -50,9 +56,9 @@
                 <div class="config-item" [class.disabled]="!tunnelerEnabledReadOnly">
                   <div class="config-container toggle-container">
                     <div class="config-container-label">TUNNELER ENABLED</div>
-                    <div (click)="tunnelerEnabledReadOnly && toggleTunnelerEnabled()"
-                      [ngClass]="{ on: formData.isTunnelerEnabled,disabled: !tunnelerEnabledReadOnly }" class="toggle"
-                      [matTooltip]="!tunnelerEnabledReadOnly ? 'Disabled because already hosted by netfoundry ' : ''"
+                    <div (click)="tunnelerEnabledReadOnly && !useStrictReadonlyForm && toggleTunnelerEnabled()"
+                      [ngClass]="{ on: formData.isTunnelerEnabled, disabled: !tunnelerEnabledReadOnly, 'toggle-readonly': useStrictReadonlyForm }" class="toggle"
+                      [matTooltip]="useStrictReadonlyForm ? '' : (!tunnelerEnabledReadOnly ? 'Disabled because already hosted by netfoundry ' : '')"
                       matTooltipPosition="above" style="pointer-events: auto;">
                       <span [hidden]="!formData.isTunnelerEnabled" class="on-label">YES</span>
                       <span [hidden]="formData.isTunnelerEnabled" class="off-label">NO</span>
@@ -64,8 +70,8 @@
                   <div class="config-container toggle-container">
                     <div class="config-container-label">ALLOW TRAVERSAL</div>
                     <div
-                      (click)="toggleNoTraversal()"
-                      [ngClass]="{ on: !formData.noTraversal }"
+                      (click)="!useStrictReadonlyForm && toggleNoTraversal()"
+                      [ngClass]="{ on: !formData.noTraversal, 'toggle-readonly': useStrictReadonlyForm }"
                       class="toggle"
                       >
                       <span [hidden]="formData.noTraversal" class="on-label">YES</span>
@@ -110,14 +116,14 @@
                 [label]="'OPTIONAL'"
                 class="form-field-advanced"
                 >
-                <lib-custom-tags [(tags)]="formData.tags"></lib-custom-tags>
+                <lib-custom-tags [(tags)]="formData.tags" [readOnly]="useStrictReadonlyForm"></lib-custom-tags>
               </lib-form-field-container>
               <lib-form-field-container
                 [title]="'App Data'"
                 [label]="'OPTIONAL'"
                 class="form-field-advanced"
                 >
-                <lib-json-view [(data)]="formData.appData"></lib-json-view>
+                <lib-json-view [(data)]="formData.appData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
               </lib-form-field-container>
             </div>
           }
@@ -183,7 +189,7 @@
     @if (formView === 'raw') {
       <div class="form-group-column">
         @if (formData) {
-          <lib-json-view [(data)]="formData"></lib-json-view>
+          <lib-json-view [(data)]="formData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
         }
       </div>
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/edge-router/edge-router-form.component.ts
@@ -155,6 +155,9 @@ export class EdgeRouterFormComponent extends ProjectableForm implements OnInit, 
   }
 
   async save(event?) {
+    if (!this.canSaveByPermissions()) {
+      return;
+    }
     const isValid = this.validate();
     const isExtValid = await this.extService.validateData();
     this.formData.name = this.formData.name.trim()

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/form-header/form-header.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/form-header/form-header.component.html
@@ -5,7 +5,7 @@
         <div class="form-title-back-arrow-icon icon-back-arrow"></div>
       </div>
       <div class="form-header-title-text">
-        <span class="form-title">{{title}}</span>
+        <span class="form-title">{{displayTitle}}</span>
         @if (data.name) {
           <span class="form-title title-name">{{data.name}}</span>
         }
@@ -39,7 +39,7 @@
           </span>
         </div>
       }
-      @if (hasMoreActions) {
+      @if (hasMoreActions && !strictReadonlyUi) {
         <div class="more-actions-container" [ngClass]="{'more-actions-open': showActionsDropDown}"  (click)="showMoreActions()">
           <div class="more-actions-button">
             <div class="more-actions-label">
@@ -64,7 +64,7 @@
           }
         </div>
       }
-      @if (!hasMultiActions && showHeaderButton) {
+      @if (!hasMultiActions && showHeaderButton && !strictReadonlyUi) {
         <div class="save-button"
           (click)="requestAction({name: 'save'})"
           [ngClass]="{'save-disabled': saveDisabled}"
@@ -72,7 +72,7 @@
           matTooltipPosition="below"
         >{{actionButtonText}}</div>
       }
-      @if (hasMultiActions) {
+      @if (hasMultiActions && !strictReadonlyUi) {
         <lib-multi-action-button
           [actions]="saveActions"
           (actionRequested)="actionClicked($event)"

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/form-header/form-header.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/form-header/form-header.component.ts
@@ -35,6 +35,8 @@ export class FormHeaderComponent implements OnChanges {
   @Input() moreActionsText = 'More Actions';
   @Input() showHeaderToggle = true;
   @Input() showHeaderButton = true;
+  /** Hide save / more-actions / multi-save and retitle Edit→View for global admin_readonly without write grants. */
+  @Input() strictReadonlyUi = false;
   @Input() multiActions: any[] = [];
   @Output() formViewChange: EventEmitter<string> = new EventEmitter<string>();
   @Output() actionRequested: EventEmitter<any> = new EventEmitter<any>();
@@ -50,6 +52,13 @@ export class FormHeaderComponent implements OnChanges {
     this.saveActions = [...this._saveActions, ...this.multiActions];
   }
 
+  get displayTitle(): string {
+    if (!this.strictReadonlyUi || !this.title) {
+      return this.title;
+    }
+    return this.title.replace(/\bEdit\b/gi, 'View').replace(/\bCreate\b/gi, 'View');
+  }
+
   get hasMoreActions() {
     let hasMoreActions = false;
     this.moreActions?.forEach(action => {
@@ -61,6 +70,9 @@ export class FormHeaderComponent implements OnChanges {
   }
 
   actionClicked(event) {
+    if (this.strictReadonlyUi) {
+      return;
+    }
     if (event?.id === 'save' && this.saveDisabled) {
       return;
     }
@@ -68,6 +80,9 @@ export class FormHeaderComponent implements OnChanges {
   }
 
   requestAction(action) {
+    if (this.strictReadonlyUi && action?.name === 'save') {
+      return;
+    }
     if (action?.name === 'save' && this.saveDisabled) {
       return;
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.html
@@ -10,24 +10,28 @@
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
     [class.is-scrolled]="isScrolled"
+    [saveDisabled]="formPermissionSaveDisabled"
+    [saveTooltip]="formPermissionSaveTooltip"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="identity-form-container projectable-form-container" #formContainer>
     @if (formView === 'simple') {
       <div class="projectable-form-main-column form-group-row">
         <div class="form-group-column three-fifths">
-          <lib-form-field-container [title]="'Identity Name'" [label]="'REQUIRED'">
-            <input
-              class="form-field-input"
-              placeholder="Name this identity"
-              [ngClass]="{error: errors['name']}"
-              [(ngModel)]="formData.name"
-              autofocus
-              #nameFieldInput
-              />
+          <lib-form-field-container [title]="'Identity Name'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'">
+              <input
+                class="form-field-input"
+                placeholder="Name this identity"
+                [ngClass]="{error: errors['name']}"
+                [(ngModel)]="formData.name"
+                autofocus
+                #nameFieldInput
+                [disabled]="useStrictReadonlyForm"
+                />
           </lib-form-field-container>
           <lib-form-field-container
             [title]="'Select or create Identity attributes'"
-            [label]="'OPTIONAL'"
+            [label]="useStrictReadonlyForm ? '' : 'OPTIONAL'"
             [contentStyle]="'z-index: 99999999'"
             [helpText]="'Attributes are tags applied to an resource. Apply the same tag to other Identities to form a group of Identities.'"
             >
@@ -36,18 +40,21 @@
               (selectedRoleAttributesChange)="roleAttributesChanged($event)"
               [availableRoleAttributes]="identityRoleAttributes"
               [placeholder]="'Add attributes to group Identities'"
+              [disableField]="useStrictReadonlyForm"
+              [disableCreate]="useStrictReadonlyForm"
             ></lib-tag-selector>
           </lib-form-field-container>
           <ng-content select="[slot=column-1-slot-1]"></ng-content>
           <lib-form-field-container
             [title]="'Auth Policy'"
-            [label]="'OPTIONAL'"
+            [label]="useStrictReadonlyForm ? '' : 'OPTIONAL'"
             [helpText]="'Authentication Policies restrict the authentication methods available to identities.'"
             >
             <select
               [(ngModel)]="formData.authPolicyId"
               id="authPolicyId"
               class="form-field-dropdown"
+              [disabled]="useStrictReadonlyForm"
               >
               <option value="">Select an Authentication Policy</option>
               @for (policy of authPolicies; track policy) {
@@ -63,9 +70,14 @@
                 <div class="form-field-title-container">
                   <span class="form-field-title">External ID</span>
                 </div>
-                <span class="form-field-label">OPTIONAL</span>
+                <span class="form-field-label">{{ useStrictReadonlyForm ? '' : 'OPTIONAL' }}</span>
               </div>
-              <input class="form-field-input" placeholder="Optional External ID" [(ngModel)]="formData.externalId"/>
+              <input
+                class="form-field-input"
+                placeholder="Optional External ID"
+                [(ngModel)]="formData.externalId"
+                [disabled]="useStrictReadonlyForm"
+                />
             </div>
           </lib-form-field-container>
           <ng-content select="[slot=column-1-slot-2]"></ng-content>
@@ -81,6 +93,7 @@
                 id="EnrollmentType"
                 class="form-field-dropdown"
                 [ngClass]="{disabled: isEditing}"
+                [disabled]="useStrictReadonlyForm || isEditing"
                 [(ngModel)]="enrollmentType"
                 (change)="updateEnrollment()"
                 >
@@ -93,9 +106,9 @@
                 <select
                   id="CertAuthorities"
                   class="form-field-dropdown"
-                  [ngClass]="{disabled: isEditing}"
+                  [ngClass]="{disabled: isEditing, error: errors.enrollmentCA}"
+                  [disabled]="useStrictReadonlyForm || isEditing"
                   [(ngModel)]="enrollmentCA"
-                  [ngClass]="{error: errors.enrollmentCA}"
                   (change)="updateEnrollment()"
                   >
                   @for (ca of cas; track ca) {
@@ -105,14 +118,15 @@
               }
               @if (enrollmentType === 'updb' && !isEditing) {
                 <input
+                  id="UPDBName"
+                  class="form-field-input"
                   [ngClass]="{disabled: isEditing, error: errors.enrollmentUPDB}"
                   [(ngModel)]="enrollmentUPDB"
                   (keyup)="updateEnrollment()"
-                  class="form-field-input"
-                  id="UPDBName"
                   type="text"
                   maxlength="500"
                   placeholder="Enter a name"
+                  [disabled]="useStrictReadonlyForm"
                   >
               }
             </lib-form-field-container>
@@ -126,7 +140,7 @@
                   <div class="config-container-label">IS ADMIN</div>
                   <div
                     (click)="toggleIsAdmin()"
-                    [ngClass]="{ on: formData.isAdmin }"
+                    [ngClass]="{ on: formData.isAdmin, 'toggle-readonly': useStrictReadonlyForm }"
                     class="toggle"
                     >
                     <span [hidden]="!formData.isAdmin" class="on-label">YES</span>
@@ -142,11 +156,17 @@
               [layout]="'row'"
               class="form-field-advanced"
               >
-              <input class="form-field-input" [(ngModel)]="formData.defaultHostingCost" type="number"/>
+              <input
+                class="form-field-input"
+                [(ngModel)]="formData.defaultHostingCost"
+                type="number"
+                [disabled]="useStrictReadonlyForm"
+                />
               <select
                 [(ngModel)]="formData.defaultHostingPrecedence"
                 id="hostingPrecedence"
                 class="form-field-dropdown"
+                [disabled]="useStrictReadonlyForm"
                 >
                 <option value="default">Default</option>
                 <option value="required">Required</option>
@@ -156,7 +176,7 @@
             @for (tagElement of tagElements; track tagElement) {
               <lib-form-field-container
                 [title]="tagElement.label"
-                [label]="'OPTIONAL'"
+                [label]="useStrictReadonlyForm ? '' : 'OPTIONAL'"
                 class="form-field-advanced"
                 >
                 <div [innerHTML]="tagElement.content | safe"></div>
@@ -165,18 +185,18 @@
             @if (!hideTags) {
               <lib-form-field-container
                 [title]="'Custom Tags'"
-                [label]="'OPTIONAL'"
+                [label]="useStrictReadonlyForm ? '' : 'OPTIONAL'"
                 class="form-field-advanced"
                 >
-                <lib-custom-tags [(tags)]="formData.tags"></lib-custom-tags>
+                <lib-custom-tags [(tags)]="formData.tags" [readOnly]="useStrictReadonlyForm"></lib-custom-tags>
               </lib-form-field-container>
             }
             <lib-form-field-container
               [title]="'App Data'"
-              [label]="'OPTIONAL'"
+              [label]="useStrictReadonlyForm ? '' : 'OPTIONAL'"
               class="form-field-advanced"
               >
-              <lib-json-view [(data)]="formData.appData"></lib-json-view>
+              <lib-json-view [(data)]="formData.appData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
             </lib-form-field-container>
           </div>
         </div>
@@ -201,6 +221,7 @@
                     </span>
                   }
                 </div>
+                @if (!useStrictReadonlyForm) {
                 <lib-qr-code
                   [identity]="formData"
                   [jwt]="jwt"
@@ -210,10 +231,11 @@
                   [canExpand]="true"
                   (doRefresh)="refreshIdentity(true)"
                 ></lib-qr-code>
+                }
               </div>
             </lib-form-field-container>
           }
-          @if (isEdit) {
+          @if (isEdit && !useStrictReadonlyForm) {
             <lib-form-field-container
               [showHeader]="false"
               [layout]="'column'"
@@ -316,7 +338,7 @@
     @if (formView === 'raw') {
       <div class="form-group-column">
         @if (formData) {
-          <lib-json-view [(data)]="formData"></lib-json-view>
+          <lib-json-view [(data)]="formData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
         }
       </div>
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/identity/identity-form.component.ts
@@ -126,7 +126,9 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
 
   override ngAfterViewInit() {
     super.ngAfterViewInit();
-    this.nameFieldInput.nativeElement.focus();
+    if (!this.useStrictReadonlyForm) {
+      this.nameFieldInput?.nativeElement?.focus();
+    }
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -337,6 +339,9 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
   }
 
   save(event?) {
+    if (!this.canSaveByPermissions()) {
+      return;
+    }
     this.formData.name = this.formData.name.trim();
     if(!this.validate()) {
       return;
@@ -430,6 +435,9 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
   }
 
   toggleIsAdmin() {
+    if (this.useStrictReadonlyForm) {
+      return;
+    }
     this.formData.isAdmin = !this.formData.isAdmin;
   }
 
@@ -465,6 +473,9 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
   }
 
   disableIdentity() {
+    if (this.useStrictReadonlyForm) {
+      return;
+    }
     const localDate = moment(this.disableDuration).local();
     const minutesDifference = localDate.diff(moment(), 'minutes');
     const confirmData = {
@@ -510,6 +521,9 @@ export class IdentityFormComponent extends ProjectableForm implements OnInit, On
   }
 
   enableIdentity() {
+    if (this.useStrictReadonlyForm) {
+      return;
+    }
     const confirmData = {
       appendId: 'EnableIdentity',
       title: 'Enable Identity',

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/jwt-signer/jwt-signer-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/jwt-signer/jwt-signer-form.component.html
@@ -9,16 +9,18 @@
     [moreActions]="moreActions"
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
-    [saveDisabled]="svc.saveDisabled || formDataInvalid"
+    [saveDisabled]="svc.saveDisabled || formDataInvalid || formPermissionSaveDisabled"
+    [saveTooltip]="formPermissionSaveTooltip"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="jwt-signer-form-container projectable-form-container" #scrollContainer>
     <div class="projectable-form-main-column form-group-row" [hidden]="formView !== 'simple'">
       <div class="form-group-column three-fifths">
         <lib-form-field-container
           [title]="'Name'"
-          [label]="'Required'"
+          [label]="useStrictReadonlyForm ? '' : 'REQUIRED'"
           >
-          <input class="form-field-input read-only" [(ngModel)]="formData.name" [ngClass]="{error: errors['name']}" placeholder="Name this JWT Signer" #nameFieldInput/>
+         <input class="form-field-input read-only" [(ngModel)]="formData.name" [ngClass]="{error: errors['name']}" placeholder="Name this JWT Signer" #nameFieldInput/>
         </lib-form-field-container>
         <lib-form-field-container
           [layout]="'column'"
@@ -34,9 +36,9 @@
                   matTooltipPosition="below"
                 ></div>
               </div>
-              <span class="form-field-label" >Required</span>
+              <span class="form-field-label" >{{ useStrictReadonlyForm ? '' : 'REQUIRED' }}</span>
             </div>
-            <input class="form-field-input" placeholder="Enter issuer" [(ngModel)]="formData.issuer" [ngClass]="{error: errors['issuer']}"/>
+            <input class="form-field-input" placeholder="Enter issuer" [(ngModel)]="formData.issuer" [ngClass]="{error: errors['issuer']}" [disabled]="useStrictReadonlyForm" />
           </div>
           <div class="form-field-label-container">
             <div class="form-field-title-container">
@@ -47,7 +49,7 @@
                 matTooltipPosition="below"
               ></div>
             </div>
-            <input class="form-field-input" placeholder="Enter audience" [(ngModel)]="formData.audience"/>
+            <input class="form-field-input" placeholder="Enter audience" [(ngModel)]="formData.audience" [disabled]="useStrictReadonlyForm" />
           </div>
           <div class="form-field-row">
             <div class="form-field-label-container">
@@ -59,7 +61,7 @@
                   matTooltipPosition="below"
                 ></div>
               </div>
-              <input class="form-field-input" placeholder="Enter claims property" [(ngModel)]="formData.claimsProperty" (keyup)="checkExternalIdToggle()" [ngClass]="{error: errors['claimsProperty']}"/>
+              <input class="form-field-input" placeholder="Enter claims property" [(ngModel)]="formData.claimsProperty" (keyup)="checkExternalIdToggle()" [ngClass]="{error: errors['claimsProperty']}" [disabled]="useStrictReadonlyForm" />
             </div>
             <div class="form-field-label-container">
               <div class="form-field-header">
@@ -78,8 +80,8 @@
                     <div class="config-container-label">Use External ID</div>
                   </div>
                   <div
-                    (click)="toggleUseExternalId()"
-                    [ngClass]="{ on: formData.useExternalId }"
+                    (click)="!useStrictReadonlyForm && toggleUseExternalId()"
+                    [ngClass]="{ on: formData.useExternalId, 'toggle-readonly': useStrictReadonlyForm }"
                     class="toggle"
                     >
                     <span [hidden]="!formData.useExternalId" class="on-label">YES</span>
@@ -103,7 +105,7 @@
                 matTooltipPosition="below"
               ></div>
             </div>
-            <input class="form-field-input" placeholder="Enter client ID" [(ngModel)]="formData.clientId"/>
+              <input class="form-field-input" placeholder="Enter client ID" [(ngModel)]="formData.clientId" [disabled]="useStrictReadonlyForm" />
           </div>
           <div class="form-field-label-container">
             <div class="form-field-title-container">
@@ -114,7 +116,7 @@
                 matTooltipPosition="below"
               ></div>
             </div>
-            <input class="form-field-input" placeholder="Enter external auth URL" [(ngModel)]="formData.externalAuthUrl"/>
+            <input class="form-field-input" placeholder="Enter external auth URL" [(ngModel)]="formData.externalAuthUrl" [disabled]="useStrictReadonlyForm" />
           </div>
           <div class="form-field-label-container">
             <div class="form-field-title-container">
@@ -132,6 +134,7 @@
               placeholder="Enter scopes"
               [addOnBlur]="true"
               separator=","
+              [disabled]="useStrictReadonlyForm"
             ></lib-chips-input>
           </div>
         </lib-form-field-container>
@@ -147,7 +150,7 @@
                   <div class="config-container-label">Auto-Enroll to Cert</div>
                   <div
                     (click)="toggleEnrollToCertEnabled()"
-                    [ngClass]="{ on: formData.enrollToCertEnabled }"
+                    [ngClass]="{ on: formData.enrollToCertEnabled, 'toggle-readonly': useStrictReadonlyForm }"
                     class="toggle"
                     >
                     <span [hidden]="!formData.enrollToCertEnabled" class="on-label">YES</span>
@@ -161,7 +164,7 @@
                   <div class="config-container-label">Auto-Enroll to Token</div>
                   <div
                     (click)="toggleEnrollToTokenEnabled()"
-                    [ngClass]="{ on: formData.enrollToTokenEnabled }"
+                    [ngClass]="{ on: formData.enrollToTokenEnabled, 'toggle-readonly': useStrictReadonlyForm }"
                     class="toggle"
                     >
                     <span [hidden]="!formData.enrollToTokenEnabled" class="on-label">YES</span>
@@ -185,6 +188,7 @@
               [(ngModel)]="targetToken"
               id="authPolicyId"
               class="form-field-dropdown"
+              [disabled]="useStrictReadonlyForm"
               >
               <option value="ACCESS">Access</option>
               <option value="ID">ID</option>
@@ -212,6 +216,7 @@
                   <div class="copy-button" (click)="copyCallbackURL()"></div>
                 </div>
               </div>
+              @if (!useStrictReadonlyForm) {
               <div class="test-oauth-button"
                 [ngClass]="{'oidc-verified': oidcVerified}"
                 (click)="testOIDCAuthentication()"
@@ -224,6 +229,7 @@
                   <input type="checkbox" [disabled]="true" [checked]="true" class="success-check">
                 }
               </div>
+              }
             </div>
             @if (oidcErrorMessageDetail) {
               <div class="oidc-error-message-container">
@@ -240,7 +246,7 @@
             @if (oidcAuthTokenClaims) {
               <div class="oidc-token-claims-container">
                 <code class="oidc-token-claims-title">OAuth Token Claims: </code>
-                <lib-json-view [showLineNumbers]="false" [(data)]="oidcAuthTokenClaims"></lib-json-view>
+                <lib-json-view [showLineNumbers]="false" [(data)]="oidcAuthTokenClaims" [readOnly]="useStrictReadonlyForm"></lib-json-view>
               </div>
             }
           </lib-form-field-container>
@@ -249,23 +255,36 @@
             [label]="'OPTIONAL'"
             class="form-field-advanced"
             >
-            <lib-custom-tags [(tags)]="formData.tags"></lib-custom-tags>
+            <lib-custom-tags [(tags)]="formData.tags" [readOnly]="useStrictReadonlyForm"></lib-custom-tags>
           </lib-form-field-container>
         </div>
       </div>
       <div class="form-group-column two-fifths">
         <lib-form-field-container
           [title]="'Verification'"
-          [label]="'REQUIRED'"
+          [label]="useStrictReadonlyForm ? '' : 'REQUIRED'"
           >
-          <div class="radio-group-container" (keydown)="radioKeyDownHandler($event)" tabindex="0">
-            <div class="radio-button-container" [ngClass]="{'selected': signatureMethod === 'JWKS_ENDPOINT'}" (click)="selectSignatureMethod('JWKS_ENDPOINT')">
+          <div
+            class="radio-group-container"
+            [class.radio-group-readonly]="useStrictReadonlyForm"
+            (keydown)="radioKeyDownHandler($event)"
+            [attr.tabindex]="useStrictReadonlyForm ? -1 : 0"
+            >
+            <div
+              class="radio-button-container"
+              [ngClass]="{'selected': signatureMethod === 'JWKS_ENDPOINT', 'toggle-readonly': useStrictReadonlyForm}"
+              (click)="!useStrictReadonlyForm && selectSignatureMethod('JWKS_ENDPOINT')"
+              >
               <div class="radio-button-circle">
                 <div class="radio-button-inner-circle"></div>
               </div>
               <span class="radio-button-label">JWKS Endpoint</span>
             </div>
-            <div class="radio-button-container" [ngClass]="{'selected': signatureMethod === 'CERT_PEM'}" (click)="selectSignatureMethod('CERT_PEM')">
+            <div
+              class="radio-button-container"
+              [ngClass]="{'selected': signatureMethod === 'CERT_PEM', 'toggle-readonly': useStrictReadonlyForm}"
+              (click)="!useStrictReadonlyForm && selectSignatureMethod('CERT_PEM')"
+              >
               <div class="radio-button-circle">
                 <div class="radio-button-inner-circle"></div>
               </div>
@@ -280,7 +299,13 @@
                     <span class="form-field-title">JWKS Endpoint</span>
                   </div>
                 </div>
-                <input class="form-field-input read-only" placeholder="Enter endpoint URL" [(ngModel)]="formData.jwksEndpoint" [ngClass]="{error: errors['jwksEndpoint']}"/>
+                <input
+                  class="form-field-input"
+                  placeholder="Enter endpoint URL"
+                  [(ngModel)]="formData.jwksEndpoint"
+                  [ngClass]="{error: errors['jwksEndpoint']}"
+                  [disabled]="useStrictReadonlyForm"
+                  />
               </div>
             </div>
           }
@@ -291,15 +316,30 @@
                   <div class="form-field-title-container">
                     <span class="form-field-title">PEM</span>
                   </div>
-                  <span class="select-file-button" (click)="openFileSelect($event)">
+                  <span
+                    class="select-file-button"
+                    [class.toggle-readonly]="useStrictReadonlyForm"
+                    (click)="!useStrictReadonlyForm && openFileSelect($event)"
+                    >
                     Select File
                     @if (fileSelectOpening) {
                       <div class="spinner"></div>
                     }
                   </span>
-                  <input #fileSelect type="file" style="display:none" (change)="selectPemFile($event)">
+                  <input
+                    #fileSelect
+                    type="file"
+                    style="display:none"
+                    [disabled]="useStrictReadonlyForm"
+                    (change)="selectPemFile($event)"
+                    >
                 </div>
-                <textarea placeholder="Paste pem contents or select file" [(ngModel)]="formData.certPem" [ngClass]="{error: errors['certPem']}"></textarea>
+                <textarea
+                  placeholder="Paste pem contents or select file"
+                  [(ngModel)]="formData.certPem"
+                  [ngClass]="{error: errors['certPem']}"
+                  [disabled]="useStrictReadonlyForm"
+                  ></textarea>
               </div>
               <div class="form-field-label-container">
                 <div class="form-field-header">
@@ -308,7 +348,7 @@
                   </div>
                   <span class="form-field-label" >Optional</span>
                 </div>
-                <input class="form-field-input" placeholder="Enter KID" [(ngModel)]="formData.kid"/>
+                <input class="form-field-input" placeholder="Enter KID" [(ngModel)]="formData.kid" [disabled]="useStrictReadonlyForm"/>
               </div>
             </div>
           }
@@ -320,8 +360,8 @@
             <div class="config-container toggle-container">
               <div class="config-container-label">ENABLED</div>
               <div
-                (click)="toggleEnabled()"
-                [ngClass]="{ on: formData.enabled }"
+                (click)="!useStrictReadonlyForm && toggleEnabled()"
+                [ngClass]="{ on: formData.enabled, 'toggle-readonly': useStrictReadonlyForm }"
                 class="toggle"
                 >
                 <span [hidden]="!formData.enabled" class="on-label">YES</span>
@@ -350,7 +390,7 @@
     @if (formView === 'raw') {
       <div class="form-group-column">
         @if (formData) {
-          <lib-json-view [(data)]="formData"></lib-json-view>
+          <lib-json-view [(data)]="formData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
         }
       </div>
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/jwt-signer/jwt-signer-form.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/jwt-signer/jwt-signer-form.component.scss
@@ -159,6 +159,18 @@
   }
 }
 
+.radio-button-container.toggle-readonly {
+  cursor: default;
+  pointer-events: none;
+  opacity: 0.92;
+}
+
+.select-file-button.toggle-readonly {
+  cursor: default;
+  pointer-events: none;
+  opacity: 0.85;
+}
+
 .test-oauth-button {
   color: var(--offWhite_ALWAYS);
   height: var(--defaultInputHeight);

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/jwt-signer/jwt-signer-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/jwt-signer/jwt-signer-form.component.ts
@@ -171,6 +171,9 @@ export class JwtSignerFormComponent extends ProjectableForm implements OnInit, O
     }
 
     async save(event?: any) {
+        if (!this.canSaveByPermissions()) {
+            return;
+        }
         if(!this.validate()) {
             return;
         }
@@ -354,10 +357,16 @@ export class JwtSignerFormComponent extends ProjectableForm implements OnInit, O
     }
 
     toggleEnabled() {
+        if (this.useStrictReadonlyForm) {
+            return;
+        }
         this.formData.enabled = !this.formData.enabled;
     }
 
     toggleUseExternalId() {
+        if (this.useStrictReadonlyForm) {
+            return;
+        }
         this.formData.useExternalId = !this.formData.useExternalId;
         if (!this.formData.useExternalId) {
             this.errors.claimsProperty = false;
@@ -381,6 +390,9 @@ export class JwtSignerFormComponent extends ProjectableForm implements OnInit, O
     }
 
     radioKeyDownHandler(event: any) {
+        if (this.useStrictReadonlyForm) {
+            return;
+        }
         switch (event.key) {
             case 'ArrowLeft':
                 this.signatureMethod = 'JWKS_ENDPOINT';
@@ -394,10 +406,16 @@ export class JwtSignerFormComponent extends ProjectableForm implements OnInit, O
     }
 
     selectSignatureMethod(method) {
+        if (this.useStrictReadonlyForm) {
+            return;
+        }
         this.signatureMethod = method;
     }
 
     openFileSelect(event: any) {
+        if (this.useStrictReadonlyForm) {
+            return;
+        }
         this.filterInput.nativeElement.click();
         this.fileSelectOpening = true;
         delay(() => {
@@ -406,6 +424,9 @@ export class JwtSignerFormComponent extends ProjectableForm implements OnInit, O
     }
 
     selectPemFile(event: any) {
+        if (this.useStrictReadonlyForm) {
+            return;
+        }
         const file: File = event?.target?.files[0];
 
         if (file) {

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/posture-check/posture-check-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/posture-check/posture-check-form.component.html
@@ -11,38 +11,44 @@
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
     [class.is-scrolled]="isScrolled"
+    [saveDisabled]="formPermissionSaveDisabled"
+    [saveTooltip]="formPermissionSaveTooltip"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="posture-checkform-container projectable-form-container" #formContainer>
     <div class="projectable-form-main-column form-group-row" [hidden]="formView !== 'simple'">
       <div class="form-group-column three-fifths">
-        <lib-form-field-container [title]="'Name'" [label]="'Required'">
-          <input
+        <lib-form-field-container [title]="'Name'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'">
+            <input
             id="PostureCheckName"
             type="text"
             maxlength="500"
             placeholder="Name this posture check"
             [ngClass]="{error: errors['name']}"
             [(ngModel)]="formData.name"
+            [disabled]="useStrictReadonlyForm"
             >
         </lib-form-field-container>
         <lib-form-field-container
           [title]="'Select or create Posture Check attributes'"
-          [label]="'OPTIONAL'"
+          [label]="useStrictReadonlyForm ? '' : 'OPTIONAL'"
           [contentStyle]="'z-index: 99999999'"
           [helpText]="'Attributes are tags applied to an resource. Apply the same tag to other Posture Checks to form a group of Posture Checks.'"
           >
           <lib-tag-selector
+            [disableField]="useStrictReadonlyForm"
+            [disableCreate]="useStrictReadonlyForm"
             [(selectedRoleAttributes)]="formData.roleAttributes"
             [availableRoleAttributes]="pcRoleAttributes"
             [placeholder]="'Add attributes to group Posture Checks'"
           ></lib-tag-selector>
         </lib-form-field-container>
-        <lib-form-field-container [title]="'Type'" [label]="'Required'" class="schema-json-editor">
+        <lib-form-field-container [title]="'Type'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'" class="schema-json-editor">
           @if (postureCheckTypes.length > 0) {
             <select
               [(ngModel)]="formData.typeId"
               (change)="pcTypeChanged($event)"
-              [disabled]="formData.id"
+              [disabled]="formData.id || useStrictReadonlyForm"
               [matTooltip]="formData.id ? 'Type cannot be changed' : ''"
               matTooltipPosition="below"
               id="SelectedConfigType"
@@ -61,7 +67,7 @@
           }
         </lib-form-field-container>
         @if (formData.typeId === 'MAC') {
-          <lib-form-field-container [title]="'MAC Addresses'" [label]="'Required'">
+          <lib-form-field-container [title]="'MAC Addresses'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'">
             <lib-chips-input
               (keyup)="macAddressesChange($event)"
               [(ngModel)]="formData.macAddresses"
@@ -72,11 +78,12 @@
               [invalid]="errors['macAddresses']"
               separator=","
               (keyup.enter)="preventEnterProp($event)"
+              [disabled]="useStrictReadonlyForm"
             ></lib-chips-input>
           </lib-form-field-container>
         }
         @if (formData.typeId === 'DOMAIN') {
-          <lib-form-field-container [title]="'Windows Domain Details'" [label]="'Required'">
+          <lib-form-field-container [title]="'Windows Domain Details'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'">
             <lib-chips-input
               (keyup)="macAddressesChange($event)"
               [(ngModel)]="formData.domains"
@@ -91,7 +98,7 @@
           </lib-form-field-container>
         }
         @if (formData.typeId === 'PROCESS') {
-          <lib-form-field-container [title]="'Process Details'" [contentClass]="'form-field-input-group'">
+          <lib-form-field-container [title]="'Process Details'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'" [contentClass]="'form-field-input-group'">
             <div class="form-field-label-container process-os-details-header">
               <div class="form-field-header">
                 <div class="form-field-title-container">
@@ -145,6 +152,7 @@
                 [invalid]="errors['processHashes']"
                 separator=","
                 (keyup.enter)="preventEnterProp($event)"
+                [disabled]="useStrictReadonlyForm"
               ></lib-chips-input>
             </div>
             <div class="form-field-label-container">
@@ -173,7 +181,7 @@
           </lib-form-field-container>
         }
         @if (formData.typeId === 'PROCESS_MULTI') {
-          <lib-form-field-container [title]="'Process Multi Details'">
+          <lib-form-field-container [title]="'Process Multi Details'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'" >
             <div class="form-field-label-container">
               <div class="form-field-header">
                 <div class="form-field-title-container">
@@ -248,6 +256,7 @@
                     [invalid]="errors['processHashes']"
                     separator=","
                     (keyup.enter)="preventEnterProp($event)"
+                    [disabled]="useStrictReadonlyForm"
                   ></lib-chips-input>
                 </div>
                 <div class="form-field-label-container">
@@ -280,6 +289,7 @@
                     [invalid]="errors['process[' + i +'].signerFingerprints']"
                     separator=","
                     (keyup.enter)="preventEnterProp($event)"
+                    [disabled]="useStrictReadonlyForm"
                   ></lib-chips-input>
                 </div>
               </div>
@@ -293,6 +303,7 @@
           <lib-form-field-container
             [title]="'Multi Factor Details'"
             [layout]="'column'"
+            [label]="useStrictReadonlyForm ? '' : 'REQUIRED'"
             >
             <div class="form-field-row">
               <div class="form-field-label-container">
@@ -344,6 +355,7 @@
           <lib-form-field-container
             [showHeader]="false"
             [layout]="'column'"
+            [label]="useStrictReadonlyForm ? '' : 'REQUIRED'"
             >
             <div class="form-field-row os-version-row">
               <div class="config-item os-toggle-container">
@@ -514,7 +526,7 @@
               [label]="'OPTIONAL'"
               class="form-field-advanced"
               >
-              <lib-custom-tags [(tags)]="formData.tags"></lib-custom-tags>
+              <lib-custom-tags [(tags)]="formData.tags" [readOnly]="useStrictReadonlyForm"></lib-custom-tags>
             </lib-form-field-container>
           }
         </div>
@@ -539,7 +551,7 @@
     @if (formView === 'raw') {
       <div class="form-group-column">
         @if (formData) {
-          <lib-json-view [(data)]="formData"></lib-json-view>
+          <lib-json-view [(data)]="formData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
         }
       </div>
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/posture-check/posture-check-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/posture-check/posture-check-form.component.ts
@@ -336,6 +336,9 @@ export class PostureCheckFormComponent extends ProjectableForm implements OnInit
     }
 
     async save(event?: any) {
+        if (!this.canSaveByPermissions()) {
+            return;
+        }
         this.errors = {};
         if (!this.validate()) {
             this.isLoading = false;

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.scss
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.scss
@@ -1,0 +1,18 @@
+/* Global admin_readonly without write grant: block interaction in the form body; header stays active. */
+:host.zac-management-readonly-form .projectable-form-container {
+    pointer-events: none;
+}
+
+:host.zac-management-readonly-form .projectable-form-container lib-config-editor,
+:host.zac-management-readonly-form .projectable-form-container lib-form-field-toggle,
+:host.zac-management-readonly-form .projectable-form-container lib-tag-selector,
+:host.zac-management-readonly-form .projectable-form-container lib-custom-tags,
+:host.zac-management-readonly-form .projectable-form-container lib-json-view,
+:host.zac-management-readonly-form .projectable-form-container lib-preview-list,
+:host.zac-management-readonly-form .projectable-form-container .copy-text,
+:host.zac-management-readonly-form .projectable-form-container [class*='icon-copy'],
+:host.zac-management-readonly-form .projectable-form-container .url-copy,
+:host.zac-management-readonly-form .projectable-form-container .copy-token-container,
+:host.zac-management-readonly-form .projectable-form-container .linkButton.cancel {
+    pointer-events: auto;
+}

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/projectable-form.class.ts
@@ -15,7 +15,7 @@
 */
 
 import {ExtendableComponent} from "../extendable/extendable.component";
-import {Component, DoCheck, ElementRef, EventEmitter, HostListener, Inject, Input, OnDestroy, OnInit, Output, ViewChild} from "@angular/core";
+import {Component, DoCheck, ElementRef, EventEmitter, HostBinding, HostListener, Inject, Input, OnDestroy, OnInit, Output, ViewChild, inject} from "@angular/core";
 
 import {defer, isEqual, unset, debounce, cloneDeep, forEach, isArray, isEmpty, isObject, isNil, map, omitBy, slice, get} from "lodash";
 import {GrowlerModel} from "../messaging/growler.model";
@@ -30,6 +30,7 @@ import {SETTINGS_SERVICE, SettingsService} from "../../services/settings.service
 import {URLS} from "../../urls";
 import {MatDialog} from "@angular/material/dialog";
 import {ConfirmComponent} from "../confirm/confirm.component";
+import {ManagementPermissionsService} from "../../services/management-permissions.service";
 
 export class Entity {
     name: ''
@@ -101,6 +102,8 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
 
     subscription: Subscription = new Subscription();
 
+    protected readonly managementPermissions = inject(ManagementPermissionsService);
+
     formInit = false;
 
     @ViewChild('formContainer') formContainer!: ElementRef;
@@ -165,10 +168,32 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
         return !isEmpty(this.formData.id);
     }
 
+    get formPermissionSaveDisabled(): boolean {
+        return this.managementPermissions.isSaveDisabled(this.entityType, this.isEdit);
+    }
+
+    get formPermissionSaveTooltip(): string {
+        return this.formPermissionSaveDisabled ? this.managementPermissions.saveDeniedTooltip : '';
+    }
+
+    get useStrictReadonlyForm(): boolean {
+        return this.managementPermissions.useStrictReadonlyFormUi(this.entityType, this.isEdit);
+    }
+
+    /** Blocks save from shortcuts/callbacks when the controller denies create/update for this resource. */
+    protected canSaveByPermissions(): boolean {
+        return !this.managementPermissions.isSaveDisabled(this.entityType, this.isEdit);
+    }
+
+    @HostBinding('class.zac-management-readonly-form')
+    get zacManagementReadonlyHostClass(): boolean {
+        return this.useStrictReadonlyForm;
+    }
+
     override ngAfterViewInit(skipFocus = false) {
         super.ngAfterViewInit();
         this.errors = {};
-        if (!skipFocus) {
+        if (!skipFocus && !this.useStrictReadonlyForm) {
             this.nameFieldInput?.nativeElement?.focus();
         }
         if (this.extService?.moreActions) {
@@ -338,7 +363,7 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
                 name: 'delete',
                 label: 'Delete',
                 icon: 'icon-trash',
-                hidden: () => false
+                hidden: () => !this.managementPermissions.canDelete(this.entityType),
             });
         }
     }
@@ -354,6 +379,10 @@ export abstract class ProjectableForm extends ExtendableComponent implements DoC
     protected deleteEntity() {
         if (!this.dialogForm) {
             console.error('MatDialog not injected. Cannot show delete confirmation.');
+            return;
+        }
+
+        if (!this.managementPermissions.canDelete(this.entityType)) {
             return;
         }
 

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service-edge-router-policy/service-edge-router-policy-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service-edge-router-policy/service-edge-router-policy-form.component.html
@@ -10,20 +10,24 @@
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
     [class.is-scrolled]="isScrolled"
+    [saveDisabled]="formPermissionSaveDisabled"
+    [saveTooltip]="formPermissionSaveTooltip"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="service-edge-router-policy-form-container projectable-form-container" #formContainer>
     @if (formView === 'simple') {
       <div class="projectable-form-main-column form-group-row">
         <div class="form-group-column three-fifths">
-          <lib-form-field-container [title]="'Service Edge Router Policy Name'" [label]="'REQUIRED'">
-            <input
-              class="form-field-input"
-              placeholder="Name this service edge router policy"
-              [ngClass]="{error: errors['name']}"
-              [(ngModel)]="formData.name"
-              autofocus
-              #nameFieldInput
-              />
+          <lib-form-field-container [title]="'Service Edge Router Policy Name'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'">
+              <input
+                class="form-field-input"
+                placeholder="Name this service edge router policy"
+                [ngClass]="{error: errors['name']}"
+                [(ngModel)]="formData.name"
+                autofocus
+                #nameFieldInput
+                [disabled]="useStrictReadonlyForm"
+                />
           </lib-form-field-container>
           <lib-form-field-container
             [title]="'Select Edge Router Attributes'"
@@ -32,6 +36,8 @@
             [helpText]="'Choose which edge router to associate to this policy by picking from the list of available attributes'"
             >
             <lib-tag-selector
+              [disableField]="useStrictReadonlyForm"
+              [disableCreate]="useStrictReadonlyForm"
               [(selectedRoleAttributes)]="selectedEdgeRouterRoleAttributes"
               [(selectedNamedAttributes)]="selectedEdgeRouterNamedAttributes"
               [availableRoleAttributes]="svc.edgeRouterRoleAttributes"
@@ -48,6 +54,8 @@
             [helpText]="'Choose which services to associate to this policy by picking from the list of available attributes'"
             >
             <lib-tag-selector
+              [disableField]="useStrictReadonlyForm"
+              [disableCreate]="useStrictReadonlyForm"
               [(selectedRoleAttributes)]="selectedServiceRoleAttributes"
               [(selectedNamedAttributes)]="selectedServiceNamedAttributes"
               [availableRoleAttributes]="svc.serviceRoleAttributes"
@@ -66,6 +74,7 @@
               (change)="updateAssociations()"
               id="PolicySemantic"
               class="form-field-dropdown"
+              [disabled]="useStrictReadonlyForm"
               >
               <option value="AnyOf">AnyOf</option>
               <option value="AllOf">AllOf</option>
@@ -79,7 +88,7 @@
                 [label]="'OPTIONAL'"
                 class="form-field-advanced"
                 >
-                <lib-custom-tags [(tags)]="formData.tags"></lib-custom-tags>
+                <lib-custom-tags [(tags)]="formData.tags" [readOnly]="useStrictReadonlyForm"></lib-custom-tags>
               </lib-form-field-container>
             }
           </div>
@@ -127,7 +136,7 @@
     @if (formView === 'raw') {
       <div class="form-group-column">
         @if (formData) {
-          <lib-json-view [(data)]="formData"></lib-json-view>
+          <lib-json-view [(data)]="formData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
         }
       </div>
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service-edge-router-policy/service-edge-router-policy-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service-edge-router-policy/service-edge-router-policy-form.component.ts
@@ -187,6 +187,9 @@ export class ServiceEdgeRouterPolicyFormComponent extends ProjectableForm implem
   }
 
   async save(event?) {
+    if (!this.canSaveByPermissions()) {
+      return;
+    }
     this.formData.name = this.formData.name.trim();
     const isValid = this.validate();
     const isExtValid = await this.extService.validateData();

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.component.html
@@ -10,20 +10,24 @@
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
     [class.is-scrolled]="isScrolled"
+    [saveDisabled]="formPermissionSaveDisabled"
+    [saveTooltip]="formPermissionSaveTooltip"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="service-policy-form-container projectable-form-container" #formContainer>
     @if (formView === 'simple') {
       <div class="projectable-form-main-column form-group-row">
         <div class="form-group-column three-fifths">
-          <lib-form-field-container [title]="'Service Policy Name'" [label]="'REQUIRED'">
-            <input
-              class="form-field-input"
-              placeholder="Name this service policy"
-              [ngClass]="{error: errors['name']}"
-              [(ngModel)]="formData.name"
-              autofocus
-              #nameFieldInput
-              />
+          <lib-form-field-container [title]="'Service Policy Name'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'">
+              <input
+                class="form-field-input"
+                placeholder="Name this service policy"
+                [ngClass]="{error: errors['name']}"
+                [(ngModel)]="formData.name"
+                autofocus
+                #nameFieldInput
+                [disabled]="useStrictReadonlyForm"
+                />
           </lib-form-field-container>
           <lib-form-field-container
             [title]="'Select Service Attributes'"
@@ -32,6 +36,8 @@
             [helpText]="'Choose which services to associate to this policy by picking from the list of available attributes'"
             >
             <lib-tag-selector
+              [disableField]="useStrictReadonlyForm"
+              [disableCreate]="useStrictReadonlyForm"
               [(selectedRoleAttributes)]="selectedServiceRoleAttributes"
               [(selectedNamedAttributes)]="selectedServiceNamedAttributes"
               [availableRoleAttributes]="svc.serviceRoleAttributes"
@@ -48,6 +54,8 @@
             [helpText]="'Choose which identities to associate to this policy by picking from the list of available attributes'"
             >
             <lib-tag-selector
+              [disableField]="useStrictReadonlyForm"
+              [disableCreate]="useStrictReadonlyForm"
               [(selectedRoleAttributes)]="selectedIdentityRoleAttributes"
               [(selectedNamedAttributes)]="selectedIdentityNamedAttributes"
               [availableRoleAttributes]="svc.identityRoleAttributes"
@@ -64,6 +72,8 @@
             [helpText]="'Choose which posture checks to associate to this policy by picking from the list of available attributes'"
             >
             <lib-tag-selector
+              [disableField]="useStrictReadonlyForm"
+              [disableCreate]="useStrictReadonlyForm"
               [(selectedRoleAttributes)]="selectedPostureRoleAttributes"
               [(selectedNamedAttributes)]="selectedPostureNamedAttributes"
               [(selectedRoleAttributes)]="svc.postureRoleAttributes"
@@ -83,6 +93,7 @@
               (change)="onPolicyTypeChanged()"
               id="PolicyType"
               class="form-field-dropdown"
+              [disabled]="useStrictReadonlyForm"
               >
               <option value="Bind">Bind</option>
               <option value="Dial">Dial</option>
@@ -92,6 +103,7 @@
               (change)="onPolicySemanticChanged()"
               id="PolicySemantic"
               class="form-field-dropdown"
+              [disabled]="useStrictReadonlyForm"
               >
               <option value="AnyOf">AnyOf</option>
               <option value="AllOf">AllOf</option>
@@ -106,7 +118,7 @@
                 [label]="'OPTIONAL'"
                 class="form-field-advanced"
                 >
-                <lib-custom-tags [(tags)]="formData.tags"></lib-custom-tags>
+                <lib-custom-tags [(tags)]="formData.tags" [readOnly]="useStrictReadonlyForm"></lib-custom-tags>
               </lib-form-field-container>
             }
           </div>
@@ -166,7 +178,7 @@
     @if (formView === 'raw') {
       <div class="form-group-column">
         @if (formData) {
-          <lib-json-view [(data)]="formData"></lib-json-view>
+          <lib-json-view [(data)]="formData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
         }
       </div>
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service-policy/service-policy-form.component.ts
@@ -225,6 +225,9 @@ export class ServicePolicyFormComponent extends ProjectableForm implements OnIni
   }
 
   async save(event?) {
+    if (!this.canSaveByPermissions()) {
+      return;
+    }
     this.formData.name = this.formData.name.trim();
     const isValid = this.validate();
     const isExtValid = await this.extService.validateData();

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.html
@@ -10,51 +10,57 @@
     [moreActions]="moreActions"
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
-    [saveDisabled]="svc.saveDisabled || formDataInvalid"
-    [saveTooltip]="saveButtonTooltip"
+    [saveDisabled]="svc.saveDisabled || formDataInvalid || formPermissionSaveDisabled"
+    [saveTooltip]="formPermissionSaveDisabled ? formPermissionSaveTooltip : saveButtonTooltip"
     [class.is-scrolled]="isScrolled"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="edge-router-form-container projectable-form-container" #formContainer>
     <div class="projectable-form-main-column form-group-row" [hidden]="formView !== 'simple'">
       <div class="form-group-column three-fifths">
-        <lib-form-field-container [title]="'Service Name'" [label]="'Required'">
-          <input
-            class="form-field-input"
-            placeholder="Name this Service"
-            [ngClass]="{error: svc.errors['name']}"
-            [(ngModel)]="formData.name"
-            autofocus
-            #nameFieldInput
-            />
+        <lib-form-field-container [title]="'Service Name'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'">
+            <input
+              class="form-field-input"
+              placeholder="Name this Service"
+              [ngClass]="{error: svc.errors['name']}"
+              [(ngModel)]="formData.name"
+              autofocus
+              #nameFieldInput
+              [disabled]="useStrictReadonlyForm"
+              />
         </lib-form-field-container>
         <lib-form-field-container
           [title]="'Select or create Service attributes'"
-          [label]="'Optional'"
+          [label]="useStrictReadonlyForm ? '' : 'OPTIONAL'"
           [contentStyle]="'z-index: 99999999'"
           [helpText]="'Attributes are tags applied to a resource. Apply the same tag to other Services to form a group of Services.'"
           >
           <lib-tag-selector
+            [disableField]="useStrictReadonlyForm"
+            [disableCreate]="useStrictReadonlyForm"
             [(selectedRoleAttributes)]="formData.roleAttributes"
             [availableRoleAttributes]="serviceRoleAttributes"
             [placeholder]="'Add attributes to group Services'"
           ></lib-tag-selector>
         </lib-form-field-container>
-        <lib-form-field-container
-          [title]="'Add Configurations'"
-          (actionRequested)="attachConfig()"
-          (keyup.enter)="captureConfigEnterEvent($event)"
-          [helpText]="'Configurations are used to define how to intercept and host a service. Ziti Networks come with built-in configuration types (ie. intercept.v1 and host.v1)'"
-          >
-          <div class="form-field-input-group">
-            <div class="config-title-row">
-              <span class="form-field-title">Select a Config</span>
-            </div>
-            <select
-              [(ngModel)]="svc.selectedConfigTypeId"
-              (change)="configTypeChanged($event)"
-              id="SelectedConfigType"
-              class="form-field-dropdown"
-              >
+        @if (!useStrictReadonlyForm) {
+          <lib-form-field-container
+            [title]="'Add Configurations'"
+            (actionRequested)="attachConfig()"
+            (keyup.enter)="captureConfigEnterEvent($event)"
+            [helpText]="'Configurations are used to define how to intercept and host a service. Ziti Networks come with built-in configuration types (ie. intercept.v1 and host.v1)'"
+            >
+            <div class="form-field-input-group">
+              <div class="config-title-row">
+                <span class="form-field-title">Select a Config</span>
+              </div>
+              <select
+                [(ngModel)]="svc.selectedConfigTypeId"
+                (change)="configTypeChanged($event)"
+                id="SelectedConfigType"
+                class="form-field-dropdown"
+                [disabled]="useStrictReadonlyForm"
+                >
               <option value="">Select configuration type...</option>
               @for (type of svc.configTypes; track type) {
                 <option
@@ -98,13 +104,13 @@
                 </div>
               }
               @if (showConfigData) {
-                <input
-                  [(ngModel)]="svc.newConfigName"
-                  class="form-field-input"
-                  [placeholder]="'New Config Name'"
-                  [ngClass]="{error: svc.configErrors['name']}"
-                  style="margin-bottom: 20px;"
-                  />
+                  <input
+                    [(ngModel)]="svc.newConfigName"
+                    class="form-field-input"
+                    [placeholder]="'New Config Name'"
+                    [ngClass]="{error: svc.configErrors['name']}"
+                    style="margin-bottom: 20px;"
+                    />
               }
               <div class="config-title-row" style="margin-bottom: 10px;">
                 <span class="form-field-title">Configuration Data</span>
@@ -145,7 +151,8 @@
               ></lib-config-editor>
             </div>
           </div>
-        </lib-form-field-container>
+          </lib-form-field-container>
+        }
         <lib-form-field-toggle [(toggleOn)]="showMore" style="margin: 0px 10px"></lib-form-field-toggle>
         @if (showMore) {
           <div class="form-group-column">
@@ -161,6 +168,7 @@
                 [(ngModel)]="formData.terminatorStrategy"
                 id="authPolicyId"
                 class="form-field-dropdown"
+                [disabled]="useStrictReadonlyForm"
                 >
                 <option value="">Select a Strategy....</option>
                 @for (strat of strategies; track strat) {
@@ -176,7 +184,7 @@
                   <div class="config-container-label">Require Encryption</div>
                   <div
                     (click)="toggleEncryptionRequired()"
-                    [ngClass]="{ on: formData.encryptionRequired }"
+                    [ngClass]="{ on: formData.encryptionRequired, 'toggle-readonly': useStrictReadonlyForm }"
                     class="toggle"
                     >
                     <span [hidden]="!formData.encryptionRequired" class="on-label">YES</span>
@@ -191,7 +199,7 @@
               [label]="'OPTIONAL'"
               class="form-field-advanced"
               >
-              <lib-custom-tags [(tags)]="formData.tags"></lib-custom-tags>
+              <lib-custom-tags [(tags)]="formData.tags" [readOnly]="useStrictReadonlyForm"></lib-custom-tags>
             </lib-form-field-container>
           </div>
         }
@@ -212,7 +220,7 @@
           <lib-preview-list
             [isLoading]="svc.associatedConfigsLoading"
             [allNames]="svc.addedConfigs"
-            [allowRemove]="true"
+            [allowRemove]="!useStrictReadonlyForm"
             [clickable]="true"
             [tooltip]="'View Config'"
             [showfilter]="false"
@@ -279,7 +287,7 @@
   @if (formView === 'raw') {
     <div class="form-group-column">
       @if (formData) {
-        <lib-json-view [(data)]="formData" [(jsonInvalid)]="formDataInvalid"></lib-json-view>
+        <lib-json-view [(data)]="formData" [(jsonInvalid)]="formDataInvalid" [readOnly]="useStrictReadonlyForm"></lib-json-view>
       }
     </div>
   }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.ts
@@ -173,9 +173,13 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
 
   override ngAfterViewInit() {
     super.ngAfterViewInit();
-    this.nameFieldInput.nativeElement.focus();
+    if (!this.useStrictReadonlyForm) {
+      this.nameFieldInput?.nativeElement?.focus();
+    }
     this.svc.configEditor = this.configEditor;
-    this.svc.getConfigTypes();
+    if (!this.useStrictReadonlyForm) {
+      this.svc.getConfigTypes();
+    }
     this.svc.getRouters();
   }
 
@@ -216,6 +220,9 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
   }
 
   configTypeChanged($event) {
+    if (this.useStrictReadonlyForm) {
+      return;
+    }
     this.svc.selectedConfigId = '';
     this.svc.newConfigName = '';
     const filters = [];
@@ -244,13 +251,20 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
   }
 
   attachConfig() {
-    this.configEditor.getConfigDataFromForm();
+    if (this.useStrictReadonlyForm) {
+      return;
+    }
+    this.configEditor?.getConfigDataFromForm();
     this.svc.attachConfig(this.svc.selectedConfigId);
   }
 
   captureConfigEnterEvent(event) {
+    if (this.useStrictReadonlyForm) {
+      event.stopPropagation();
+      return;
+    }
     event.stopPropagation();
-    this.configEditor.getConfigDataFromForm();
+    this.configEditor?.getConfigDataFromForm();
     this.svc.attachConfig(this.svc.selectedConfigId);
   }
 
@@ -392,6 +406,9 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
   }
 
   async save(event?) {
+    if (!this.canSaveByPermissions()) {
+      return;
+    }
     this.formData.name = this.formData.name.trim();
     const isValid = this.svc.validate();
     const isExtValid = await this.extService.validateData();
@@ -428,6 +445,9 @@ export class ServiceFormComponent extends ProjectableForm implements OnInit, OnC
   }
 
   toggleEncryptionRequired() {
+    if (this.useStrictReadonlyForm) {
+      return;
+    }
     this.formData.encryptionRequired = !this.formData.encryptionRequired;
   }
 

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.html
@@ -14,6 +14,7 @@
     [(formView)]="formView"
     [moreActions]="moreActions"
     [class.is-scrolled]="isScrolled"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
 
   <div class="simple-service-form-container projectable-form-container" #formContainer>
@@ -27,7 +28,8 @@
                   <div class="config-title-row">
                     <span class="form-field-title">Service Name</span>
                   </div>
-                  <input
+                  @if (!useStrictReadonlyForm) {
+                    <input
                     class="form-field-input"
                     placeholder="Name this service"
                     autofocus
@@ -37,12 +39,17 @@
                     (keyup)="serviceNameChanged($event)"
                     (change)="validateServiceName()"
                     />
+                  } @else {
+                    <div class="form-field-readonly-value">{{ serviceApiData.name }}</div>
+                  }
                 </div>
                 <div class="form-field-sub-group">
                   <div class="config-title-row">
                     <span class="form-field-title">SELECT OR CREATE SERVICE ATTRIBUTES</span>
                   </div>
                   <lib-tag-selector
+                    [disableField]="useStrictReadonlyForm"
+                    [disableCreate]="useStrictReadonlyForm"
                     [(selectedRoleAttributes)]="serviceApiData.roleAttributes"
                     [availableRoleAttributes]="serviceRoleAttributes"
                     [placeholder]="'Add attributes to group services'"
@@ -68,6 +75,8 @@
                   <span class="form-field-title">What identities can access this service?</span>
                 </div>
                 <lib-tag-selector
+                  [disableField]="useStrictReadonlyForm"
+                  [disableCreate]="useStrictReadonlyForm"
                   [(selectedNamedAttributes)]="dialPolicyNamedAttributes"
                   [(selectedRoleAttributes)]="dialPolicyRoleAttributes"
                   [availableNamedAttributes]="identityNamedAttributes"
@@ -137,6 +146,8 @@
                   <span class="form-field-title">What identities can host this service?</span>
                 </div>
                 <lib-tag-selector
+                  [disableField]="useStrictReadonlyForm"
+                  [disableCreate]="useStrictReadonlyForm"
                   [(selectedNamedAttributes)]="bindPolicyNamedAttributes"
                   [(selectedRoleAttributes)]="bindPolicyRoleAttributes"
                   [availableNamedAttributes]="identityNamedAttributes"

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/simple-service/simple-service.component.ts
@@ -480,6 +480,9 @@ export class SimpleServiceComponent extends ProjectableForm {
   }
 
   async save(refresh?) {
+    if (!this.canSaveByPermissions()) {
+      return;
+    }
     this.serviceApiData.name = this.serviceApiData.name.trim();
     if (!this.validate()) {
       return;

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/session/session-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/session/session-form.component.html
@@ -9,6 +9,7 @@
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
     [showHeaderButton]="false"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="edge-router-form-container projectable-form-container">
     @if (formView === 'simple') {
@@ -128,7 +129,7 @@
     @if (formView === 'raw') {
       <div class="form-group-column">
         @if (formData) {
-          <lib-json-view [(data)]="formData"></lib-json-view>
+          <lib-json-view [(data)]="formData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
         }
       </div>
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/terminator/terminator-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/terminator/terminator-form.component.html
@@ -9,7 +9,9 @@
     [moreActions]="moreActions"
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
-    [saveDisabled]="svc.saveDisabled || formDataInvalid"
+    [saveDisabled]="svc.saveDisabled || formDataInvalid || formPermissionSaveDisabled"
+    [saveTooltip]="formPermissionSaveTooltip"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="terminator-form-container projectable-form-container">
     <div class="projectable-form-main-column form-group-row" [hidden]="formView !== 'simple'">
@@ -102,7 +104,7 @@
 @if (formView === 'raw') {
   <div class="form-group-column">
     @if (formData) {
-      <lib-json-view [(data)]="formData"></lib-json-view>
+      <lib-json-view [(data)]="formData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
     }
   </div>
 }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/terminator/terminator-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/terminator/terminator-form.component.ts
@@ -131,6 +131,9 @@ export class TerminatorFormComponent extends ProjectableForm implements OnInit, 
     }
 
     async save(event?: any) {
+        if (!this.canSaveByPermissions()) {
+            return;
+        }
         if(!this.validate()) {
             return;
         }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/transit-router/transit-router-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/transit-router/transit-router-form.component.html
@@ -8,20 +8,24 @@
     [moreActions]="moreActions"
     (actionRequested)="headerActionRequested($event)"
     [(formView)]="formView"
+    [saveDisabled]="formPermissionSaveDisabled"
+    [saveTooltip]="formPermissionSaveTooltip"
+    [strictReadonlyUi]="useStrictReadonlyForm"
   ></lib-form-header>
   <div class="edge-router-form-container projectable-form-container">
     @if (formView === 'simple') {
       <div class="projectable-form-main-column form-group-row">
         <div class="form-group-column three-fifths">
-          <lib-form-field-container [title]="'Edge Router Name'" [label]="'REQUIRED'">
-            <input
-              class="form-field-input"
-              placeholder="Name this edge router"
-              [ngClass]="{error: errors['name']}"
-              [(ngModel)]="formData.name"
-              autofocus
-              #nameFieldInput
-              />
+          <lib-form-field-container [title]="'Transit Router Name'" [label]="useStrictReadonlyForm ? '' : 'REQUIRED'">
+              <input
+                class="form-field-input"
+                placeholder="Name this transit router"
+                [ngClass]="{error: errors['name']}"
+                [(ngModel)]="formData.name"
+                autofocus
+                #nameFieldInput
+                [disabled]="useStrictReadonlyForm"
+                />
           </lib-form-field-container>
           <lib-form-field-container
             [showHeader]="false"
@@ -31,20 +35,21 @@
               <div class="form-field-title-container">
                 <span class="form-field-title">Cost</span>
               </div>
-              <input
-                type="number"
-                class="form-field-input"
+                <input
+                  type="number"
+                  class="form-field-input"
                 placeholder="Name this edge router"
-                [ngClass]="{error: errors['cost']}"
-                [(ngModel)]="formData.cost"
-                />
+                  [ngClass]="{error: errors['cost']}"
+                  [(ngModel)]="formData.cost"
+                  [disabled]="useStrictReadonlyForm"
+                  />
             </div>
             <div class="config-item">
               <div class="config-container toggle-container">
                 <div class="config-container-label">ENABLED</div>
                 <div
-                  (click)="toggleDisabled()"
-                  [ngClass]="{ on: !formData.disabled }"
+                  (click)="!useStrictReadonlyForm && toggleDisabled()"
+                  [ngClass]="{ on: !formData.disabled, 'toggle-readonly': useStrictReadonlyForm }"
                   class="toggle"
                   >
                   <span [hidden]="formData.disabled" class="on-label">YES</span>
@@ -57,8 +62,8 @@
               <div class="config-container toggle-container">
                 <div class="config-container-label">ALLOW TRAVERSAL</div>
                 <div
-                  (click)="toggleNoTraversal()"
-                  [ngClass]="{ on: !formData.noTraversal }"
+                  (click)="!useStrictReadonlyForm && toggleNoTraversal()"
+                  [ngClass]="{ on: !formData.noTraversal, 'toggle-readonly': useStrictReadonlyForm }"
                   class="toggle"
                   >
                   <span [hidden]="formData.noTraversal" class="on-label">YES</span>
@@ -77,7 +82,7 @@
                 [label]="'OPTIONAL'"
                 class="form-field-advanced"
                 >
-                <lib-custom-tags [(tags)]="formData.tags"></lib-custom-tags>
+                <lib-custom-tags [(tags)]="formData.tags" [readOnly]="useStrictReadonlyForm"></lib-custom-tags>
               </lib-form-field-container>
             </div>
           }
@@ -116,7 +121,7 @@
     @if (formView === 'raw') {
       <div class="form-group-column">
         @if (formData) {
-          <lib-json-view [(data)]="formData"></lib-json-view>
+          <lib-json-view [(data)]="formData" [readOnly]="useStrictReadonlyForm"></lib-json-view>
         }
       </div>
     }

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/transit-router/transit-router-form.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/transit-router/transit-router-form.component.ts
@@ -145,6 +145,9 @@ export class TransitRouterFormComponent extends ProjectableForm implements OnIni
   }
 
   async save(event?) {
+    if (!this.canSaveByPermissions()) {
+      return;
+    }
     const isValid = this.validate();
     const isExtValid = await this.extService.validateData();
     this.formData.name = this.formData.name.trim()

--- a/projects/ziti-console-lib/src/lib/features/tag-selector/tag-selector.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/tag-selector/tag-selector.component.scss
@@ -373,6 +373,10 @@
   opacity: 0.75;
   cursor: default;
 
+  .select2-selection__choice__remove {
+    display: none !important;
+  }
+
   .select2-container {
     .select2-selection__rendered:not(.empty) {
       min-height: var(--defaultInputHeight);

--- a/projects/ziti-console-lib/src/lib/features/tag-selector/tag-selector.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/tag-selector/tag-selector.component.scss
@@ -386,7 +386,6 @@
       &:disabled {
         font-weight: 600;
         font-family: Open Sans, Arial, sans-serif;
-        height: 0rem !important;
         width: 100%;
         padding-left: 0.625rem;
         padding-right: 0.625rem;
@@ -401,13 +400,17 @@
         color: var(--tableText);
         text-transform: none;
 
-        &:hover {
-          box-shadow: none;
-          filter: none;
+        &:not(.empty) {
+          height: 0rem !important;
         }
 
         &.empty {
-          height: 3.125rem;
+          height: var(--defaultInputHeight) !important;
+        }
+
+        &:hover {
+          box-shadow: none;
+          filter: none;
         }
       }
     }

--- a/projects/ziti-console-lib/src/lib/pages/api-sessions/api-sessions-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/api-sessions/api-sessions-page.component.html
@@ -2,9 +2,12 @@
   <lib-list-page-header [title]="title"
     [tabs]="tabs"
     [hideAction]="true"
+    [blockCreate]="headerBlockCreate"
+    [blockDelete]="headerBlockDelete"
   (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
 
   <lib-data-table [tableId]="'api-sessions'"
+    [noItemsReadonly]="headerBlockCreate"
     [rowData]="rowData"
     [isLoading]="isLoading"
     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/pages/auth-policies/auth-policies-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/auth-policies/auth-policies-page.component.html
@@ -2,9 +2,12 @@
     <lib-list-page-header [title]="title"
                           [tabs]="tabs"
                           [showAdd]="!itemsSelected"
+                          [blockCreate]="headerBlockCreate"
+                          [blockDelete]="headerBlockDelete"
                           (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
 
     <lib-data-table [tableId]="'auth-policies'"
+                    [noItemsReadonly]="headerBlockCreate"
                     [rowData]="rowData"
                     [isLoading]="isLoading"
                     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/pages/certificate-authorities/certificate-authorities-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/certificate-authorities/certificate-authorities-page.component.html
@@ -2,9 +2,12 @@
   <lib-list-page-header [title]="title"
     [tabs]="tabs"
     [showAdd]="!itemsSelected"
+    [blockCreate]="headerBlockCreate"
+    [blockDelete]="headerBlockDelete"
   (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
 
   <lib-data-table [tableId]="'certificate-authorities'"
+    [noItemsReadonly]="headerBlockCreate"
     [rowData]="rowData"
     [isLoading]="isLoading"
     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/pages/config-types/config-types-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/config-types/config-types-page.component.html
@@ -2,9 +2,12 @@
   <lib-list-page-header [title]="title"
     [tabs]="tabs"
     [showAdd]="!itemsSelected"
+    [blockCreate]="headerBlockCreate"
+    [blockDelete]="headerBlockDelete"
   (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
 
   <lib-data-table [tableId]="'config-types'"
+    [noItemsReadonly]="headerBlockCreate"
     [rowData]="rowData"
     [isLoading]="isLoading"
     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/pages/configurations/configurations-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/configurations/configurations-page.component.html
@@ -3,9 +3,12 @@
     <lib-list-page-header [title]="title"
                           [tabs]="tabs"
                           [showAdd]="!itemsSelected"
+                          [blockCreate]="headerBlockCreate"
+                          [blockDelete]="headerBlockDelete"
                           (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
 
     <lib-data-table [tableId]="'configurations'"
+                    [noItemsReadonly]="headerBlockCreate"
                     [rowData]="rowData"
                     [isLoading]="isLoading"
                     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/pages/edge-router-policies/edge-router-policies-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/edge-router-policies/edge-router-policies-page.component.html
@@ -2,9 +2,12 @@
   <lib-list-page-header [title]="title"
     [tabs]="tabs"
     [showAdd]="!itemsSelected"
+    [blockCreate]="headerBlockCreate"
+    [blockDelete]="headerBlockDelete"
   (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
 
   <lib-data-table [tableId]="'edge-router-policies'"
+    [noItemsReadonly]="headerBlockCreate"
     [rowData]="rowData"
     [isLoading]="isLoading"
     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/edge-routers/edge-routers-page.component.html
@@ -2,9 +2,12 @@
   <lib-list-page-header [title]="title"
     [tabs]="tabs"
     [showAdd]="!itemsSelected"
+    [blockCreate]="headerBlockCreate"
+    [blockDelete]="headerBlockDelete"
   (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
 
   <lib-data-table [tableId]="'edge-routers'"
+    [noItemsReadonly]="headerBlockCreate"
     [rowData]="rowData"
     [isLoading]="isLoading"
     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/pages/identities/identities-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/identities/identities-page.component.html
@@ -2,9 +2,12 @@
   <lib-list-page-header [title]="title"
     [tabs]="tabs"
     [showAdd]="!itemsSelected"
+    [blockCreate]="headerBlockCreate"
+    [blockDelete]="headerBlockDelete"
   (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
   <ng-content select="[slot=list-page-subheader]"></ng-content>
   <lib-data-table [tableId]="'identities'"
+    [noItemsReadonly]="headerBlockCreate"
     [rowData]="rowData"
     [isLoading]="isLoading"
     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/pages/jwt-signers/jwt-signers-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/jwt-signers/jwt-signers-page.component.html
@@ -11,9 +11,12 @@
   <lib-list-page-header [title]="title"
     [tabs]="tabs"
     [showAdd]="!itemsSelected"
+    [blockCreate]="headerBlockCreate"
+    [blockDelete]="headerBlockDelete"
   (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
 
   <lib-data-table [tableId]="'ext-jwt-signers'"
+    [noItemsReadonly]="headerBlockCreate"
     [rowData]="rowData"
     [isLoading]="isLoading"
     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/pages/posture-checks/posture-checks-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/posture-checks/posture-checks-page.component.html
@@ -2,9 +2,12 @@
   <lib-list-page-header [title]="title"
     [tabs]="tabs"
     [showAdd]="!itemsSelected"
+    [blockCreate]="headerBlockCreate"
+    [blockDelete]="headerBlockDelete"
   (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
 
   <lib-data-table [tableId]="'posture-checks'"
+    [noItemsReadonly]="headerBlockCreate"
     [rowData]="rowData"
     [isLoading]="isLoading"
     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/pages/service-edge-router-policies/service-edge-router-policies-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/service-edge-router-policies/service-edge-router-policies-page.component.html
@@ -2,9 +2,12 @@
   <lib-list-page-header [title]="title"
     [tabs]="tabs"
     [showAdd]="!itemsSelected"
+    [blockCreate]="headerBlockCreate"
+    [blockDelete]="headerBlockDelete"
   (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
 
   <lib-data-table [tableId]="'service-edge-router-policies'"
+    [noItemsReadonly]="headerBlockCreate"
     [rowData]="rowData"
     [isLoading]="isLoading"
     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/pages/service-policies/service-policies-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/service-policies/service-policies-page.component.html
@@ -2,9 +2,12 @@
   <lib-list-page-header [title]="title"
     [tabs]="tabs"
     [showAdd]="!itemsSelected"
+    [blockCreate]="headerBlockCreate"
+    [blockDelete]="headerBlockDelete"
   (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
 
   <lib-data-table [tableId]="'service-policies'"
+    [noItemsReadonly]="headerBlockCreate"
     [rowData]="rowData"
     [isLoading]="isLoading"
     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/pages/services/services-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/services/services-page.component.html
@@ -2,9 +2,12 @@
   <lib-list-page-header [title]="'Services'"
     [tabs]="tabs"
     [showAdd]="!itemsSelected"
+    [blockCreate]="headerBlockCreate"
+    [blockDelete]="headerBlockDelete"
   (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
 
   <lib-data-table [tableId]="'services'"
+    [noItemsReadonly]="headerBlockCreate"
     [rowData]="rowData"
     [isLoading]="isLoading"
     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/pages/sessions/sessions-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/sessions/sessions-page.component.html
@@ -2,9 +2,12 @@
   <lib-list-page-header [title]="title"
     [tabs]="tabs"
     [hideAction]="true"
+    [blockCreate]="headerBlockCreate"
+    [blockDelete]="headerBlockDelete"
   (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
 
   <lib-data-table [tableId]="'sessions'"
+    [noItemsReadonly]="headerBlockCreate"
     [rowData]="rowData"
     [isLoading]="isLoading"
     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/pages/terminators/terminators-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/terminators/terminators-page.component.html
@@ -2,8 +2,11 @@
   <lib-list-page-header [title]="title"
     [tabs]="tabs"
     [hideAction]="true"
+    [blockCreate]="headerBlockCreate"
+    [blockDelete]="headerBlockDelete"
   (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
   <lib-data-table [tableId]="'terminators'"
+    [noItemsReadonly]="headerBlockCreate"
     [rowData]="rowData"
     [isLoading]="isLoading"
     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/pages/transit-routers/transit-routers-page.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/transit-routers/transit-routers-page.component.html
@@ -2,9 +2,12 @@
   <lib-list-page-header [title]="title"
     [tabs]="tabs"
     [showAdd]="!itemsSelected"
+    [blockCreate]="headerBlockCreate"
+    [blockDelete]="headerBlockDelete"
   (actionClicked)="headerActionClicked($event)"></lib-list-page-header>
 
   <lib-data-table [tableId]="'transit-routers'"
+    [noItemsReadonly]="headerBlockCreate"
     [rowData]="rowData"
     [isLoading]="isLoading"
     [columnDefinitions]="columnDefs"

--- a/projects/ziti-console-lib/src/lib/services/management-permissions.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/management-permissions.service.ts
@@ -1,0 +1,242 @@
+/*
+    Copyright NetFoundry Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import {Inject, Injectable} from '@angular/core';
+import {BehaviorSubject} from 'rxjs';
+import {debounceTime, distinctUntilChanged, map} from 'rxjs/operators';
+import {isEmpty} from 'lodash';
+import {SETTINGS_SERVICE} from './settings.service';
+import {SettingsServiceClass} from './settings-service.class';
+import {ZITI_DATA_SERVICE, ZitiDataService} from './ziti-data.service';
+
+export const SAVE_DENIED_BY_PERMISSION_TOOLTIP = 'You do not have permission to save changes.';
+
+/** Session + controller URL — permissions only depend on these, not on version() metadata updates. */
+interface SessionFingerprint {
+    sessionId: string;
+    edgeController: string;
+}
+
+@Injectable({
+    providedIn: 'root',
+})
+export class ManagementPermissionsService {
+    readonly saveDeniedTooltip = SAVE_DENIED_BY_PERMISSION_TOOLTIP;
+
+    private readonly permissionSet = new Set<string>();
+    private identityIsAdmin = false;
+    /** Legacy controller, failed refresh, or empty permissions — keep prior UX (no gating). */
+    private unrestricted = true;
+
+    private readonly versionSubject = new BehaviorSubject<number>(0);
+
+    readonly stateVersion$ = this.versionSubject.asObservable();
+
+    /** Coalesce overlapping current-identity HTTP calls (debounce + rapid settings churn). */
+    private identityLoadPromise: Promise<void> | null = null;
+
+    constructor(
+        @Inject(SETTINGS_SERVICE) private readonly settings: SettingsServiceClass,
+        @Inject(ZITI_DATA_SERVICE) private readonly zitiData: ZitiDataService,
+    ) {
+        this.settings.settingsChange
+            .pipe(
+                map((): SessionFingerprint => ({
+                    sessionId: this.settings.settings?.session?.id ?? '',
+                    edgeController: this.settings.settings?.selectedEdgeController ?? '',
+                })),
+                distinctUntilChanged(
+                    (a, b) => a.sessionId === b.sessionId && a.edgeController === b.edgeController,
+                ),
+                debounceTime(200),
+            )
+            .subscribe(() => {
+                if (!this.settings.hasSession() || isEmpty(this.settings.settings?.selectedEdgeController)) {
+                    this.clear();
+                    return;
+                }
+                void this.loadCurrentIdentity();
+            });
+    }
+
+    private bumpVersion(): void {
+        this.versionSubject.next(this.versionSubject.value + 1);
+    }
+
+    clear(): void {
+        this.permissionSet.clear();
+        this.identityIsAdmin = false;
+        this.unrestricted = true;
+        this.bumpVersion();
+    }
+
+    async refresh(): Promise<void> {
+        await this.loadCurrentIdentity();
+    }
+
+    private async loadCurrentIdentity(): Promise<void> {
+        if (this.identityLoadPromise) {
+            return this.identityLoadPromise;
+        }
+        this.identityLoadPromise = this.fetchCurrentIdentity().finally(() => {
+            this.identityLoadPromise = null;
+        });
+        return this.identityLoadPromise;
+    }
+
+    private async fetchCurrentIdentity(): Promise<void> {
+        try {
+            const result: any = await this.zitiData.call('current-identity');
+            const data = result?.data;
+            if (!data) {
+                this.applyLegacyMode();
+                this.bumpVersion();
+                return;
+            }
+            const rawPerms = Array.isArray(data.permissions) ? data.permissions : [];
+            this.identityIsAdmin = !!data.isAdmin;
+            if (rawPerms.length === 0 && !this.identityIsAdmin) {
+                this.applyLegacyMode();
+                this.identityIsAdmin = false;
+                this.bumpVersion();
+                return;
+            }
+            this.unrestricted = false;
+            this.permissionSet.clear();
+            rawPerms.forEach((p: string) => {
+                if (typeof p === 'string' && p.length > 0) {
+                    this.permissionSet.add(p);
+                }
+            });
+        } catch {
+            this.applyLegacyMode();
+        }
+        this.bumpVersion();
+    }
+
+    private applyLegacyMode(): void {
+        this.unrestricted = true;
+        this.permissionSet.clear();
+        this.identityIsAdmin = false;
+    }
+
+    isUnrestricted(): boolean {
+        return this.unrestricted;
+    }
+
+    private isAdmin(): boolean {
+        if (this.permissionSet.has('admin_readonly')) {
+            return false;
+        }
+        return this.identityIsAdmin || this.permissionSet.has('admin');
+    }
+
+    isAdminReadonly(): boolean {
+        return this.permissionSet.has('admin_readonly');
+    }
+
+    /** Read is not entity-scoped yet; parameter reserved for future use. */
+    canRead(_apiResource: string): boolean {
+        return true;
+    }
+
+    /** Create is global-role only until entity grants exist; apiResource unused for now. */
+    canCreate(_apiResource: string): boolean {
+        if (this.unrestricted) {
+            return true;
+        }
+        return this.isAdmin();
+    }
+
+    /** Update is global-role only until entity grants exist; apiResource unused for now. */
+    canUpdate(_apiResource: string): boolean {
+        if (this.unrestricted) {
+            return true;
+        }
+        return this.isAdmin();
+    }
+
+    /** Delete is global-role only until entity grants exist; apiResource unused for now. */
+    canDelete(_apiResource: string): boolean {
+        if (this.unrestricted) {
+            return true;
+        }
+        return this.isAdmin();
+    }
+
+    /** Strict read-only shell when the session has global admin_readonly (no writes). */
+    useStrictReadonlyFormUi(apiResource: string, isEdit: boolean): boolean {
+        if (this.unrestricted || this.isAdmin()) {
+            return false;
+        }
+        return this.isAdminReadonly() && this.isSaveDisabled(apiResource, isEdit);
+    }
+
+    isSaveDisabled(apiResource: string, isEdit: boolean): boolean {
+        if (this.unrestricted) {
+            return false;
+        }
+        return isEdit ? !this.canUpdate(apiResource) : !this.canCreate(apiResource);
+    }
+
+    isMenuActionAllowed(apiResource: string, action: string): boolean {
+        if (this.unrestricted) {
+            return true;
+        }
+        switch (action) {
+            case 'delete':
+                return this.canDelete(apiResource);
+            case 'update':
+                return this.canUpdate(apiResource);
+            case 'reset-enrollment':
+            case 'reissue-enrollment':
+            case 'reset-mfa':
+            case 'override':
+                return this.canUpdate(apiResource);
+            case 'download-enrollment':
+            case 'qr-code':
+            case 'identity-service-path':
+                return this.canRead(apiResource);
+            default:
+                return this.canRead(apiResource);
+        }
+    }
+
+    isTableHeaderActionAllowed(apiResource: string, action: string): boolean {
+        if (this.unrestricted) {
+            return true;
+        }
+        if (this.isAdmin()) {
+            return true;
+        }
+        if (this.isAdminReadonly()) {
+            switch (action) {
+                case 'download-all':
+                case 'download-selected':
+                    return this.canRead(apiResource);
+                default:
+                    return false;
+            }
+        }
+        switch (action) {
+            case 'download-all':
+            case 'download-selected':
+                return this.canRead(apiResource);
+            default:
+                return true;
+        }
+    }
+}

--- a/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
+++ b/projects/ziti-console-lib/src/lib/shared-assets/styles/global.scss
@@ -537,6 +537,13 @@ a:hover {
   }
 }
 
+@mixin projectable-readonly-field-appearance {
+  cursor: default;
+  opacity: 0.95;
+  background-color: var(--stroke) !important;
+  color: var(--tableText);
+}
+
 .projectable-form-wrapper {
   display: flex;
   flex-direction: column;
@@ -572,6 +579,20 @@ a:hover {
     .projectable-form-main-column {
       max-width: 68.75rem;
     }
+  }
+  .toggle.toggle-readonly {
+    cursor: default;
+    opacity: 0.9;
+    pointer-events: none;
+  }
+
+  /** Disabled fields styled like terminator form (`read-only` + [disabled]). */
+  .form-field-input.read-only,
+  .form-field-dropdown.read-only,
+  .form-field-input:disabled,
+  .form-field-dropdown:disabled,
+  .grid.tags input:disabled {
+    @include projectable-readonly-field-appearance;
   }
 }
 

--- a/projects/ziti-console-lib/src/lib/shared/list-page-component.class.ts
+++ b/projects/ziti-console-lib/src/lib/shared/list-page-component.class.ts
@@ -17,6 +17,7 @@
 import {DataTableFilterService} from "../features/data-table/data-table-filter.service";
 import {ListPageServiceClass} from "./list-page-service.class";
 import {inject, Injectable} from "@angular/core";
+import {ManagementPermissionsService} from "../services/management-permissions.service";
 import {Subscription} from "rxjs";
 import {ConsoleEventsService} from "../services/console-events.service";
 import {ConfirmComponent} from "../features/confirm/confirm.component";
@@ -53,6 +54,15 @@ export abstract class ListPageComponent {
     subscription: Subscription = new Subscription();
 
     private growlerSvc = inject(GrowlerService);
+    protected readonly managementPermissions = inject(ManagementPermissionsService);
+
+    get headerBlockCreate(): boolean {
+        return !this.managementPermissions.canCreate(this.svc.resourceType);
+    }
+
+    get headerBlockDelete(): boolean {
+        return !this.managementPermissions.canDelete(this.svc.resourceType);
+    }
 
     constructor(
         protected filterService: DataTableFilterService,
@@ -66,8 +76,16 @@ export abstract class ListPageComponent {
         this.filterService.currentPage = 1;
         this.svc.sideModalOpen = false;
         this.svc.refreshData = this.refreshData.bind(this);
+        this.svc.resetMenusForInit();
         this.svc.initMenuActions();
         this.columnDefs = this.svc.initTableColumns();
+        this.svc.capturePermissionSnapshots();
+        this.subscription.add(
+            this.managementPermissions.stateVersion$.subscribe(() => {
+                this.svc.rebuildMenusAndHeaders(this.managementPermissions);
+                this.syncBulkDownloadHeaderAction();
+            }),
+        );
         this.filterService.clearFilters();
         this.extensionService?.extendOnInit();
         this.subscription.add(
@@ -98,10 +116,19 @@ export abstract class ListPageComponent {
 
     itemToggled(item: any): void {
         this.updateSelectedItems(item);
+        this.syncBulkDownloadHeaderAction();
+    }
+
+    protected syncBulkDownloadHeaderAction(): void {
         const hasSelection = this.selectedItems.length > 0;
-        const index = this.svc.tableHeaderActions.findIndex(a => a.action === 'download-selected');
-        hasSelection && index === -1 && this.svc.tableHeaderActions.push({ name: 'Download Selected', action: 'download-selected' });
-        !hasSelection && index !== -1 && this.svc.tableHeaderActions.splice(index, 1);
+        const index = this.svc.tableHeaderActions.findIndex((a) => a.action === 'download-selected');
+        const allow = this.managementPermissions.canRead(this.svc.resourceType);
+        if (hasSelection && allow && index === -1) {
+            this.svc.tableHeaderActions.push({ name: 'Download Selected', action: 'download-selected' });
+        }
+        if ((!hasSelection || !allow) && index !== -1) {
+            this.svc.tableHeaderActions.splice(index, 1);
+        }
     }
 
     updateSelectedItems(toggledItem?: any) {
@@ -145,6 +172,7 @@ export abstract class ListPageComponent {
                     this.endCount = data.meta.pagination.offset + data.meta.pagination.limit;
                 }
                 this.updateSelectedItems();
+                this.syncBulkDownloadHeaderAction();
                 this.refreshCells();
             }).finally(() => {
                 this.isLoading = false;
@@ -175,6 +203,9 @@ export abstract class ListPageComponent {
     }
 
     protected openBulkDelete(selectedItems: any[], entityTypeLabel = 'item(s)', ) {
+        if (!this.managementPermissions.canDelete(this.svc.resourceType)) {
+            return;
+        }
         const selectedIds = selectedItems.map((row) => {
             return row.id;
         });

--- a/projects/ziti-console-lib/src/lib/shared/list-page-service.class.ts
+++ b/projects/ziti-console-lib/src/lib/shared/list-page-service.class.ts
@@ -33,6 +33,7 @@ import {
     TableColumnDefaultComponent
 } from "../features/data-table/column-headers/table-column-default/table-column-default.component";
 import {GrowlerModel} from "../features/messaging/growler.model";
+import {ManagementPermissionsService} from "../services/management-permissions.service";
 
 export abstract class ListPageServiceClass {
 
@@ -85,11 +86,17 @@ export abstract class ListPageServiceClass {
     }
     totalCount = 0;
     dataService: ZitiDataService;
+    protected readonly managementPermissions = inject(ManagementPermissionsService);
     refreshData: (sort?: {sortBy: string, ordering: string}) => void | undefined;
 
     selectedEntityId: String;
     menuItems: any = [];
     tableHeaderActions: any = [];
+    /** Original menus/header actions before permission filtering (for singleton page services). */
+    private menuItemsBaseline: any[] | null = null;
+    private tableHeaderActionsBaseline: any[] | null = null;
+    private menuTemplateSnapshot: any[] | null = null;
+    private tableHeaderActionsSnapshot: any[] | null = null;
     currentSettings: any = {};
     dialogRef: any;
     sideModalOpen = false;
@@ -158,6 +165,19 @@ export abstract class ListPageServiceClass {
                 this.basePath = pathSegments[0];
               }
         });
+    }
+
+    /**
+     * Root-provided page services survive route changes; restore baseline menus before each table init
+     * so permission filtering does not stack on already-filtered items.
+     */
+    resetMenusForInit(): void {
+        if (!this.menuItemsBaseline) {
+            this.menuItemsBaseline = cloneDeep(this.menuItems);
+            this.tableHeaderActionsBaseline = cloneDeep(this.tableHeaderActions);
+        }
+        this.menuItems = cloneDeep(this.menuItemsBaseline);
+        this.tableHeaderActions = cloneDeep(this.tableHeaderActionsBaseline);
     }
 
     initMenuActions() {
@@ -276,7 +296,14 @@ export abstract class ListPageServiceClass {
     }
 
     public openEditForm(itemId = '', basePath?: undefined) {
-        if (isEmpty(itemId)) {
+        const isCreate = isEmpty(itemId);
+        if (isCreate && !this.managementPermissions.canCreate(this.resourceType)) {
+            return;
+        }
+        if (!isCreate && !this.managementPermissions.canRead(this.resourceType)) {
+            return;
+        }
+        if (isCreate) {
             itemId = 'create';
         }
         const finalBasePath: string = basePath ?? this.basePath ?? '';
@@ -287,4 +314,21 @@ export abstract class ListPageServiceClass {
         const rootFontSize: any = parseFloat(window.getComputedStyle(document.documentElement).fontSize);
         return remValue * rootFontSize;
     };
+
+    capturePermissionSnapshots(): void {
+        this.menuTemplateSnapshot = cloneDeep(this.menuItems);
+        this.tableHeaderActionsSnapshot = cloneDeep(this.tableHeaderActions);
+    }
+
+    rebuildMenusAndHeaders(perm: ManagementPermissionsService): void {
+        if (!this.menuTemplateSnapshot || !this.tableHeaderActionsSnapshot) {
+            return;
+        }
+        this.menuItems = cloneDeep(this.menuTemplateSnapshot).filter((item: { action?: string }) =>
+            perm.isMenuActionAllowed(this.resourceType, item.action),
+        );
+        this.tableHeaderActions = cloneDeep(this.tableHeaderActionsSnapshot).filter((item: { action?: string }) =>
+            perm.isTableHeaderActionAllowed(this.resourceType, item.action),
+        );
+    }
 }

--- a/projects/ziti-console-lib/src/public-api.ts
+++ b/projects/ziti-console-lib/src/public-api.ts
@@ -38,6 +38,7 @@ export * from './lib/services/login-service.class';
 export * from './lib/services/noop-login.service';
 export * from './lib/services/settings-service.class';
 export * from './lib/services/settings.service';
+export * from './lib/services/management-permissions.service';
 export * from './lib/services/ha-controller.service';
 export * from './lib/services/tab-name.service';
 export * from './lib/services/ziti-data.service';


### PR DESCRIPTION
Enhance readonly functionality across components

- Introduced `readOnly` input property to various components, allowing for view-only mode.
- Updated chips input, config editor, custom tags, and data table components to respect the `readOnly` state.
- Modified form components to disable editing and save actions based on permissions.
- Improved user experience by conditionally rendering UI elements based on the `readOnly` state.
- Added management permissions service to handle save and edit permissions effectively.

fix #868 