### PR TITLE
fix: tolerate a trailing slash on the submitted controller URL

### DIFF
--- a/server.js
+++ b/server.js
@@ -100,6 +100,13 @@ const processControllerUrls = (urlString) => {
 	return validUrls;
 };
 
+// Normalize a controller URL for comparison and request building: strip any
+// trailing slash(es). ZAC_CONTROLLER_URLS values are stored without a trailing
+// slash (see processControllerUrls), but the console can submit the URL with
+// one — an exact-match check then fails ("Invalid Edge Controller"), and a
+// trailing slash also produces a double slash when request paths are appended.
+const trimTrailingSlash = (url) => (typeof url === 'string' ? url.replace(/\/+$/, '') : url);
+
 var ziti;
 const zitiServiceName = process.env.ZITI_SERVICE_NAME || 'zac';
 const zitiIdentityFile = process.env.ZITI_IDENTITY_FILE;
@@ -340,7 +347,7 @@ function hasAccess(user) {
  * Authentication method, authenticates the user to the provided edge controller defined by url
  */
 app.post("/api/login", function(request, response) {
-	var urlToSet = request.body.url;
+	var urlToSet = trimTrailingSlash(request.body.url);
 	if (!IsServerDefined(urlToSet)) response.json({error: errors.invalidServer });
 	else {
 		baseUrl = urlToSet;
@@ -520,7 +527,7 @@ app.post("/api/reset", function(request, response) {
  */
 function IsServerDefined(url) {
 	for (var i=0; i<settings.edgeControllers.length; i++) {
-		if (settings.edgeControllers[i].url==url) return true;
+		if (trimTrailingSlash(settings.edgeControllers[i].url)==trimTrailingSlash(url)) return true;
 	}
 	return false;
 }
@@ -615,7 +622,7 @@ app.delete("/api/server", function(request, response) {
  * Set the current controller to use
  */
 app.post("/api/controller", function(request, response) {
-	var urlToSet = request.body.url;
+	var urlToSet = trimTrailingSlash(request.body.url);
 	if (!IsServerDefined(urlToSet)) response.json({error: errors.invalidServer });
 	else serviceUrl = urlToSet;
 });


### PR DESCRIPTION
## Problem

When controllers are configured via `ZAC_CONTROLLER_URLS`, selecting any controller on the login screen fails with **"Invalid Edge Controller"** (rendered in the UI as `Invalid Edge Controller: [object Object]`).

## Root cause

`processControllerUrls` stores each URL with the trailing slash stripped:

```js
const ctrlUrl = validatedUrl.toString().replace(/\/$/, '');
```

so the stored value is `https://host:1280`. But the console submits the selected controller URL **with** a trailing slash to `/api/login` (and `/api/controller`). `IsServerDefined` does an exact string match, so `https://host:1280/` never matches the stored `https://host:1280`, and the request is rejected with `errors.invalidServer`.

Keeping the slash on the stored value is not a fix either — `baseUrl + "/edge/management/v1/version"` then contains a double slash (`…:1280//edge/…`), which the controller rejects with a 404 (surfaced as "Invalid Management Api").

## Fix

Add a `trimTrailingSlash` helper and:
- trim the submitted `urlToSet` in `/api/login` and `/api/controller` (so `baseUrl`/`serviceUrl` are built without a double slash), and
- compare normalized values in `IsServerDefined`.

## Testing

Reproduced against a live 3-node controller with `ZAC_CONTROLLER_URLS=https://host:1280`:

- **before:** `POST /api/login {"url":"https://host:1280/"}` → `{"error":"Invalid Edge Controller"}`
- **after:** the same request passes `IsServerDefined`, `GetPath` resolves the management API (single slash, `200`), and the flow proceeds to controller authentication.
