### PR TITLE
Add filtering and sorting to service and router queries

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service-edge-router-policy/service-edge-router-policy-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service-edge-router-policy/service-edge-router-policy-form.service.ts
@@ -126,7 +126,7 @@ export class ServiceEdgeRouterPolicyFormService {
     }
 
     public getServiceNamedAttributes() {
-        return this.zitiService.get('services', {}, []).then((result) => {
+        return this.zitiService.get('services', {rawFilter: true, filter: '', sort: 'name', order: 'asc', total: -1, page: 1}, []).then((result) => {
             const namedAttributes = result.data.map((service) => {
                 this.serviceNamedAttributesMap[service.name] = service.id;
                 return service.name;
@@ -137,7 +137,7 @@ export class ServiceEdgeRouterPolicyFormService {
     }
 
     public getEdgeRouterNamedAttributes() {
-        return this.zitiService.get('edge-routers', {}, []).then((result) => {
+        return this.zitiService.get('edge-routers', {rawFilter: true, filter: '', sort: 'name', order: 'asc', total: -1, page: 1}, []).then((result) => {
             const namedAttributes = result.data.map((router) => {
                 this.edgeRouterNamedAttributesMap[router.name] = router.id;
                 return router.name;


### PR DESCRIPTION
Attributes are shown incorrectly when network has more than 1k of an attribute type
fix #912 