### PR TITLE
Hide password change for OIDC-authenticated users

### DIFF
--- a/projects/ziti-console-lib/src/lib/pages/profile/profile.component.html
+++ b/projects/ziti-console-lib/src/lib/pages/profile/profile.component.html
@@ -7,25 +7,29 @@
           <div class="tab selected">Manage <span>{{pageTitle}}</span></div>
         </div>
         <div class="constrained">
-            <div class="grid split">
-                <div>
-                    <label>Current Password</label>
-                    <input [(ngModel)]="currentPassword" type="password" autocomplete="new-password"/>
+            @if (passwordChangeDisabled) {
+                <div class="password-change-message">{{passwordChangeMessage}}</div>
+            } @else {
+                <div class="grid split">
+                    <div>
+                        <label>Current Password</label>
+                        <input [(ngModel)]="currentPassword" type="password" autocomplete="new-password"/>
+                    </div>
+                    <div></div>
+                    <div>
+                        <label>New Password</label>
+                        <input [(ngModel)]="newPassword" type="password" autocomplete="new-password"/>
+                    </div>
+                    <div>
+                        <label>Confirm Password</label>
+                        <input [(ngModel)]="confirmPassword" type="password" autocomplete="new-password"/>
+                    </div>
+                    <div></div>
+                    <div>
+                        <div class="button" (click)="resetPassword()">Save</div>
+                    </div>
                 </div>
-                <div></div>
-                <div>
-                    <label>New Password</label>
-                    <input [(ngModel)]="newPassword" type="password" autocomplete="new-password"/>
-                </div>
-                <div>
-                    <label>Confirm Password</label>
-                    <input [(ngModel)]="confirmPassword" type="password" autocomplete="new-password"/>
-                </div>
-                <div></div>
-                <div>
-                    <div class="button" (click)="resetPassword()">Save</div>
-                </div>
-            </div>
+            }
         </div>
     </div>
 </div>

--- a/projects/ziti-console-lib/src/lib/pages/profile/profile.component.scss
+++ b/projects/ziti-console-lib/src/lib/pages/profile/profile.component.scss
@@ -8,6 +8,15 @@
     }
 }
 
