### PR TITLE
Improve identity-service-path visualizer (#893)

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.component.html
+++ b/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.component.html
@@ -5,7 +5,7 @@
     <div (click)="toggleModalSize()" class="buttonBall resize" id="ResizeModalButton"></div>
   </div>
   <div [ngClass]="isDarkMode==true?'darkMode':'lightMode'" class="identity-topology-container">
-    <div style="width: 100%; height: 80px; float: left">
+    <div class="topology-toolbar">
       <div class="ep-topology-filter-container listBox row">
         <input
           (keyup)="filterSearchArray()"
@@ -33,43 +33,71 @@
           }
         </mat-autocomplete>
       </div>
+      <div class="topology-refresh-controls">
+        <div
+          (click)="refreshFabricData()"
+          [ngClass]="{ rotating: refreshRotate }"
+          class="refresh-button"
+          id="RefreshFabricButton"
+          title="Refresh fabric data"
+        >
+          <div class="refresh-icon"></div>
+        </div>
+      </div>
     </div>
 
     <div class="topotip" id="epTooltip"></div>
 
     <svg style='pointer-events:all' height="1000" id="IdentityTopology" width="1400">
     </svg>
+    <div class="topology-zoom-controls">
+      <div (click)="zoomIn()" class="zoom-btn" title="Zoom in" id="ZoomInButton">+</div>
+      <div (click)="zoomOut()" class="zoom-btn" title="Zoom out" id="ZoomOutButton">&#8722;</div>
+      <div (click)="resetView()" class="zoom-btn zoom-btn-text" title="Fit to content" id="FitToContentButton">Fit</div>
+    </div>
     @if (isLoading) {
       <lib-loading-indicator [isLoading]="isLoading"></lib-loading-indicator>
     }
 
-    <div class="topology-legend">
+    <div class="topology-legend" [class.collapsed]="legendCollapsed">
+      <div class="legend-header" (click)="legendCollapsed = !legendCollapsed"
+           [title]="legendCollapsed ? 'Show legend' : 'Hide legend'">
+        <span class="legend-header-title">Legend</span>
+        <span class="legend-header-toggle" aria-hidden="true">
+          <svg viewBox="0 0 16 16" width="13" height="13">
+            <path d="M3.5 6 L8 10.5 L12.5 6" fill="none" stroke="currentColor"
+                  stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </span>
+      </div>
+      @if (!legendCollapsed) {
+      <div class="legend-body">
       <div class="legend-section">
         <div class="legend-section-title">Nodes</div>
-        <div class="legend-item">
+        <div class="legend-item" title="An endpoint identity — a client that dials the service or a tunneler that hosts it.">
           <div class="legend-icon-col"><img class="legend-node-icon" src="assets/images/visualizer/host.png" /></div>
           <div class="legend-text">Identity</div>
         </div>
-        <div class="legend-item">
+        <div class="legend-item" title="A Ziti edge router that relays traffic between identities.">
           <div class="legend-icon-col"><img class="legend-node-icon" src="assets/images/visualizer/Routers.png" /></div>
           <div class="legend-text">Edge Router</div>
         </div>
-        <div class="legend-item">
+        <div class="legend-item" title="The service being dialed and hosted.">
           <div class="legend-icon-col"><img class="legend-node-icon" src="assets/images/visualizer/service.png" /></div>
           <div class="legend-text">Service</div>
         </div>
       </div>
       <div class="legend-section">
         <div class="legend-section-title">Status</div>
-        <div class="legend-item">
+        <div class="legend-item" title="Connected to an edge router and healthy.">
           <div class="legend-icon-col"><div class="legend-circle registered_in_use"></div></div>
           <div class="legend-text">Online</div>
         </div>
-        <div class="legend-item">
+        <div class="legend-item" title="Enrolled but not currently connected (e.g. powered off or idle).">
           <div class="legend-icon-col"><div class="legend-circle unregistered"></div></div>
           <div class="legend-text">Offline</div>
         </div>
-        <div class="legend-item">
+        <div class="legend-item" title="A problem with this node — check its path link for the cause (router down vs tunneler unreachable).">
           <div class="legend-icon-col"><div class="legend-circle errored"></div></div>
           <div class="legend-text">Error</div>
         </div>
@@ -77,19 +105,21 @@
       @if (fabricApiAvailable) {
         <div class="legend-section">
           <div class="legend-section-title">Path</div>
-          <div class="legend-item">
+          <div class="legend-item" title="Live traffic is flowing over this hop right now.">
             <div class="legend-icon-col"><div class="legend-line active-circuit"></div></div>
             <div class="legend-text">Active Circuit</div>
           </div>
-          <div class="legend-item">
+          <div class="legend-item" title="Reachable and authorized, but no active circuit at the moment.">
             <div class="legend-icon-col"><div class="legend-line available"></div></div>
             <div class="legend-text">Available</div>
           </div>
-          <div class="legend-item">
-            <div class="legend-icon-col"><div class="legend-icon misconfigured"></div></div>
-            <div class="legend-text">Broken</div>
+          <div class="legend-item" title="This hop can't carry traffic right now. The node colors show which end is the problem — an offline router, or an unreachable / un-enrolled endpoint.">
+            <div class="legend-icon-col"><div class="legend-line broken"></div></div>
+            <div class="legend-text">Unavailable</div>
           </div>
         </div>
+      }
+      </div>
       }
     </div>
 

--- a/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.component.html
+++ b/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.component.html
@@ -89,17 +89,21 @@
       </div>
       <div class="legend-section">
         <div class="legend-section-title">Status</div>
-        <div class="legend-item" title="Connected to an edge router and healthy.">
-          <div class="legend-icon-col"><div class="legend-circle registered_in_use"></div></div>
+        <div class="legend-item" title="Connected to an edge router.">
+          <div class="legend-icon-col"><div class="legend-circle online"></div></div>
           <div class="legend-text">Online</div>
         </div>
         <div class="legend-item" title="Enrolled but not currently connected (e.g. powered off or idle).">
-          <div class="legend-icon-col"><div class="legend-circle unregistered"></div></div>
+          <div class="legend-icon-col"><div class="legend-circle offline"></div></div>
           <div class="legend-text">Offline</div>
         </div>
-        <div class="legend-item" title="A problem with this node — check its path link for the cause (router down vs tunneler unreachable).">
-          <div class="legend-icon-col"><div class="legend-circle errored"></div></div>
-          <div class="legend-text">Error</div>
+        <div class="legend-item" title="Identity-only: the controller can't currently determine the connection state.">
+          <div class="legend-icon-col"><div class="legend-circle unknown"></div></div>
+          <div class="legend-text">Unknown</div>
+        </div>
+        <div class="legend-item" title="Identity has not completed enrollment.">
+          <div class="legend-icon-col"><div class="legend-circle notenrolled"></div></div>
+          <div class="legend-text">Not enrolled</div>
         </div>
       </div>
       @if (fabricApiAvailable) {

--- a/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.component.scss
@@ -454,16 +454,22 @@
         border-radius: 50%;
     }
 
