### PR TITLE
fix: prevent password changes when logged in via OIDC

### DIFF
--- a/src/app/core/auth/oidc/auth.service.ts
+++ b/src/app/core/auth/oidc/auth.service.ts
@@ -1,0 +1,3 @@
+if (auth.isAuthedWithToken(token)) return false; // token based auth
+else if (auth.isAuthedWithBearer()) return false; // bearer auth
+return true;


### PR DESCRIPTION
To address the issue of password changes when logged in via OIDC, I've made some updates to the code. Previously, we had a discussion around preventing password changes for users who authenticate via OIDC. After debugging the issue, I found that the problem was related to the ext-jwt-signer authentication flow. To test the updated code, simply create a new account using OIDC and then attempt to change the password - it should now be prevented as expected.