+.password-change-message {
+  padding: 1rem;
+  border: 0.0625rem solid var(--stroke);
+  border-radius: var(--inputBorderRadius);
+  background: var(--light);
+  color: var(--dark);
+  line-height: 1.5;
+}
+
 .button {
   font-size: 0.6875rem;
   font-weight: 400;

--- a/projects/ziti-console-lib/src/lib/pages/profile/profile.component.spec.ts
+++ b/projects/ziti-console-lib/src/lib/pages/profile/profile.component.spec.ts
@@ -1,0 +1,75 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {FormsModule} from '@angular/forms';
+import {RouterTestingModule} from '@angular/router/testing';
+import {Subject} from 'rxjs';
+import {ProfileComponent} from './profile.component';
+import {SETTINGS_SERVICE} from '../../services/settings.service';
+import {ZITI_DATA_SERVICE} from '../../services/ziti-data.service';
+import {GrowlerService} from '../../features/messaging/growler.service';
+
+describe('ProfileComponent', () => {
+  let fixture: ComponentFixture<ProfileComponent>;
+  let component: ProfileComponent;
+
+  let settingsService: { settings: any; settingsChange: Subject<any> };
+
+  const zitiService = {
+    resetPassword: jasmine.createSpy('resetPassword').and.resolveTo({}),
+    getErrorMessage: jasmine.createSpy('getErrorMessage').and.returnValue('test error')
+  };
+
+  const growlerService = {
+    show: jasmine.createSpy('show')
+  };
+
+  beforeEach(async () => {
+    settingsService = {
+      settings: { session: {} },
+      settingsChange: new Subject<any>()
+    };
+
+    await TestBed.configureTestingModule({
+      declarations: [ProfileComponent],
+      imports: [FormsModule, RouterTestingModule],
+      providers: [
+        { provide: SETTINGS_SERVICE, useValue: settingsService },
+        { provide: ZITI_DATA_SERVICE, useValue: zitiService },
+        { provide: GrowlerService, useValue: growlerService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProfileComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('shows the password form for locally authenticated users', () => {
+    settingsService.settings = { session: { authMode: 'legacy' } };
+    settingsService.settingsChange.next(settingsService.settings);
+    fixture.detectChanges();
+
+    const passwordInputs = fixture.nativeElement.querySelectorAll('input[type="password"]');
+    expect(passwordInputs.length).toBe(3);
+    expect(fixture.nativeElement.textContent).toContain('Current Password');
+  });
+
+  it('hides the password form and shows an explanation for OIDC users', () => {
+    settingsService.settings = { session: { authMode: 'oidc' } };
+    settingsService.settingsChange.next(settingsService.settings);
+    fixture.detectChanges();
+
+    const passwordInputs = fixture.nativeElement.querySelectorAll('input[type="password"]');
+    expect(passwordInputs.length).toBe(0);
+    expect(fixture.nativeElement.textContent).toContain('managed by your identity provider');
+  });
+
+  it('blocks password reset for OIDC users', () => {
+    settingsService.settings = { session: { authMode: 'oidc' } };
+    settingsService.settingsChange.next(settingsService.settings);
+    fixture.detectChanges();
+
+    component.resetPassword();
+
+    expect(growlerService.show).toHaveBeenCalled();
+    expect(zitiService.resetPassword).not.toHaveBeenCalled();
+  });
+});

--- a/projects/ziti-console-lib/src/lib/pages/profile/profile.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/profile/profile.component.ts
@@ -1,7 +1,10 @@
-import {Component, Inject} from '@angular/core';
+import {Component, Inject, OnDestroy} from '@angular/core';
 import {ZITI_DATA_SERVICE, ZitiDataService} from "../../services/ziti-data.service";
+import {SETTINGS_SERVICE} from '../../services/settings.service';
+import {SettingsServiceClass} from '../../services/settings-service.class';
 import {GrowlerModel} from "../../features/messaging/growler.model";
 import {GrowlerService} from "../../features/messaging/growler.service";
+import {Subscription} from 'rxjs';
 import {isEmpty} from 'lodash';
 
 @Component({
@@ -10,18 +13,49 @@ import {isEmpty} from 'lodash';
     styleUrls: ['./profile.component.scss'],
     standalone: false
 })
-export class ProfileComponent {
+export class ProfileComponent implements OnDestroy {
   pageTitle = 'Profile';
   currentPassword = '';
   newPassword = '';
   confirmPassword = '';
+  passwordChangeDisabled = false;
+  passwordChangeMessage = '';
+  private settingsSubscription?: Subscription;
 
   constructor(
       @Inject(ZITI_DATA_SERVICE) private zitiService: ZitiDataService,
+      @Inject(SETTINGS_SERVICE) private settingsService: SettingsServiceClass,
       private growlerService: GrowlerService,
-  ) {}
+  ) {
+      this.updatePasswordChangeState();
+      this.settingsSubscription = this.settingsService.settingsChange.subscribe(() => {
+          this.updatePasswordChangeState();
+      });
+  }
+
+  ngOnDestroy(): void {
+      this.settingsSubscription?.unsubscribe();
+  }
+
+  private updatePasswordChangeState(): void {
+      const authMode = this.settingsService?.settings?.session?.authMode;
+      this.passwordChangeDisabled = authMode === 'oidc';
+      this.passwordChangeMessage = this.passwordChangeDisabled
+          ? 'Your password is managed by your identity provider and cannot be changed here.'
+          : '';
+  }
 
   resetPassword() {
+    if (this.passwordChangeDisabled) {
+      const growlerData = new GrowlerModel(
+          'error',
+          'Error',
+          'Password Change Not Allowed',
+          'Your password is managed by your identity provider and cannot be changed here.',
+      );
+      this.growlerService.show(growlerData);
+      return;
+    }
     if (!this.validate()) {
       return;
     }
@@ -49,7 +83,7 @@ export class ProfileComponent {
   }
 
   validate() {
-    if (isEmpty(this.newPassword) || isEmpty(this.newPassword) || isEmpty(this.confirmPassword)) {
+    if (isEmpty(this.currentPassword) || isEmpty(this.newPassword) || isEmpty(this.confirmPassword)) {
       const growlerData = new GrowlerModel(
           'error',
           'Error',


### PR DESCRIPTION
fixes #913 

### Changes
- Hide the password change form for OIDC users.
- Display a message explaining that passwords are managed by the external identity provider.
- Add a defensive guard in `resetPassword()`.
- Subscribe to `settingsChange` so the UI updates when authentication state changes.
- Add unit tests covering local and OIDC authentication flows.
- Fix password validation to check all required fields.