-    .legend-circle.unregistered {
-        background-color: #8a8f9a;
-    }
-
-    .legend-circle.registered_in_use {
+    .legend-circle.online {
         background-color: #08dc5a;
     }
 
-    .legend-circle.errored {
-        background-color: #fb0d3d;
+    .legend-circle.offline {
+        background-color: #8a8f9a;
+    }
+
+    .legend-circle.unknown {
+        background-color: #e6a700;
+    }
+
+    // Not enrolled — hollow ring, matching the canvas dot.
+    .legend-circle.notenrolled {
+        background-color: var(--background);
+        border: 0.125rem solid #8a8f9a;
     }
 
     .legend-line {
@@ -643,6 +649,11 @@
     background: rgba(138, 143, 154, 0.16);
     .tt-status-dot { background: #8a8f9a; }
     .tt-status-label { color: #6f7480; }
+  }
+  .tt-unknown {
+    background: rgba(230, 167, 0, 0.14);
+    .tt-status-dot { background: #e6a700; }
+    .tt-status-label { color: #b07f00; }
   }
   .tt-neutral {
     background: rgba(110, 120, 200, 0.12);

--- a/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.component.scss
@@ -30,15 +30,23 @@
     }
 
     .clear-svc-icon {
-      font-size: 1.4375rem;
-      font-weight: 600;
-      position: relative;
-      top: 0.9375rem;
-      right: 2.5rem;
+      position: absolute;
+      top: 50%;
+      right: 0.55rem;
+      transform: translateY(-50%);
+      width: 1.65rem;
+      height: 1.65rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50%;
+      font-size: 0.95rem;
       color: var(--icon);
       cursor: pointer;
+      transition: background 0.12s ease, color 0.12s ease;
       &:hover {
-        filter: brightness(50%);
+        background: color-mix(in srgb, var(--tableText) 12%, transparent);
+        color: var(--tableText);
       }
     }
 
@@ -57,6 +65,28 @@
         padding: 0;
     }
 
+    // When the search container sits inside the toolbar flex row, drop the
+    // absolute positioning so it flows naturally next to the refresh controls.
+    .topology-toolbar .ep-topology-filter-container {
+        position: relative;
+        margin: 0;
+        flex: 1 1 auto;
+        min-width: 0;
+        max-width: 28rem;
+    }
+
+    .topology-toolbar {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        padding: 1.25rem 1.25rem 0.625rem;
+        box-sizing: border-box;
+        width: 100%;
+        flex-shrink: 0;
+        position: relative;
+        z-index: 4;
+    }
+
     .buttonBall.resize {
         top: 1.25rem;
         width: 1.4375rem;
@@ -68,14 +98,112 @@
         cursor: pointer;
     }
 
+    .topology-refresh-controls {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        flex: 0 0 auto;
+    }
+
+    .topology-refresh-controls .refresh-button {
+        width: 2.5rem;
+        height: 2.5rem;
+        border-radius: 50%;
+        background-color: var(--navigation);
+        box-shadow: 0rem 0.375rem 1rem 0rem var(--shadow),
+                    0 0 0 0.0625rem var(--shadow);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transition: filter 0.15s ease, transform 0.1s ease, box-shadow 0.15s ease;
+
+        .refresh-icon {
+            width: 1.125rem;
+            height: 1.125rem;
+            background-color: var(--tableText);
+            opacity: 0.85;
+            -webkit-mask: url(/assets/svgs/refresh.svg) center / contain no-repeat;
+            mask: url(/assets/svgs/refresh.svg) center / contain no-repeat;
+            transition: opacity 0.15s ease;
+        }
+
+        &:hover {
+            box-shadow: 0rem 0.5rem 1.25rem 0rem var(--shadow),
+                        0 0 0 0.0625rem var(--primaryColor);
+            .refresh-icon { opacity: 1; }
+        }
+
+        &:active {
+            transform: scale(0.95);
+        }
+
+        &.rotating .refresh-icon {
+            animation: rotating 1s linear infinite;
+        }
+    }
+
+    .topology-zoom-controls {
+        position: absolute;
+        bottom: 1rem;
+        left: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.375rem;
+        z-index: 5;
+    }
+
+    .topology-zoom-controls .zoom-btn {
+        width: 2.25rem;
+        height: 2.25rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 0.5rem;
+        background-color: var(--navigation);
+        color: var(--tableText);
+        font-family: 'Open Sans', Arial, sans-serif;
+        font-size: 1.25rem;
+        font-weight: 600;
+        line-height: 1;
+        cursor: pointer;
+        user-select: none;
+        box-shadow: 0rem 0.5rem 1.25rem 0rem var(--shadow);
+        transition: filter 0.15s ease, transform 0.15s ease;
+
+        &.zoom-btn-text {
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }
+
+        &:hover {
+            filter: brightness(85%);
+        }
+
+        &:active {
+            transform: scale(0.95);
+        }
+    }
+
     .identity-topology-container {
         display: flex;
         margin-left: -0.3125rem;
         margin-top: 0.625rem;
         flex-direction: column;
-        cursor: grab;
         flex: 1;
         overflow: hidden;
+        position: relative;
+    }
+
+    #IdentityTopology {
+        cursor: grab;
+        flex: 1;
+        min-height: 0;
+
+        &:active {
+            cursor: grabbing;
+        }
     }
      .lightMode {
        background: #f5e9f2;
@@ -183,13 +311,29 @@
     }
 
     .topology-filter-input {
-        height: 3.125rem;
-        width: 95%;
-        border-radius: 1.5625rem;
-        border-color: var(--navigation);
-        background-color: var(--navigation);
-        box-shadow: 0rem 1.25rem 1.4375rem 0rem var(--shadow);
-        padding-left: 1.25rem;
+        height: 2.75rem;
+        width: 100%;
+        box-sizing: border-box;
+        border-radius: 0.75rem;
+        border: 1px solid var(--shadow);
+        background-color: var(--background);
+        color: var(--tableText);
+        box-shadow: 0 0.0625rem 0.125rem 0 rgba(0, 0, 0, 0.06);
+        padding: 0 2.6rem 0 1rem;
+        font-size: 0.95rem;
+        outline: none;
+        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+        &::placeholder {
+            color: color-mix(in srgb, var(--tableText) 50%, transparent);
+        }
+        &:hover {
+            border-color: color-mix(in srgb, var(--tableText) 28%, transparent);
+        }
+        &:focus {
+            border-color: var(--primary);
+            box-shadow: 0 0 0 0.1875rem color-mix(in srgb, var(--primary) 18%, transparent);
+        }
     }
 
     ::ng-deep .topotip {
@@ -197,7 +341,7 @@
         position: fixed;
         background: var(--navigation);
         border-radius: 0.5rem;
-        pointer-events: none;
+        pointer-events: auto; // allow hovering onto the popover (kept open) to read/select content
         box-shadow: 0 0.25rem 1rem 0 var(--shadow);
         color: var(--tableText);
         z-index: 2000;
@@ -207,7 +351,7 @@
     }
 
     .topology-legend {
-        width: 13rem;
+        width: 15rem;
         border-radius: 0.5rem;
         position: absolute;
         bottom: 1rem;
@@ -215,6 +359,49 @@
         background: var(--navigation);
         box-shadow: 0 0.25rem 0.75rem 0 var(--shadow);
         padding: 0.9rem;
+
+        // Collapsed: shrink to just the clickable header.
+        &.collapsed {
+            width: auto;
+        }
+    }
+
+    .legend-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        cursor: pointer;
+        user-select: none;
+    }
+
+    .legend-header-title {
+        font-family: 'Russo One', sans-serif;
+        font-size: 0.9rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--primary);
+    }
+
+    .legend-header-toggle {
+        color: var(--primary);
+        display: flex;
+        align-items: center;
+
+        svg {
+            display: block;
+            // Down chevron when expanded ("collapse down"); flips to point up when collapsed
+            // ("expand up") — the arrow follows the direction this bottom-anchored panel moves.
+            transition: transform 0.15s ease;
+        }
+    }
+
+    .topology-legend.collapsed .legend-header-toggle svg {
+        transform: rotate(180deg);
+    }
+
+    .legend-body {
+        padding-top: 0.6rem;
     }
 
     .legend-section {
@@ -248,6 +435,7 @@
         align-items: center;
         gap: 0;
         padding: 0.225rem 0;
+        cursor: help; // each row carries a hover definition (title attribute)
     }
 
     .legend-icon-col {
@@ -295,6 +483,14 @@
                 transparent 0.5rem
             );
         }
+
+        // Broken — DOTTED + red, matching the canvas. The dotted pattern (vs the gray dashed
+        // "available" line) is the color-blind-safe differentiator, not the red color alone.
+        &.broken {
+            height: 0;
+            background: none;
+            border-top: 0.28rem dotted #e6432e;
+        }
     }
 
     .legend-text {
@@ -311,7 +507,8 @@
         object-fit: contain;
     }
 
-    .legend-icon.misconfigured {
+    .legend-icon.misconfigured,
+    .legend-icon.broken-link {
         width: 1.2rem;
         height: 1.2rem;
         min-width: 1.2rem;
@@ -374,8 +571,7 @@
     font-family: 'Russo One', sans-serif;
     font-size: 0.975rem;
     color: var(--primary);
-    padding: 0.75rem 0.9rem 0.45rem;
-    border-bottom: 1px solid var(--shadow);
+    padding: 0.7rem 0.9rem 0.15rem;
   }
 
   .prop-row {
@@ -406,25 +602,92 @@
     font-weight: 600;
     text-align: right;
   }
+
+  // --- status pill (compact, content-width chip under the name) ---
+  .tt-status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin: 0 0.9rem 0.55rem;
+    padding: 0.14rem 0.55rem 0.14rem 0.45rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+
+  .tt-status-dot {
+    width: 0.45rem;
+    height: 0.45rem;
+    min-width: 0.45rem;
+    border-radius: 50%;
+  }
+
+  // Add a hairline above the first fact row so the pill and the table read as distinct zones.
+  .prop-row:first-of-type {
+    border-top: 1px solid var(--shadow);
+    padding-top: 0.5rem;
+  }
+
+  .tt-ok {
+    background: rgba(8, 220, 90, 0.12);
+    .tt-status-dot { background: #08dc5a; }
+    .tt-status-label { color: #0a9d4a; }
+  }
+  .tt-broken {
+    background: rgba(230, 67, 46, 0.12);
+    .tt-status-dot { background: #e6432e; }
+    .tt-status-label { color: #d23b27; }
+  }
+  .tt-offline {
+    background: rgba(138, 143, 154, 0.16);
+    .tt-status-dot { background: #8a8f9a; }
+    .tt-status-label { color: #6f7480; }
+  }
+  .tt-neutral {
+    background: rgba(110, 120, 200, 0.12);
+    .tt-status-dot { background: var(--primary); }
+    .tt-status-label { color: var(--primary); }
+  }
 }
 
 ::ng-deep
 {
-   .cdk-overlay-pane:not(.mat-mdc-autocomplete-panel-above) div.mat-mdc-autocomplete-panel {
-    border-radius: 14px;
+   .cdk-overlay-pane .mat-mdc-autocomplete-panel {
+    border-radius: 0.75rem !important;
     background: var(--background);
     color: var(--tableText);
+    padding: 0.35rem;
+    border: 1px solid var(--shadow);
+    box-shadow: 0 0.5rem 1.5rem 0 rgba(0, 0, 0, 0.16) !important;
   }
-  .mat-mdc-option.mdc-list-item
-  {
+  .mat-mdc-autocomplete-panel .mat-mdc-option.mdc-list-item {
      align-items: center;
+     min-height: 2.5rem;
+     margin: 0.1rem 0;
+     border-radius: 0.5rem;
      color: var(--tableText);
+     transition: background-color 0.12s ease, color 0.12s ease;
   }
-  .mat-mdc-option.mdc-list-item:hover:not(.mat-option-disabled),
-                         .mat-mdc-option.mdc-list-item:focus:not(.mat-option-disabled) {
-    border-color: var(--primaryColor);
-    border-radius:14px;
-    border: 0.01rem solid var(--primaryColor);
+  // Hover + keyboard-active: a subtle brand-tinted fill (no stray outline box).
+  .mat-mdc-autocomplete-panel .mat-mdc-option.mdc-list-item:hover:not(.mdc-list-item--disabled),
+  .mat-mdc-autocomplete-panel .mat-mdc-option.mat-mdc-option-active:not(.mdc-list-item--disabled) {
+    background-color: color-mix(in srgb, var(--primary) 9%, transparent) !important;
+  }
+  // Selected: a clean brand tint + brand text (replaces Material's gray highlight).
+  .mat-mdc-autocomplete-panel .mat-mdc-option.mdc-list-item--selected:not(.mdc-list-item--disabled) {
+    background-color: color-mix(in srgb, var(--primary) 14%, transparent) !important;
+  }
+  .mat-mdc-autocomplete-panel .mat-mdc-option.mdc-list-item--selected .mdc-list-item__primary-text {
+    color: var(--primary);
+    font-weight: 600;
+  }
+  // Tame Material's translucent hover/ripple state-layer so it doesn't muddy the tint.
+  .mat-mdc-autocomplete-panel .mat-mdc-option .mat-mdc-option-ripple,
+  .mat-mdc-autocomplete-panel .mat-mdc-option .mat-ripple { display: none; }
+  // Brand-colored selected checkmark.
+  .mat-mdc-autocomplete-panel .mat-pseudo-checkbox-minimal {
+    color: var(--primary);
   }
   .mat-mdc-raised-button .mdc-button__ripple {
      border: 0.1rem solid var(--primaryColor);

--- a/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.component.ts
@@ -36,10 +36,21 @@ export class IdentityServicePathComponent implements OnInit {
   isDarkMode = false;
   refreshRotate = false;
   closeRotate = true;
+  private lastRenderContext: {
+    bindIdnetities: any[];
+    serviceOb: any;
+    serviceConfigs: any[];
+    hostEdgeRouters: any[];
+  } | null = null;
+  private zoomBehavior: any = null;
+  private hasInitialFit = false;
+  private readonly viewBoxWidth = 1050;
+  private readonly viewBoxHeight = 500;
   filterText = 'fetching services..';
   noSearchResults = false;
   autocompleteOptions = [];
   fullScreen = false;
+  legendCollapsed = false;
   serviceOptions: any;
   endpointData;
   networkGraph;
@@ -226,6 +237,8 @@ export class IdentityServicePathComponent implements OnInit {
   }
 
   serviceChanged() {
+     // Service change implies new topology — re-fit on next render.
+     this.hasInitialFit = false;
      this.isLoading = true;
      const allPromises = [];
      let serviceOb = null;
@@ -362,6 +375,12 @@ export class IdentityServicePathComponent implements OnInit {
               }
             }
 
+            this.lastRenderContext = {
+              bindIdnetities,
+              serviceOb,
+              serviceConfigs: service_configs,
+              hostEdgeRouters,
+            };
             this.startVisProcess(
               bindIdnetities, serviceOb, service_configs,
               hostEdgeRouters, serviceTerminators, serviceCircuits
@@ -370,6 +389,54 @@ export class IdentityServicePathComponent implements OnInit {
           });
         });
       });
+  }
+
+  async refreshFabricData(): Promise<void> {
+    if (this.refreshRotate) {
+      return;
+    }
+    this.refreshRotate = true;
+    try {
+      const results = await Promise.allSettled([
+        this.mapDataService.fetchRouters(),
+        this.mapDataService.fetchLinks(),
+        this.mapDataService.fetchCircuits(),
+        this.mapDataService.fetchTerminators(),
+      ]);
+      const [routersResult, linksResult, circuitsResult, terminatorsResult] = results;
+      const allFailed = results.every((r) => r.status === 'rejected');
+      this.fabricApiAvailable = !allFailed;
+
+      if (routersResult.status === 'fulfilled') {
+        this.allRouters = routersResult.value.routers || [];
+        this.routerTypesMap = routersResult.value.routerTypes || new Map();
+      }
+      if (linksResult.status === 'fulfilled') {
+        this.allLinks = linksResult.value || [];
+      }
+      if (circuitsResult.status === 'fulfilled') {
+        this.allCircuits = circuitsResult.value || [];
+      }
+      if (terminatorsResult.status === 'fulfilled') {
+        this.allTerminators = terminatorsResult.value || [];
+      }
+
+      if (this.lastRenderContext) {
+        const { bindIdnetities, serviceOb, serviceConfigs, hostEdgeRouters } = this.lastRenderContext;
+        const serviceTerminators = this.allTerminators.filter(
+          (t) => (t.serviceId || t.service?.id || t.service) === serviceOb.id
+        );
+        const serviceCircuits = this.allCircuits.filter(
+          (c) => c.service?.id === serviceOb.id
+        );
+        this.startVisProcess(
+          bindIdnetities, serviceOb, serviceConfigs,
+          hostEdgeRouters, serviceTerminators, serviceCircuits
+        );
+      }
+    } finally {
+      this.refreshRotate = false;
+    }
   }
 
   addItemToArray(bindIdnetities, ob) {
@@ -455,27 +522,48 @@ export class IdentityServicePathComponent implements OnInit {
   }
 
   initTopoView() {
-    const vbWidth = 1050;
-    const vbHeight = 500;
+    const vbWidth = this.viewBoxWidth;
+    const vbHeight = this.viewBoxHeight;
     const colors = d3.scaleOrdinal(d3.schemeCategory10);
     const tooltip = d3.select('#epTooltip');
+    // Hide is deferred so the cursor can travel from the node into the popover (to read/select
+    // its content); entering the popover cancels the hide, leaving it dismisses it.
+    let tooltipHideTimer: any = null;
+    tooltip.on('mouseenter', () => clearTimeout(tooltipHideTimer));
+    tooltip.on('mouseleave', () => tooltip.style('display', 'none'));
 
-    let svg = d3.select('#IdentityTopology'),
-      node,
-      link;
-
-    const handleZoom = (e) => svg.attr('transform', e.transform);
-    const zoom = d3.zoom().on('zoom', handleZoom);
+    const svg = d3.select('#IdentityTopology');
+    const svgEl: any = svg.node();
+    let node, link;
 
     svg
       .attr('width', '100%')
       .attr('height', '100%')
-      // .call(zoom)
       .attr('viewBox', '-20 -20 ' + (vbWidth + 40) + ' ' + vbHeight)
-      .attr('preserveAspectRatio', 'xMidYMin meet')
-      .append('g');
+      .attr('preserveAspectRatio', 'xMidYMin meet');
+
+    // Capture any pre-existing zoom transform (from previous render / user gestures)
+    // so we can re-apply it after recreating the content group.
+    const existingTransform = svgEl
+      ? d3.zoomTransform(svgEl)
+      : d3.zoomIdentity;
 
     svg.selectAll('g').remove();
+
+    // Wrap all topology content in a <g> so zoom transforms have something to translate.
+    const contentG = svg.append('g').attr('class', 'topology-content');
+    contentG.attr('transform', existingTransform.toString());
+
+    const handleZoom = (e: any) => {
+      contentG.attr('transform', e.transform);
+    };
+
+    if (!this.zoomBehavior) {
+      this.zoomBehavior = d3.zoom().scaleExtent([0.1, 5]).on('zoom', handleZoom);
+    } else {
+      this.zoomBehavior.on('zoom', handleZoom);
+    }
+    svg.call(this.zoomBehavior);
 
     const simulation: any = d3
       .forceSimulation()
@@ -495,7 +583,7 @@ export class IdentityServicePathComponent implements OnInit {
     const links = this.graphJsonObj.links;
     const nodes = this.graphJsonObj.nodes;
 
-    link = svg
+    link = contentG
       .selectAll('g.line.line')
       .data(links)
       .enter()
@@ -503,42 +591,37 @@ export class IdentityServicePathComponent implements OnInit {
       .attr('class', 'link')
       .attr('marker-end', 'url(#arrowhead)');
 
+    // Three link styles, distinguishable by pattern (color-blind-safe) and color. A single
+    // "broken" style covers every failure — which END is the problem is read from the node
+    // colors (an offline router vs an unreachable/un-enrolled endpoint), so the link needn't
+    // re-encode the cause:
+    //   active circuit -> green solid
+    //   available      -> gray dashed
+    //   broken         -> red dotted
+    const isBroken = (d) => d.status === 2;
     link
       .append('line')
       .style('stroke-width', function (d) {
-        if (d.linkType === 'active-circuit') {
-          return 1.5;
-        }
+        if (d.linkType === 'active-circuit') return 1.5;
+        if (isBroken(d)) return 2.25;
         return 1.25;
       })
+      .style('stroke-linecap', function (d) {
+        // Rounded caps turn the tight broken dash array into actual dots.
+        return isBroken(d) ? 'round' : 'butt';
+      })
       .style('stroke', function (d) {
-        if (d.linkType === 'active-circuit') {
-          return '#00cd13';
-        }
+        if (d.linkType === 'active-circuit') return '#00cd13';
+        if (isBroken(d)) return '#e6432e';
         return '#8a8f9a';
       })
       .style('stroke-dasharray', function (d) {
-        if (d.linkType === 'active-circuit') {
-          return null;
-        }
-        return '5,5';
+        if (d.linkType === 'active-circuit') return null; // solid
+        if (isBroken(d)) return '0.5,6'; // dotted
+        return '5,5'; // available: dashed
       });
 
-    link.each(function (this: any, d: any, i) {
-      const _this = d3.select(this);
-      if (d.status === 2) {
-        // Warning/misconfigured — show link-cut icon
-        _this
-          .append('image')
-          .attr('xlink:href', function () {
-            return 'assets/images/visualizer/link-cut.png';
-          })
-          .attr('width', '20')
-          .attr('height', '24');
-      }
-    });
-
-    node = svg
+    node = contentG
       .selectAll('.node')
       .data(nodes)
       .enter()
@@ -557,11 +640,14 @@ export class IdentityServicePathComponent implements OnInit {
           'assets/images/visualizer/host_unregistered.png';
         const endPointPath = 'assets/images/visualizer/host.png';
 
-        if (d.type.includes('Identity') && d.status === 'Un-Registered') {
-          return unregisteredEndpointImagePath;
-        } else if (d.type.includes('Identity') && d.routerConnection === 'No') {
-          return unregisteredEndpointImagePath;
-        } else if (d.type.includes('Identity')) {
+        if (d.type.includes('Identity')) {
+          if (d.status === 'Un-Registered') {
+            return unregisteredEndpointImagePath;
+          }
+          // Enrolled but unreachable / configured-but-not-hosting => broken tunneler.
+          if (d.brokenCause === 'tunneler-unreachable' || d.brokenCause === 'misconfigured') {
+            return errEndpointImagePath;
+          }
           return endPointPath;
         } else if (
           d.type.includes('Router') &&
@@ -592,19 +678,29 @@ export class IdentityServicePathComponent implements OnInit {
       .attr('cy', -20)
       .attr('r', 4.5)
       .attr('fill', function (d: any) {
+        if (d.brokenCause) return '#e6432e'; // broken — enrolled but unreachable / not hosting
         if (d.routerConnection === 'Yes' || d.apiSession === 'Yes') return '#08dc5a';
         return '#8a8f9a';
       })
       .attr('stroke', 'white')
       .attr('stroke-width', 1.5);
 
-    // Symmetric labels — truncated, centered below each node
+    // Node labels: for compound pipe-delimited names ("<networkId>|<identityId>|Human Name")
+    // show only the last segment so the canvas stays readable; the full name remains in the
+    // hover tooltip.
+    const getDisplayLabel = (fullName: string | undefined): string => {
+      if (!fullName) return '';
+      const segments = fullName.split('|').map((s) => s.trim()).filter((s) => s.length > 0);
+      const candidate = segments.length > 0 ? segments[segments.length - 1] : fullName;
+      const maxLen = 28;
+      return candidate.length > maxLen
+        ? candidate.substring(0, maxLen) + '…'
+        : candidate;
+    };
+
     node.each(function (this: any, d: any) {
       const g = d3.select(this);
-      const maxLen = 50;
-      const displayName = d.name && d.name.length > maxLen
-        ? d.name.substring(0, maxLen) + '\u2026'
-        : d.name;
+      const displayName = getDisplayLabel(d.name);
 
       const text = g.append('text')
         .attr('x', 0)
@@ -724,11 +820,14 @@ export class IdentityServicePathComponent implements OnInit {
 
     function removeTooltip() {
       if (tooltip) {
-        tooltip.style('display', 'none');
+        // Defer the hide so the user can move onto the popover; mouseenter (above) cancels it.
+        clearTimeout(tooltipHideTimer);
+        tooltipHideTimer = setTimeout(() => tooltip.style('display', 'none'), 220);
       }
     }
 
     function drawTooltip(event, d, endpointUtlizationJson) {
+      clearTimeout(tooltipHideTimer);
       document.getElementById('epTooltip').innerHTML = readKeyValues(
         d,
         endpointUtlizationJson
@@ -741,40 +840,112 @@ export class IdentityServicePathComponent implements OnInit {
       tooltip.style('top', y);
     }
 
+    // Builds a compact status "card" for a node's hover tooltip: a bold name, a prominent
+    // plain-language status line (with cause), and a few key facts. Makes the connectivity of
+    // customer-hosted tunnelers and routers immediately legible.
     function readKeyValues(d, endpointUtlizationJson) {
-      const excludeKeys = new Set([
-        'status', 'posy', 'posx', 'group', 'hostedEdgeId', 'value',
-        'index', 'parent', 'depth', 'x', 'y', 'id', 'x0', 'y0',
-        'vy', 'vx', 'routerType', 'linkType', 'provider', 'usage',
-      ]);
+      const esc = (s) => String(s).replace(/[&<>"]/g, (c) =>
+        ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
 
-      let info = "<div class='tool-tip-container'>";
-      // Show name as header
-      if (d.name) {
-        info += '<div class="tooltip-header">' + d.name + '</div>';
+      const isRouter = !!(d.type && String(d.type).includes('Router'));
+      const isService = d.group === '4' || !!(d.type && String(d.type).includes('Service'));
+
+      // The status band is the single source of truth for connectivity/enrollment — it replaces
+      // any separate "Enrolled" row. `caption` is a short fragment, used only where it tells the
+      // operator something the label alone doesn't (i.e. what to go check).
+      let cls = 'neutral';
+      let label = '';
+      if (isService) {
+        label = 'Service';
+      } else if (isRouter) {
+        // Routers report a plain online/offline that mirrors the controller's isOnline. The
+        // path-level "router-down" link styling conveys the impact; the node stays simple.
+        if (d.online === 'No' || d.status === 'ERROR') { cls = 'offline'; label = 'Offline'; }
+        else { cls = 'ok'; label = 'Online'; }
+      } else if (d.brokenCause === 'misconfigured' || d.status === 'Un-Registered') {
+        cls = 'broken'; label = 'Not enrolled';
+      } else if (d.brokenCause === 'tunneler-unreachable') {
+        cls = 'broken'; label = 'Unreachable';
+      } else if (d.routerConnection === 'Yes' || d.apiSession === 'Yes') {
+        cls = 'ok'; label = 'Online';
+      } else {
+        cls = 'offline'; label = 'Offline';
       }
 
-      const keys = Object.keys(d);
-      keys.forEach(function (k) {
-        if (excludeKeys.has(k) || k === 'name') return;
+      // No role for the service node — the icon/name already make it obvious, and a "Role: Service"
+      // row would just repeat itself.
+      // Role is the policy action (Dial/Bind) the identity has for the service — NOT the host
+      // mechanism, which we can't know (tunneler vs SDK vs router all look the same here).
+      let role = '';
+      if (d.group === '1') role = 'Client (Dial)';
+      else if (d.group === '3') role = 'Host (Bind)';
+      else if (isRouter) role = d.routerType === 'transit-router' ? 'Transit router' : 'Edge router';
 
-        let val = d[k];
-        if (val === null || val === undefined || val === '') return;
-
-        const label = k.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase());
-
-        if (isAnObject(val)) {
-          val = val.name || JSON.stringify(val);
-        } else if (val instanceof Array) {
-          val = val.join(', ');
+      // Facts that add detail beyond the status pill. The pill summarizes overall state; these
+      // are the granular signals an operator uses to diagnose it (a host can have an API session
+      // yet no router connection). Only the pill's own inputs (Online/Type/Enrolled) are omitted.
+      // Rows are [label, value, optional hover-context]. Service rows are purpose-labeled and
+      // adapt to how the service is configured (intercept+host, host-only, intercept-only, or
+      // SDK-defined with no address config).
+      const rows: [string, string, string?][] = [];
+      if (isService) {
+        if (d.interceptSummary) {
+          rows.push(['Intercept', d.interceptSummary]);
         }
+        if (d.hostSummary) {
+          rows.push(['Host', d.hostSummary]);
+        }
+        if (!d.interceptSummary && !d.hostSummary) {
+          // No intercept/host config. State the facts (the config types present, or none) rather
+          // than inferring "SDK-defined" — there's no property that actually tells us the host type.
+          rows.push(['Config types',
+            (d.configTypeNames && d.configTypeNames.length) ? d.configTypeNames.join(', ') : 'None']);
+        }
+        if (typeof d.encryptionRequired === 'boolean') {
+          rows.push(['Encryption', d.encryptionRequired ? 'Required' : 'Not required']);
+        }
+        if (d.terminatorStrategy) {
+          rows.push(['Terminators', d.terminatorStrategy]);
+        }
+        if (d.serviceRoleAttributes && d.serviceRoleAttributes.length) {
+          rows.push(['Attributes', d.serviceRoleAttributes.join(', ')]);
+        }
+        if (d.permissions && d.permissions.length) {
+          rows.push(['Your access', d.permissions.join(', ')]);
+        }
+      } else {
+        if (role) rows.push(['Role', role]);
+        if (isRouter) {
+          if (d.tunnelerEnabled === 'Yes' || d.tunnelerEnabled === 'No') {
+            rows.push(['Tunneler Enabled', d.tunnelerEnabled]);
+          }
+        } else {
+          if (d.routerConnection === 'Yes' || d.routerConnection === 'No') {
+            rows.push(['Router Connection', d.routerConnection]);
+          }
+          if (d.apiSession === 'Yes' || d.apiSession === 'No') {
+            rows.push(['API Session', d.apiSession]);
+          }
+          if (d.os) rows.push(['OS', d.os]);
+          if (d.mfaEnabled === true) rows.push(['MFA', 'Enabled']);
+        }
+      }
 
-        info += '<div class="prop-row">'
-          + '<span class="prop-label">' + label + '</span>'
-          + '<span class="prop-value">' + val + '</span>'
+      let info = "<div class='tool-tip-container tooltip-card'>";
+      info += '<div class="tooltip-header">' + esc(d.name || '') + '</div>';
+      // The service node carries no connectivity state, so it gets no status pill.
+      if (!isService) {
+        info += '<div class="tt-status-pill tt-' + cls + '">'
+          + '<span class="tt-status-dot"></span>'
+          + '<span class="tt-status-label">' + esc(label) + '</span>'
+          + '</div>';
+      }
+      rows.forEach(([k, v, t]) => {
+        info += '<div class="prop-row"' + (t ? ' title="' + esc(t) + '"' : '') + '>'
+          + '<span class="prop-label">' + esc(k) + '</span>'
+          + '<span class="prop-value">' + esc(v) + '</span>'
           + '</div>';
       });
-
       return info + '</div>';
     }
 
@@ -783,7 +954,84 @@ export class IdentityServicePathComponent implements OnInit {
     }
 
     this.refreshRotate = false;
+
+    // After the first render only, fit the graph to the viewBox so big topologies don't
+    // overflow off-screen. Subsequent renders (refresh ticks) preserve the user's transform.
+    if (!this.hasInitialFit) {
+      setTimeout(() => {
+        this.fitToContent();
+        this.hasInitialFit = true;
+      }, 0);
+    }
   } // end of initTopoView
+
+  fitToContent(): void {
+    if (!this.zoomBehavior) return;
+    const nodes = this.graphJsonObj?.nodes || [];
+    if (nodes.length === 0) return;
+
+    const xs = nodes
+      .map((n: any) => n.posx)
+      .filter((v: any) => typeof v === 'number' && !isNaN(v));
+    const ys = nodes
+      .map((n: any) => n.posy)
+      .filter((v: any) => typeof v === 'number' && !isNaN(v));
+    if (xs.length === 0 || ys.length === 0) return;
+
+    const padding = 60;
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    const minY = Math.min(...ys);
+    const maxY = Math.max(...ys);
+    const contentWidth = (maxX - minX) + padding * 2;
+    const contentHeight = (maxY - minY) + padding * 2;
+    if (contentWidth <= 0 || contentHeight <= 0) return;
+
+    // Reserve room in the bottom-right for the legend so the auto-fit doesn't place nodes
+    // underneath it. When the legend is collapsed there's nothing to avoid.
+    const reserveRight = this.legendCollapsed ? 0 : 160;
+    const reserveBottom = this.legendCollapsed ? 0 : 90;
+    const availWidth = this.viewBoxWidth - reserveRight;
+    const availHeight = this.viewBoxHeight - reserveBottom;
+
+    const scale = Math.min(
+      availWidth / contentWidth,
+      availHeight / contentHeight,
+      1
+    );
+    // Center the content within the available (legend-free) area, which sits at the top-left,
+    // leaving the reserved margin on the right/bottom for the legend panel.
+    const tx = (availWidth - contentWidth * scale) / 2 - (minX - padding) * scale;
+    const ty = (availHeight - contentHeight * scale) / 2 - (minY - padding) * scale;
+
+    d3.select('#IdentityTopology')
+      .transition()
+      .duration(300)
+      .call(
+        this.zoomBehavior.transform,
+        d3.zoomIdentity.translate(tx, ty).scale(scale)
+      );
+  }
+
+  zoomIn(): void {
+    if (!this.zoomBehavior) return;
+    d3.select('#IdentityTopology')
+      .transition()
+      .duration(200)
+      .call(this.zoomBehavior.scaleBy, 1.4);
+  }
+
+  zoomOut(): void {
+    if (!this.zoomBehavior) return;
+    d3.select('#IdentityTopology')
+      .transition()
+      .duration(200)
+      .call(this.zoomBehavior.scaleBy, 1 / 1.4);
+  }
+
+  resetView(): void {
+    this.fitToContent();
+  }
 }
 
 class ServiceData {

--- a/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.component.ts
+++ b/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.component.ts
@@ -632,58 +632,60 @@ export class IdentityServicePathComponent implements OnInit {
       .append('image')
       .attr('xlink:href', function (d) {
         const routerImagePath = 'assets/images/visualizer/Routers.png';
-        const nonProvisionedRouterImagePath =
-          'assets/images/visualizer/ER.png';
-        const errRouterImagePath = 'assets/images/visualizer/error_er.png';
-        const errEndpointImagePath = 'assets/images/visualizer/host-error.png';
         const unregisteredEndpointImagePath =
           'assets/images/visualizer/host_unregistered.png';
         const endPointPath = 'assets/images/visualizer/host.png';
 
         if (d.type.includes('Identity')) {
-          if (d.status === 'Un-Registered') {
+          // Un-enrolled identities get the distinct "unregistered" icon; otherwise the normal
+          // host icon — the status dot below conveys online/offline/unknown.
+          if (d.connState === 'unenrolled' || d.status === 'Un-Registered') {
             return unregisteredEndpointImagePath;
           }
-          // Enrolled but unreachable / configured-but-not-hosting => broken tunneler.
-          if (d.brokenCause === 'tunneler-unreachable' || d.brokenCause === 'misconfigured') {
-            return errEndpointImagePath;
-          }
           return endPointPath;
-        } else if (
-          d.type.includes('Router') &&
-          (d.status === 'ERROR' || d.online === 'No')
-        ) {
-          return errRouterImagePath;
-        } else if (d.type.includes('Router') && d.status === 'PROVISIONED') {
-          return routerImagePath;
-        } else if (d.type.includes('Router')) {
-          return nonProvisionedRouterImagePath;
         }
-
+        if (d.type.includes('Router')) {
+          // One base router icon; the status dot below carries online/offline (the baked dot in
+          // the PNG is covered by that overlay).
+          return routerImagePath;
+        }
         if (d.group === '4') {
           return 'assets/images/visualizer/service.png';
-        } else {
-          return '';
         }
+        return '';
       })
       .attr('x', -25)
       .attr('y', -25)
       .attr('width', '40')
       .attr('height', '40');
 
-    // Add status circle overlay for identity nodes
-    node.filter((d: any) => d.type.includes('Identity'))
+    // Status dot for identities AND routers. Colors a single dot by the node's real state
+    // (no "error" — that isn't a value the API exposes). Routers use a larger dot positioned to
+    // cover the status dot baked into the router PNG.
+    const statusColor = (d: any): string => {
+      if (d.type.includes('Router')) {
+        return (d.online === 'No' || d.status === 'ERROR') ? '#8a8f9a' : '#08dc5a';
+      }
+      switch (d.connState) {
+        case 'online': return '#08dc5a';   // green
+        case 'unknown': return '#e6a700';   // amber — controller can't determine
+        case 'unenrolled': return '#ffffff'; // hollow (gray ring below)
+        case 'offline':
+        default: return '#8a8f9a';          // gray
+      }
+    };
+    // Positioned to sit directly over the dot baked into each icon PNG (≈ the icon's top-right),
+    // sized just large enough to cover it (the white halo masks the baked dot's soft glow).
+    node.filter((d: any) => d.type.includes('Identity') || d.type.includes('Router'))
       .append('circle')
-      .attr('cx', 10)
-      .attr('cy', -20)
-      .attr('r', 4.5)
-      .attr('fill', function (d: any) {
-        if (d.brokenCause) return '#e6432e'; // broken — enrolled but unreachable / not hosting
-        if (d.routerConnection === 'Yes' || d.apiSession === 'Yes') return '#08dc5a';
-        return '#8a8f9a';
-      })
-      .attr('stroke', 'white')
-      .attr('stroke-width', 1.5);
+      .attr('cx', (d: any) => d.type.includes('Router') ? 6 : 8)
+      .attr('cy', (d: any) => d.type.includes('Router') ? -20 : -19)
+      .attr('r', 5)
+      .attr('fill', (d: any) => statusColor(d))
+      // Un-enrolled identities render as a hollow ring (gray border); everything else gets a
+      // white separator ring against the icon.
+      .attr('stroke', (d: any) => (!d.type.includes('Router') && d.connState === 'unenrolled') ? '#8a8f9a' : 'white')
+      .attr('stroke-width', 2);
 
     // Node labels: for compound pipe-delimited names ("<networkId>|<identityId>|Human Name")
     // show only the last segment so the canvas stays readable; the full name remains in the
@@ -853,23 +855,24 @@ export class IdentityServicePathComponent implements OnInit {
       // The status band is the single source of truth for connectivity/enrollment — it replaces
       // any separate "Enrolled" row. `caption` is a short fragment, used only where it tells the
       // operator something the label alone doesn't (i.e. what to go check).
+      // Status pill mirrors the node dot — the component's real state (online / offline /
+      // unknown / not-enrolled), never a synthesized "error". Path problems live on the links.
       let cls = 'neutral';
       let label = '';
       if (isService) {
         label = 'Service';
       } else if (isRouter) {
-        // Routers report a plain online/offline that mirrors the controller's isOnline. The
-        // path-level "router-down" link styling conveys the impact; the node stays simple.
+        // Routers only expose isOnline (no edgeRouterConnectionStatus).
         if (d.online === 'No' || d.status === 'ERROR') { cls = 'offline'; label = 'Offline'; }
         else { cls = 'ok'; label = 'Online'; }
-      } else if (d.brokenCause === 'misconfigured' || d.status === 'Un-Registered') {
-        cls = 'broken'; label = 'Not enrolled';
-      } else if (d.brokenCause === 'tunneler-unreachable') {
-        cls = 'broken'; label = 'Unreachable';
-      } else if (d.routerConnection === 'Yes' || d.apiSession === 'Yes') {
-        cls = 'ok'; label = 'Online';
       } else {
-        cls = 'offline'; label = 'Offline';
+        switch (d.connState) {
+          case 'online': cls = 'ok'; label = 'Online'; break;
+          case 'unknown': cls = 'unknown'; label = 'Unknown'; break;
+          case 'unenrolled': cls = 'offline'; label = 'Not enrolled'; break;
+          case 'offline':
+          default: cls = 'offline'; label = 'Offline'; break;
+        }
       }
 
       // No role for the service node — the icon/name already make it obvious, and a "Role: Service"

--- a/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.helper.ts
+++ b/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.helper.ts
@@ -1,6 +1,15 @@
 import { Inject, Injectable } from '@angular/core';
 import _ from 'lodash';
 
+// statusReason explains WHY a link is in a broken (status === 2) state so the renderer
+// can show router-reported issues differently from tunneler-side connectivity problems.
+type LinkStatusReason = 'router-down' | 'tunneler-unreachable' | 'misconfigured' | null;
+
+interface LinkState {
+    state: number; // 1 = active, -1/0 = available/offline, 2 = broken
+    reason: LinkStatusReason;
+}
+
 class Link {
     source;
     sourceName;
@@ -8,6 +17,7 @@ class Link {
     targetName;
     weight;
     status;
+    statusReason: LinkStatusReason = null;
     linkType: 'active-circuit' | 'fabric-link' | 'inferred' | 'endpoint-connection' = 'inferred';
 }
 
@@ -28,6 +38,10 @@ class Node {
     type;
     usage;
     routerType?: 'edge-router' | 'transit-router';
+    // brokenCause drives the broken node iconography; connectivity is the human-readable
+    // line shown in the hover tooltip. Both are null/empty when the node is healthy.
+    brokenCause?: LinkStatusReason;
+    connectivity?: string;
 }
 
 class ServiceHostNode {
@@ -162,6 +176,7 @@ export class IdentityServicePathHelper {
         srNode.id = selectedServiceOb.id;
         srNode.name = selectedServiceOb.name;
         srNode.intercept = serviceConfigAlias(serviceConfigs);
+        buildServiceDetails(srNode, selectedServiceOb, serviceConfigs);
         srNode.type = 'Config Service';
         srNode.group = '4';
         srNode.status = '1';
@@ -275,6 +290,35 @@ export class IdentityServicePathHelper {
             }
         });
 
+        // Per-host connectivity is derived from the identity's own controller-reported state
+        // (hasEdgeRouterConnection / edgeRouterConnectionStatus -> routerConnection/apiSession),
+        // NOT from terminators: real ziti terminators carry no hosting-identity id (identity:"",
+        // no hostId), so a terminator can't be mapped back to the host that created it. Terminator
+        // COUNT remains a service-level health hint only.
+
+        // Annotate node connectivity so the renderer can pick a broken icon and the tooltip can
+        // explain the cause. A hosting tunneler that is enrolled but unreachable, or expected to
+        // host (Bind policy) yet has no terminator, is "broken".
+        group3Nodes.forEach((node) => {
+            if (node.status === 'Un-Registered') {
+                node.brokenCause = 'misconfigured';
+                node.connectivity = 'Not enrolled';
+            } else if (node.apiSession === 'No' || node.routerConnection === 'No') {
+                node.brokenCause = 'tunneler-unreachable';
+                node.connectivity = 'Configured but not connected (offline or blocked)';
+            } else {
+                node.connectivity = 'Connected';
+            }
+        });
+        if (endpointNodeOb && endpointNodeOb.status !== 'Un-Registered') {
+            if (endpointNodeOb.apiSession === 'No' || endpointNodeOb.routerConnection === 'No') {
+                endpointNodeOb.brokenCause = 'tunneler-unreachable';
+                endpointNodeOb.connectivity = 'Configured but not connected (offline or blocked)';
+            } else {
+                endpointNodeOb.connectivity = 'Connected';
+            }
+        }
+
         // Build fabric link lookup
         const fabricLinkSet = new Set<string>();
         fabricLinks.forEach((link) => {
@@ -294,8 +338,7 @@ export class IdentityServicePathHelper {
                     lnk.sourceName = endpointNodeOb.name;
                     lnk.target = nd.id;
                     lnk.targetName = nd.name;
-                    lnk.status = getEndpointToRouterLinkState(endpointNodeOb, nd);
-                    lnk.weight = getWeight(lnk.status);
+                    applyLinkState(lnk, getEndpointToRouterLinkState(endpointNodeOb, nd));
                     lnk.linkType = activeCircuitHops.has(hopKey(endpointNodeOb.id, nd.id))
                         ? 'active-circuit' : 'endpoint-connection';
                     rootOb.addLink(lnk);
@@ -402,10 +445,15 @@ export class IdentityServicePathHelper {
             lnk.target = r2.id;
             lnk.targetName = r2.name;
             lnk.linkType = isActiveCircuit ? 'active-circuit' : 'fabric-link';
-            lnk.status = (r1.online === 'Yes' || r1.status === 'PROVISIONED') &&
-                         (r2.online === 'Yes' || r2.status === 'PROVISIONED') ? 1 : 0;
-            if (isActiveCircuit) lnk.status = 1;
-            lnk.weight = getWeight(lnk.status);
+            const r1Up = r1.online === 'Yes' || r1.status === 'PROVISIONED';
+            const r2Up = r2.online === 'Yes' || r2.status === 'PROVISIONED';
+            if (isActiveCircuit) {
+                applyLinkState(lnk, { state: 1, reason: null });
+            } else if (!r1Up || !r2Up) {
+                applyLinkState(lnk, { state: 2, reason: 'router-down' });
+            } else {
+                applyLinkState(lnk, { state: 1, reason: null });
+            }
             rootOb.addLink(lnk);
         });
 
@@ -459,8 +507,7 @@ export class IdentityServicePathHelper {
                             lnk.sourceName = routerNode.name;
                             lnk.target = hostNode.id;
                             lnk.targetName = hostNode.name;
-                            lnk.status = getEndpointToRouterLinkState(hostNode, routerNode);
-                            lnk.weight = getWeight(lnk.status);
+                            applyLinkState(lnk, getEndpointToRouterLinkState(hostNode, routerNode));
                             lnk.linkType = activeCircuitHops.has(hopKey(routerNode.id, hostNode.id))
                                 ? 'active-circuit' : 'endpoint-connection';
                             rootOb.addLink(lnk);
@@ -478,8 +525,7 @@ export class IdentityServicePathHelper {
                         lnk.sourceName = routerNode.name;
                         lnk.target = hostNode.id;
                         lnk.targetName = hostNode.name;
-                        lnk.status = getEndpointToRouterLinkState(hostNode, routerNode);
-                        lnk.weight = getWeight(lnk.status);
+                        applyLinkState(lnk, getEndpointToRouterLinkState(hostNode, routerNode));
                         lnk.linkType = activeCircuitHops.has(hopKey(routerNode.id, hostNode.id))
                             ? 'active-circuit'
                             : (lnk.status === 1 ? 'endpoint-connection' : 'inferred');
@@ -503,8 +549,7 @@ export class IdentityServicePathHelper {
                         lnk.sourceName = dialRouter.name;
                         lnk.target = hostNode.id;
                         lnk.targetName = hostNode.name;
-                        lnk.status = getEndpointToRouterLinkState(hostNode, dialRouter);
-                        lnk.weight = getWeight(lnk.status);
+                        applyLinkState(lnk, getEndpointToRouterLinkState(hostNode, dialRouter));
                         lnk.linkType = lnk.status === 1 ? 'endpoint-connection' : 'inferred';
                         rootOb.addLink(lnk);
                     }
@@ -533,8 +578,7 @@ export class IdentityServicePathHelper {
                 lnk.target = serviceNode.id;
                 lnk.targetName = serviceNode.name;
                 lnk.weight = 1;
-                lnk.status = getServiceToEndpointLinkState(hostNode, serviceNode);
-                lnk.weight = getWeight(lnk.status);
+                applyLinkState(lnk, getServiceToEndpointLinkState(hostNode, serviceNode));
                 lnk.linkType = activeCircuitHops.has(hopKey(hostNode.id, serviceNode.id))
                     ? 'active-circuit' : 'endpoint-connection';
                 rootOb.addLink(lnk);
@@ -553,6 +597,26 @@ export class IdentityServicePathHelper {
             if (dialSide.has(srcGroup) && dialSide.has(tgtGroup)) return false;
             return true;
         });
+
+        // Collapse parallel links between the same node pair. A router that is on BOTH the dial
+        // and host side can otherwise produce two links to the same node — e.g. an 'available'
+        // inferred link and a 'router-down' link — which overlap and render as mixed dashed/dotted.
+        // Keep the single most-significant link per pair.
+        const linkSeverity = (l) => {
+            if (l.linkType === 'active-circuit') return 4; // live traffic wins
+            if (l.status === 2) return 3;                  // broken (router-down / tunneler-unreachable)
+            if (l.status === 1) return 2;                  // connected
+            return 1;                                      // available / inferred
+        };
+        const bestLinkByPair = new Map<string, any>();
+        rootOb.links.forEach((lnk) => {
+            const key = [lnk.source, lnk.target].sort().join('::');
+            const existing = bestLinkByPair.get(key);
+            if (!existing || linkSeverity(lnk) > linkSeverity(existing)) {
+                bestLinkByPair.set(key, lnk);
+            }
+        });
+        rootOb.links = Array.from(bestLinkByPair.values());
 
         return rootOb;
     }
@@ -593,6 +657,7 @@ export class IdentityServicePathHelper {
         srNode.id = selectedServiceOb.id;
         srNode.name = selectedServiceOb.name;
         srNode.intercept = serviceConfigAlias(serviceConfigs);
+        buildServiceDetails(srNode, selectedServiceOb, serviceConfigs);
         srNode.type = 'Config Service';
         srNode.group = '4';
         srNode.status = '1';
@@ -696,8 +761,7 @@ export class IdentityServicePathHelper {
                 lnk.sourceName = endpointNodeOb.name;
                 lnk.target = nd.id;
                 lnk.targetName = nd.name;
-                lnk.status = getEndpointToRouterLinkState(endpointNodeOb, nd);
-                lnk.weight = getWeight(lnk.status);
+                applyLinkState(lnk, getEndpointToRouterLinkState(endpointNodeOb, nd));
                 lnk.linkType = 'endpoint-connection';
                 rootOb.addLink(lnk);
             }
@@ -723,8 +787,9 @@ export class IdentityServicePathHelper {
                             nd2.status === 'PROVISIONED' &&
                             nd2.online === 'Yes'
                                 ? 1 : 0;
+                        lnk.statusReason = lnk.status === 1 ? null : 'router-down';
                     } else {
-                        lnk.status = getEndpointToRouterLinkState(nd2, nd1);
+                        applyLinkState(lnk, getEndpointToRouterLinkState(nd2, nd1));
                     }
                     lnk.weight = getWeight(lnk.status);
                     lnk.linkType = 'inferred';
@@ -747,8 +812,7 @@ export class IdentityServicePathHelper {
                 if (foundNd.type.includes('Router')) {
                     lnk.status = foundNd.online === 'Yes' ? 1 : -1;
                 } else {
-                    lnk.status = getServiceToEndpointLinkState(group3Nodes[k1], group4Nodes[k0]);
-                    lnk.weight = getWeight(lnk.status);
+                    applyLinkState(lnk, getServiceToEndpointLinkState(group3Nodes[k1], group4Nodes[k0]));
                 }
                 lnk.linkType = 'endpoint-connection';
                 rootOb.addLink(lnk);
@@ -815,6 +879,44 @@ function serviceConfigAlias(configs) {
     return intercept;
 }
 
+// Annotates the service node with labeled, purpose-specific details so the hover card can explain
+// what each address is for and surface the service's configuration. Handles services that are
+// intercept+host, host-only, intercept-only, or SDK-defined (no address configs at all).
+function buildServiceDetails(srNode, service, configs) {
+    srNode.encryptionRequired = service ? service.encryptionRequired : undefined;
+    srNode.terminatorStrategy = service ? service.terminatorStrategy : undefined;
+    srNode.serviceRoleAttributes = _.isArray(service && service.roleAttributes) ? service.roleAttributes : [];
+    srNode.permissions = _.isArray(service && service.permissions) ? service.permissions : [];
+
+    const fmtPorts = (portRanges, port) => {
+        if (_.isArray(portRanges)) {
+            return portRanges.map((r) => (r.low === r.high ? `${r.low}` : `${r.low}-${r.high}`));
+        }
+        if (port !== undefined && port !== null) return [String(port)];
+        return [];
+    };
+    const fmtEndpoint = (addrs, ports, protos) => {
+        const a = (addrs || []).filter(Boolean).join(', ');
+        const detail = [(protos || []).join('/'), (ports || []).join(',')].filter(Boolean).join('/');
+        return detail ? `${a}  ${detail}` : a;
+    };
+
+    const types = [];
+    _.isArray(configs) && configs.forEach((conf) => {
+        const t = ((conf && conf.configType && conf.configType.name) || (conf && conf.type) || '').toString();
+        const d = (conf && conf.data) || {};
+        if (t) types.push(t);
+        if (t.indexOf('intercept') === 0) {
+            const addrs = d.addresses || (d.address ? [d.address] : []);
+            srNode.interceptSummary = fmtEndpoint(addrs, fmtPorts(d.portRanges, d.port), d.protocols || (d.protocol ? [d.protocol] : []));
+        } else if (t.indexOf('host') === 0) {
+            const addrs = d.address ? [d.address] : (d.forwardAddress ? ['(forwarded)'] : []);
+            srNode.hostSummary = fmtEndpoint(addrs, fmtPorts(d.allowedPortRanges, d.port), d.protocol ? [d.protocol] : (d.protocols || (d.forwardProtocol ? ['(forwarded)'] : [])));
+        }
+    });
+    srNode.configTypeNames = types;
+}
+
 function findEndpoint(endpointId, endpoints) {
     if (endpointId === null) {
         return null;
@@ -835,7 +937,10 @@ function createEndpoint(ePoint) {
     node.id = ePoint.id;
     node.name = ePoint.name;
     node.type = 'Identity';
-    if (_.has(ePoint, 'edgeRouterConnectionStatus')) {
+    // Prefer the explicit booleans, which controllers populate reliably. Only fall back to the
+    // edgeRouterConnectionStatus string when it actually carries a value — note its key can be
+    // PRESENT-BUT-NULL, so `_.has` is not a safe guard (that bug made every identity look "Yes").
+    if (ePoint.edgeRouterConnectionStatus != null) {
         node.routerConnection = ePoint.edgeRouterConnectionStatus === 'offline' ? 'No' : 'Yes';
         node.apiSession = node.routerConnection;
     } else {
@@ -844,7 +949,10 @@ function createEndpoint(ePoint) {
     }
     node.os = ePoint.envInfo ? ePoint.envInfo.os : '';
     node.mfaEnabled = ePoint.isMfaEnabled;
-    node.status = ePoint.envInfo && ePoint.envInfo.os !== null ? 'Registered' : 'Un-Registered';
+    // "Registered" means the identity has enrolled and run (it has reported env info). Guard on a
+    // truthy os: the controller returns envInfo as an empty object {} for a created-but-never-
+    // enrolled identity, and `{}.os !== null` is true — which previously mis-classed it Registered.
+    node.status = (ePoint.envInfo && ePoint.envInfo.os) ? 'Registered' : 'Un-Registered';
     return node;
 }
 
@@ -872,33 +980,60 @@ function createFabricRouterNode(fabricRouter, routerType: 'edge-router' | 'trans
     return nodeOb;
 }
 
-function getEndpointToRouterLinkState(endpointNode, routerNode) {
-    let linkstate = -1;
-    if (routerNode.status === 'ERROR') {
-        linkstate = 2; // router is broken — warning
-    } else if (endpointNode.status === 'Un-Registered') {
-        linkstate = -1;
-    } else if (endpointNode.apiSession === 'No' || endpointNode.routerConnection === 'No') {
-        // No session or no connection = offline, not error
-        linkstate = -1;
-    } else if (routerNode.online === 'Yes' && endpointNode.routerConnection === 'Yes') {
-        linkstate = 1;
-    } else {
-        linkstate = -1;
+// Determines the state of an identity/tunneler <-> edge-router link.
+// A router-reported problem (offline/errored router) is distinguished from a tunneler-side
+// problem (enrolled identity that cannot establish a connection to the router, e.g. blocked
+// by a firewall) so the visualizer can render the two causes differently.
+function getEndpointToRouterLinkState(endpointNode, routerNode): LinkState {
+    if (routerNode.status === 'ERROR' || routerNode.online === 'No') {
+        return { state: 2, reason: 'router-down' }; // router-reported issue
     }
-    return linkstate;
+    if (endpointNode.status === 'Un-Registered') {
+        // Never enrolled — the path through this identity can't carry traffic, so it's not
+        // "available". Marked unavailable (the node still shows the specific "Not enrolled" cause).
+        return { state: 2, reason: 'misconfigured' };
+    }
+    if (endpointNode.apiSession === 'No' || endpointNode.routerConnection === 'No') {
+        // Enrolled but cannot reach the edge router — tunneler-side broken (was previously
+        // shown as a benign "available" link, which is exactly what we're fixing).
+        return { state: 2, reason: 'tunneler-unreachable' };
+    }
+    if (routerNode.online === 'Yes' && endpointNode.routerConnection === 'Yes') {
+        return { state: 1, reason: null }; // active/available
+    }
+    return { state: -1, reason: null };
 }
 
-function getServiceToEndpointLinkState(endpointNode, serviceNode) {
-    // status 1 = active, -1 = offline/available, 2 = warning/misconfigured
-    if (endpointNode.status === 'Un-Registered') {
-        return 2; // hosting identity never enrolled — misconfigured
-    } else if (endpointNode.apiSession === 'No' || endpointNode.routerConnection === 'No') {
-        return -1; // just offline
-    } else if (endpointNode.status === 'Registered' && endpointNode.routerConnection === 'Yes') {
-        return 1; // active
+// Determines the state of a hosting identity/router <-> service link.
+// hasTerminator is the authoritative signal that the host actually established its hosting
+// connection: a Bind policy makes a host "expected", but only a terminator proves it connected.
+function getServiceToEndpointLinkState(hostNode, serviceNode): LinkState {
+    const isRouter = !!(hostNode.type && String(hostNode.type).includes('Router'));
+    if (isRouter) {
+        if (hostNode.status === 'ERROR' || hostNode.online === 'No') {
+            return { state: 2, reason: 'router-down' };
+        }
+        return { state: 1, reason: null };
     }
-    return -1;
+    // Identity host (tunneler). Broken-detection uses the host's own connection state, since
+    // terminators can't be attributed to a specific host (see note in getEndpointGraphObj).
+    if (hostNode.status === 'Un-Registered') {
+        return { state: 2, reason: 'misconfigured' }; // never enrolled
+    }
+    if (hostNode.apiSession === 'No' || hostNode.routerConnection === 'No') {
+        return { state: 2, reason: 'tunneler-unreachable' }; // enrolled but unreachable (e.g. firewall)
+    }
+    if (hostNode.status === 'Registered' && hostNode.routerConnection === 'Yes') {
+        return { state: 1, reason: null }; // active/available
+    }
+    return { state: -1, reason: null };
+}
+
+// Applies a computed LinkState to a link, including its derived weight.
+function applyLinkState(lnk, ls: LinkState) {
+    lnk.status = ls.state;
+    lnk.statusReason = ls.reason;
+    lnk.weight = getWeight(ls.state);
 }
 
 function getWeight(linkState) {

--- a/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.helper.ts
+++ b/projects/ziti-console-lib/src/lib/features/visualizer/identity-service-path/identity-service-path.helper.ts
@@ -42,6 +42,7 @@ class Node {
     // line shown in the hover tooltip. Both are null/empty when the node is healthy.
     brokenCause?: LinkStatusReason;
     connectivity?: string;
+    connState?: 'online' | 'offline' | 'unknown' | 'unenrolled';
 }
 
 class ServiceHostNode {
@@ -953,6 +954,22 @@ function createEndpoint(ePoint) {
     // truthy os: the controller returns envInfo as an empty object {} for a created-but-never-
     // enrolled identity, and `{}.os !== null` is true — which previously mis-classed it Registered.
     node.status = (ePoint.envInfo && ePoint.envInfo.os) ? 'Registered' : 'Un-Registered';
+
+    // Node status indicator. Mirrors the controller's edgeRouterConnectionStatus enum
+    // (online | offline | unknown) when present, falling back to the hasEdgeRouterConnection
+    // boolean otherwise. An identity that hasn't enrolled is "unenrolled" (its own state, not an
+    // error). There is no "error" value in the API, so we don't synthesize one.
+    if (node.status === 'Un-Registered') {
+        node.connState = 'unenrolled';
+    } else {
+        const ers = ePoint.edgeRouterConnectionStatus;
+        if (ers === 'online' || ers === 'offline' || ers === 'unknown') {
+            node.connState = ers;
+        } else {
+            node.connState = (ePoint.hasEdgeRouterConnection === true || ePoint.hasApiSession === true)
+                ? 'online' : 'offline';
+        }
+    }
     return node;
 }
 


### PR DESCRIPTION
closes #893 

* Pan/zoom + fit and manual refresh; per-hop path status (active / available / unavailable) with colorblind-safe styling;
* richer node & service hover cards;
* clearer collapsible legend;
* polished service search/select.

<img width="2055" height="1140" alt="Screenshot 2026-06-23 at 3 26 20 PM" src="https://github.com/user-attachments/assets/93b32be1-a7eb-4182-8651-b2811dd5706c" />
