### PR TITLE
Enable external JWT (IdP) login on node server deployments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "io.netfoundry.zac",
-  "version": "4.2.0",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "io.netfoundry.zac",
-      "version": "4.2.0",
+      "version": "4.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -102,7 +102,7 @@
     },
     "dist/ziti-console-lib": {
       "name": "@openziti/ziti-console-lib",
-      "version": "1.1.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/projects/app-ziti-console/src/app/app.module.ts
+++ b/projects/app-ziti-console/src/app/app.module.ts
@@ -93,7 +93,13 @@ export function initializeApp(settingsService: any, injector: Injector) {
     return () =>
         settingsService.init().then(() => {
             injector.get(ManagementPermissionsService);
-            injector.get(SessionRefreshService).start();
+            // SessionRefreshService renews browser-held controller-native OIDC tokens. The node
+            // deployment authenticates server-side (no browser-held refresh token), so starting it
+            // here only lets a stale authMode:'oidc' localStorage session log the user out of a valid
+            // node session. Only run it for the controller-served (non-node) build. See #915.
+            if (!environment.nodeIntegration) {
+                injector.get(SessionRefreshService).start();
+            }
         });
 }
 

--- a/projects/app-ziti-console/src/app/interceptors/node-api.interceptor.ts
+++ b/projects/app-ziti-console/src/app/interceptors/node-api.interceptor.ts
@@ -41,17 +41,30 @@ export class NodeApiInterceptor implements HttpInterceptor {
         return next.handle(req).pipe(
             switchMap((event: HttpEvent<any>) => {
                 if (event instanceof HttpResponse) {
-                    return this.handleResponse(event);
+                    return this.handleResponse(event, req);
                 }
                 return of(event);
             })
         );
     }
 
-    private handleResponse(event: any): Observable<any> {
+    private handleResponse(event: any, req?: HttpRequest<any>): Observable<any> {
         const body = event?.body;
         if (body?.errorObj?.code === 'UNAUTHORIZED') {
             if (this.loginService.loginDialogOpen) {
+                return of(event);
+            }
+            // A passive session-validity probe (checkForValidNodeSession) 401s whenever we're logged
+            // out; that must route to /login, never pop the re-login modal - otherwise a probe fired
+            // during a logout/login transition leaves a stale modal over the dashboard. See #915.
+            if (req?.headers?.get('x-zac-session-check')) {
+                return of(event);
+            }
+            // Don't pop the "Session Expired" modal while a login/logout is mid-flight: on /callback
+            // the ext-jwt session check runs before navigating away, and logout navigates to /login -
+            // in-flight polls momentarily 401 during these transitions. See openziti/ziti-console#915.
+            const path = (this.router.url || '').split('?')[0];
+            if (path.endsWith('/login') || path.endsWith('/callback')) {
                 return of(event);
             }
             this.dialogRef = this.dialogForm.open(LoginDialogComponent, {

--- a/projects/app-ziti-console/src/app/login/controller-login.service.spec.ts
+++ b/projects/app-ziti-console/src/app/login/controller-login.service.spec.ts
@@ -1,0 +1,83 @@
+/*
+    Copyright NetFoundry Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import {ControllerLoginService} from './controller-login.service';
+
+// Covers the openziti/ziti-console#915 fix: logout() must clear the whole session object,
+// not just .id - otherwise authMode:'oidc' and the (expired) refreshToken survive, keeping
+// hasOidcSession() true so an expired session keeps triggering the "session expired" logout
+// on every load, including the /callback route where it preempts a brand-new login.
+describe('ControllerLoginService.logout()', () => {
+    let service: ControllerLoginService;
+    let settings: any;
+    let oidc: any;
+    let sessionRefresh: any;
+    let ha: any;
+    let router: any;
+    let growler: any;
+
+    beforeEach(() => {
+        settings = {
+            settings: {
+                session: {
+                    id: 'access-token',
+                    authMode: 'oidc',
+                    refreshToken: 'refresh-token',
+                    oidcClientId: 'openziti',
+                    controllerDomain: 'https://ctrl.example.com:1280'
+                }
+            },
+            set: jasmine.createSpy('set'),
+            edgeOidcPath: '/oidc'
+        };
+        oidc = jasmine.createSpyObj('ZitiOidcService', ['revokeToken']);
+        sessionRefresh = jasmine.createSpyObj('SessionRefreshService', ['stop']);
+        ha = jasmine.createSpyObj('HAControllerService', ['reset']);
+        router = jasmine.createSpyObj('Router', ['navigate']);
+        growler = jasmine.createSpyObj('GrowlerService', ['show']);
+
+        service = new ControllerLoginService({} as any, settings, router, growler, ha, oidc, sessionRefresh);
+        spyOn<any>(service, 'cancelMfaAuth').and.stub();
+    });
+
+    it('clears the entire session object, not just .id', () => {
+        spyOn(localStorage, 'removeItem');
+
+        service.logout();
+
+        expect(settings.settings.session).toEqual({});
+        expect(settings.settings.session.authMode).toBeUndefined();
+        expect(settings.settings.session.refreshToken).toBeUndefined();
+        expect(localStorage.removeItem).toHaveBeenCalledWith('ziti.settings');
+        expect(sessionRefresh.stop).toHaveBeenCalled();
+        expect(ha.reset).toHaveBeenCalled();
+        expect(router.navigate).toHaveBeenCalledWith(['/login']);
+    });
+
+    it('revokes the refresh token when logging out of an OIDC session', () => {
+        service.logout();
+        expect(oidc.revokeToken).toHaveBeenCalled();
+    });
+
+    it('does not attempt revocation for a non-OIDC session but still clears it', () => {
+        settings.settings.session = {authMode: 'legacy', id: 'x'};
+
+        service.logout();
+
+        expect(oidc.revokeToken).not.toHaveBeenCalled();
+        expect(settings.settings.session).toEqual({});
+    });
+});

--- a/projects/app-ziti-console/src/app/login/controller-login.service.ts
+++ b/projects/app-ziti-console/src/app/login/controller-login.service.ts
@@ -646,10 +646,8 @@ export class ControllerLoginService extends LoginServiceClass {
         }
         this.sessionRefreshService.stop();
         this.cancelMfaAuth();
-        // Clear the whole session, not just .id - otherwise authMode:'oidc' and the
-        // (expired) refreshToken survive, keeping hasOidcSession() true so an expired
-        // session keeps triggering handleUnrecoverable() on every load, including the
-        // /callback route where it preempts a brand-new login. See openziti/ziti-console#915.
+        // Clear the whole session, not just .id, so a stale expired OIDC session stops
+        // firing handleUnrecoverable(). See openziti/ziti-console#915.
         this.settingsService.settings.session = {} as any;
         this.settingsService.set(this.settingsService.settings);
         localStorage.removeItem('ziti.settings');

--- a/projects/app-ziti-console/src/app/login/controller-login.service.ts
+++ b/projects/app-ziti-console/src/app/login/controller-login.service.ts
@@ -646,9 +646,13 @@ export class ControllerLoginService extends LoginServiceClass {
         }
         this.sessionRefreshService.stop();
         this.cancelMfaAuth();
-        localStorage.removeItem('ziti.settings');
-        this.settingsService.settings.session.id = undefined;
+        // Clear the whole session, not just .id - otherwise authMode:'oidc' and the
+        // (expired) refreshToken survive, keeping hasOidcSession() true so an expired
+        // session keeps triggering handleUnrecoverable() on every load, including the
+        // /callback route where it preempts a brand-new login. See openziti/ziti-console#915.
+        this.settingsService.settings.session = {} as any;
         this.settingsService.set(this.settingsService.settings);
+        localStorage.removeItem('ziti.settings');
         this.haControllerService.reset(); // Clear HA cluster status
         this.router.navigate(['/login']);
     }

--- a/projects/app-ziti-console/src/app/login/login.component.scss
+++ b/projects/app-ziti-console/src/app/login/login.component.scss
@@ -296,6 +296,9 @@
   color: var(--tableText);
   height: var(--defaultInputHeight);
   border-style: solid;
+  // match the input fields' border width; without this it falls back to the CSS default
+  // (medium, ~3px) and reads noticeably thicker than the rest of the form
+  border-width: var(--inputBorderWidth);
   border-color: var(--inputBorder);
   border-radius: var(--inputBorderRadius);
   vertical-align: middle;

--- a/projects/app-ziti-console/src/app/login/login.component.ts
+++ b/projects/app-ziti-console/src/app/login/login.component.ts
@@ -98,7 +98,10 @@ export class LoginComponent implements OnInit, OnDestroy {
 
     getExternalJwtSigners() {
         this.extJwtSigners = [];
-        if (isEmpty(this.settingsService.settings.selectedEdgeController) || !this.settingsService.allowControllerAdd) {
+        // Gate only on having a controller to query. Previously this also required
+        // allowControllerAdd, which is false for the node server deployment
+        // (NodeSettingsService), silently hiding IdP login there. See openziti/ziti-console#915.
+        if (isEmpty(this.settingsService.settings.selectedEdgeController)) {
             return;
         }
         this.extJwtSignersLoading = true;

--- a/projects/app-ziti-console/src/app/login/login.component.ts
+++ b/projects/app-ziti-console/src/app/login/login.component.ts
@@ -98,9 +98,8 @@ export class LoginComponent implements OnInit, OnDestroy {
 
     getExternalJwtSigners() {
         this.extJwtSigners = [];
-        // Gate only on having a controller to query. Previously this also required
-        // allowControllerAdd, which is false for the node server deployment
-        // (NodeSettingsService), silently hiding IdP login there. See openziti/ziti-console#915.
+        // Don't gate on allowControllerAdd (false under NodeSettingsService), which hid
+        // IdP login on the node server. See openziti/ziti-console#915.
         if (isEmpty(this.settingsService.settings.selectedEdgeController)) {
             return;
         }

--- a/projects/app-ziti-console/src/app/login/node-login.service.ts
+++ b/projects/app-ziti-console/src/app/login/node-login.service.ts
@@ -40,6 +40,13 @@ export class NodeLoginService extends LoginServiceClass {
     }
 
     init() {
+        // On /callback the OIDC code exchange and /api/login haven't run yet, so this bootstrap probe
+        // hits a userless session and its 401 resolves late - after navigation to /dashboard - popping
+        // the "Session Expired" modal. Skip it here; handleLoginResponse re-checks once login completes.
+        // Mirrors SessionRefreshService.start()'s /callback guard. See openziti/ziti-console#915.
+        if (window.location.pathname.endsWith('/callback')) {
+            return Promise.resolve(false);
+        }
         return this.checkForValidNodeSession();
     }
 
@@ -116,6 +123,10 @@ export class NodeLoginService extends LoginServiceClass {
         const options = {
             headers: {
                 accept: 'application/json',
+                // Mark this as a passive session-validity probe. Its 401 just means "not logged in"
+                // and must route to /login, never pop the re-login modal - otherwise a probe fired
+                // during a logout/login transition leaves a stale modal over the dashboard. See #915.
+                'x-zac-session-check': 'true',
             },
             params: {},
             responseType: 'json' as const,

--- a/projects/app-ziti-console/src/app/login/node-login.service.ts
+++ b/projects/app-ziti-console/src/app/login/node-login.service.ts
@@ -43,12 +43,12 @@ export class NodeLoginService extends LoginServiceClass {
         return this.checkForValidNodeSession();
     }
 
-    async login(prefix: string, url: string, username: string, password: string, doNav = true) {
-        return this.nodeLogin(url, username, password, doNav);
+    async login(prefix: string, url: string, username: string, password: string, doNav = true, type?, token?) {
+        return this.nodeLogin(url, username, password, doNav, type, token);
     }
 
-    nodeLogin(controllerURL: string, username: string, password: string, doNav = true) {
-        return lastValueFrom(this.observeLogin(controllerURL, username, password, doNav)
+    nodeLogin(controllerURL: string, username: string, password: string, doNav = true, type?, token?) {
+        return lastValueFrom(this.observeLogin(controllerURL, username, password, doNav, type, token)
             ).then(() => {
                 if (doNav) {
                     this.router.navigate(['/']);
@@ -56,11 +56,13 @@ export class NodeLoginService extends LoginServiceClass {
             });
     }
 
-    observeLogin(controllerURL: string, username: string, password: string, doNav = true): Observable<any> {
+    observeLogin(controllerURL: string, username: string, password: string, doNav = true, type?, token?): Observable<any> {
         const loginURL = '/api/login';
+        // For ext-jwt (IdP/OIDC) logins the browser already holds the IdP token; forward it so the
+        // node server can exchange it for a ziti session. See openziti/ziti-console#915.
         return this.httpClient.post(
             loginURL,
-            { url: controllerURL, username: username, password: password },
+            { url: controllerURL, username: username, password: password, type: type, token: token },
             {
                 headers: {
                     "content-type": "application/json"

--- a/projects/app-ziti-console/src/app/services/node-settings.service.ts
+++ b/projects/app-ziti-console/src/app/services/node-settings.service.ts
@@ -145,31 +145,25 @@ export class NodeSettingsService extends SettingsServiceClass {
         return firstValueFrom(this.httpClient.post(callUrl, {}, options)
             .pipe(
                 tap((body: any) => {
-                    try {
-                        if (body.error) {
-                            let growlerData = new GrowlerModel(
-                              'error',
-                              'Error',
-                              'Invalid Edge Controller: ' + body.error,
-                            );
-                            this.growlerService.show(growlerData);
-                        } else {
-                            this.apiVersions = body.data.apiVersions;
-                            this.zitiSemver = body.data?.version?.replace("v", "");
-                        }
-                    } catch (e) {
-                      let growlerData = new GrowlerModel(
-                        'error',
-                        'Error',
-                        'Invalid Edge Controller: ' + body,
-                      );
-                      this.growlerService.show(growlerData);
+                    if (body?.error) {
+                        // a genuine bad-controller response - surface the message, not [object Object]
+                        const detail = body.error?.message || (typeof body.error === 'string' ? body.error : JSON.stringify(body.error));
+                        this.growlerService.show(new GrowlerModel(
+                            'error',
+                            'Error',
+                            'Invalid Edge Controller: ' + detail,
+                        ));
+                    } else if (body?.data?.apiVersions) {
+                        this.apiVersions = body.data.apiVersions;
+                        this.zitiSemver = body.data?.version?.replace("v", "");
                     }
+                    // else: the node server has no controller context yet (e.g. the pre-login version
+                    // probe from the OIDC callback) - skip quietly rather than growling. See #915.
                 }),
                 catchError((err: any) => {
                     throw "Edge Controller not Online: " + err?.message;
                 }),
-                map(body => body.data.apiVersions)));
+                map((body: any) => body?.data?.apiVersions)));
     }
 
     // HA Controller methods - Node server doesn't support HA, so these are no-op implementations

--- a/projects/ziti-console-lib/src/lib/pages/callback/callback.component.ts
+++ b/projects/ziti-console-lib/src/lib/pages/callback/callback.component.ts
@@ -47,7 +47,11 @@ export class CallbackComponent implements OnInit {
                                 token = this.oauthService.getAccessToken();
                             }
                             const prefix = '/edge/client/v1';
-                            const url = this.settingsService.settings.selectedEdgeController;
+                            // Use the controller pinned when the flow was initiated, not the currently
+                            // selected one (which may have changed across the IdP redirect).
+                            const url = localStorage.getItem('oauth_callback_controller') || this.settingsService.settings.selectedEdgeController;
+                            localStorage.removeItem('oauth_callback_controller');
+                            this.settingsService.settings.selectedEdgeController = url;
                             let doNav = true;
                             let isTest = false;
                             if (!isEmpty(redirectRoute)) {

--- a/projects/ziti-console-lib/src/lib/services/auth.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/auth.service.ts
@@ -5,6 +5,8 @@ import {GrowlerModel} from "../features/messaging/growler.model";
 import {GrowlerService} from "../features/messaging/growler.service";
 import {APP_BASE_HREF} from "@angular/common";
 import {NavigationEnd, Router} from "@angular/router";
+import {SETTINGS_SERVICE} from "./settings.service";
+import {SettingsServiceClass} from "./settings-service.class";
 
 @Injectable({
     providedIn: 'root'
@@ -14,7 +16,8 @@ export class AuthService {
     constructor(
         private oauthService: OAuthService, private http: HttpClient,
         private growlerService: GrowlerService,
-        private router: Router
+        private router: Router,
+        @Inject(SETTINGS_SERVICE) private settingsService: SettingsServiceClass
     ) {
         router.events.subscribe((event: any) => {
             if (event instanceof NavigationEnd) {
@@ -35,6 +38,7 @@ export class AuthService {
         window.history.pushState({}, '', urlWithoutHash);
         localStorage.removeItem(configKey);
         localStorage.removeItem(tokenTypeKey);
+        localStorage.removeItem('oauth_callback_controller');
         this.oauthService.logOut();
         this.oauthService.configure({});
     }
@@ -63,6 +67,9 @@ export class AuthService {
         if (extJwtSigner.targetToken) {
             localStorage.setItem(tokenTypeKey || 'oauth_callback_target_token', extJwtSigner.targetToken);
         }
+        // Pin the controller selected when the flow was initiated. The IdP round-trip reloads state,
+        // so the callback must exchange against this controller, not whatever is selected on return.
+        localStorage.setItem('oauth_callback_controller', this.settingsService.settings?.selectedEdgeController || '');
         this.oauthService.configure(oauthConfig);
         return this.oauthService.loadDiscoveryDocumentAndTryLogin().then((initSuccess) => {
             if (initSuccess) {

--- a/projects/ziti-console-lib/src/lib/services/node-data.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/node-data.service.ts
@@ -117,9 +117,8 @@ export class NodeDataService extends ZitiDataService {
         paging.filter = urlFilter;
         const body: any = {paging: paging, type: type, url: url};
         if (useClient) {
-            // The client API (edge/client/v1) is public; the node backend must fetch it
-            // unauthenticated rather than via the session-scoped management API. Pass the
-            // selected controller so it can be reached pre-login. See openziti/ziti-console#915.
+            // Fetch the public client API unauthenticated (pre-login) via the selected
+            // controller, not the session-scoped mgmt API. See openziti/ziti-console#915.
             body.useClient = true;
             body.controllerUrl = this.settingsService?.settings?.selectedEdgeController;
         }

--- a/projects/ziti-console-lib/src/lib/services/node-data.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/node-data.service.ts
@@ -110,12 +110,19 @@ export class NodeDataService extends ZitiDataService {
         );
     }
 
-    doGet(type: string, paging: any, filters: FilterObj[] = [], url?) {
+    doGet(type: string, paging: any, filters: FilterObj[] = [], url?, useClient?) {
         const nodeServerURL = window.location.origin;
         const serviceUrl = nodeServerURL + '/api/data';
         const urlFilter = this.getUrlFilter(paging, filters);
         paging.filter = urlFilter;
-        const body = {paging: paging, type: type, url: url};
+        const body: any = {paging: paging, type: type, url: url};
+        if (useClient) {
+            // The client API (edge/client/v1) is public; the node backend must fetch it
+            // unauthenticated rather than via the session-scoped management API. Pass the
+            // selected controller so it can be reached pre-login. See openziti/ziti-console#915.
+            body.useClient = true;
+            body.controllerUrl = this.settingsService?.settings?.selectedEdgeController;
+        }
 
         return firstValueFrom(this.httpClient.post(serviceUrl,body,{}).pipe(
                 catchError((err: any) => {

--- a/projects/ziti-console-lib/src/lib/services/session-refresh.service.spec.ts
+++ b/projects/ziti-console-lib/src/lib/services/session-refresh.service.spec.ts
@@ -129,6 +129,24 @@ describe('SessionRefreshService', () => {
         expect(loginService.logout).toHaveBeenCalled();
     });
 
+    it('start() does not end an expired session while on the /callback route (openziti/ziti-console#915)', () => {
+        // Same expired-refresh-token scenario as above, but mid-login on /callback: the monitor
+        // must not fire, or it would redirect to /login before the auth code is exchanged.
+        const originalPath = window.location.pathname;
+        history.pushState({}, '', '/zac/callback');
+        try {
+            const nowSec = Math.floor(Date.now() / 1000);
+            settingsService.settings.session.refreshExpiresAt = (nowSec - 60) * 1000;
+
+            service.start();
+            expect(loginService.logout).not.toHaveBeenCalled();
+            expect(growlerService.show).not.toHaveBeenCalled();
+            expect((service as any).running).toBe(false);
+        } finally {
+            history.pushState({}, '', originalPath);
+        }
+    });
+
     it('start() schedules a proactive refresh before the access token expires', () => {
         jasmine.clock().install();
         try {

--- a/projects/ziti-console-lib/src/lib/services/session-refresh.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/session-refresh.service.ts
@@ -70,9 +70,8 @@ export class SessionRefreshService {
     ) {}
 
     start(): void {
-        // Never run the refresh/expiry monitor while an OAuth/OIDC login is completing on the
-        // /callback route - a stale expired session must not fire handleUnrecoverable() and
-        // redirect to /login before CallbackComponent can exchange the authorization code.
+        // Skip the monitor on /callback so a stale expired session can't redirect to /login
+        // before the code exchange completes. See openziti/ziti-console#915.
         if (window.location.pathname.endsWith('/callback')) {
             return;
         }

--- a/projects/ziti-console-lib/src/lib/services/session-refresh.service.ts
+++ b/projects/ziti-console-lib/src/lib/services/session-refresh.service.ts
@@ -70,6 +70,12 @@ export class SessionRefreshService {
     ) {}
 
     start(): void {
+        // Never run the refresh/expiry monitor while an OAuth/OIDC login is completing on the
+        // /callback route - a stale expired session must not fire handleUnrecoverable() and
+        // redirect to /login before CallbackComponent can exchange the authorization code.
+        if (window.location.pathname.endsWith('/callback')) {
+            return;
+        }
         if (!this.hasOidcSession()) {
             return;
         }

--- a/server.js
+++ b/server.js
@@ -952,19 +952,18 @@ function GetClientItems(type, paging, request, response) {
 // Resolve the client-API controller base; a browser controllerUrl is honored only if it matches
 // a configured controller (SSRF guard), else fall back to session/global.
 function GetClientControllerBase(request) {
-	if (request.body.controllerUrl) {
-		var requested = trimTrailingSlash(request.body.controllerUrl);
-		var match = "";
-		if (settings.edgeControllers) {
-			settings.edgeControllers.forEach(function(controller) {
-				// return the configured URL on match, never the request value
-				if (trimTrailingSlash(controller.url) === requested) match = trimTrailingSlash(controller.url);
-			});
-		}
-		return match;
+	// Resolve a candidate, then always return the matching CONFIGURED url - never the request or
+	// session value - so the request target is fully trusted.
+	var requested = request.body.controllerUrl || request.session.baseUrl || baseUrl;
+	if (!requested) return "";
+	requested = trimTrailingSlash(requested);
+	var match = "";
+	if (settings.edgeControllers) {
+		settings.edgeControllers.forEach(function(controller) {
+			if (trimTrailingSlash(controller.url) === requested) match = trimTrailingSlash(controller.url);
+		});
 	}
-	var fallback = request.session.baseUrl || baseUrl;
-	return fallback ? trimTrailingSlash(fallback) : "";
+	return match;
 }
 
 /**

--- a/server.js
+++ b/server.js
@@ -249,14 +249,17 @@ app.use(function(req, res, next) {
 });
 app.use(bodyParser.json());
 app.use(fileUpload());
-app.use(session({ 
-	store: new sessionStore({}), 
-	secret: 'NetFoundryZiti', 
-	retries: 0, 
-	resave: true, 
-	saveUninitialized: true, 
-	ttl: 60000, 
-	logFn: () => {}
+app.use(session({
+	// retries/logFn belong to the store, not to session() - passing them to session() left the store
+	// on its defaults (5 retries + console logging), so a cookie whose file was missing looped on
+	// ENOENT instead of failing fast to a fresh session. See #915.
+	store: new sessionStore({ retries: 0, logFn: () => {} }),
+	secret: 'NetFoundryZiti',
+	// resave/saveUninitialized false: read-only requests must not re-save (and clobber) a session
+	// that a concurrent /api/login just wrote the user to. This fixes the ext-jwt "Session Expired"
+	// race, where bootstrap polls wiped the freshly-authenticated session.
+	resave: false,
+	saveUninitialized: false
 }));
 app.use(function (req, res, next) {
 	res.setHeader('X-XSS-Protection', '1; mode=block');

--- a/server.js
+++ b/server.js
@@ -182,13 +182,8 @@ if (integration !== 'classic') {
 	helmetOptions.contentSecurityPolicy.directives.scriptSrcAttr.push("'unsafe-eval'");
 }
 
-// --- Dynamic CSP for external OIDC login ------------------------------------
-// OIDC login (discovery, JWKS, token exchange) is a browser fetch from the console
-// to the identity provider. Rather than weaken connect-src to a wildcard, allow only
-// the origins of External JWT Signers the controller admin has already configured as
-// trusted token issuers. The list is refreshed from the controller's public client API
-// (see refreshIdpOrigins) and applied per-request, so newly added signers take effect
-// without a restart. Operators can add extra origins via ZAC_CSP_CONNECT_SRC.
+// Dynamic CSP: allow connect/frame-src only to configured signers' IdP origins so the
+// browser OIDC flow works without a wildcard. Extra origins via ZAC_CSP_CONNECT_SRC.
 let idpConnectOrigins = [];
 const extraCspConnect = (process.env.ZAC_CSP_CONNECT_SRC || '')
 	.split(',').map(function(s) { return s.trim(); }).filter(Boolean);
@@ -213,8 +208,7 @@ function buildHelmetOptions() {
 	};
 }
 
-// Fetch the distinct externalAuthUrl origins of every enabled signer across all
-// configured controllers. Uses the public client API - no session required.
+// Collect distinct externalAuthUrl origins of all signers via the public client API.
 function refreshIdpOrigins() {
 	var controllers = (settings.edgeControllers || [])
 		.map(function(c) { return trimTrailingSlash(c.url); }).filter(Boolean);
@@ -365,8 +359,7 @@ for (var i=0; i<settings.edgeControllers.length; i++) {
 	}
 }
 
-// Prime the IdP CSP allowlist now that controllers/rejectUnauthorized are resolved,
-// then refresh periodically so signers added later are picked up without a restart.
+// Prime the IdP CSP allowlist, then refresh periodically to pick up new signers.
 refreshIdpOrigins();
 setInterval(refreshIdpOrigins, 5 * 60 * 1000);
 
@@ -870,11 +863,7 @@ function GetItems(type, paging, request, response, cli, serviceCall) {
 	}
 }
 
-/**
- * Build the edge API query string (?filter=...&limit=...&offset=...&sort=...) from the
- * paging parameters supplied by the browser. Shared by the authenticated management path
- * (GetItems) and the public client path (GetClientItems) so both behave identically.
- */
+// Build the edge API query string from paging params. Shared by GetItems and GetClientItems.
 function BuildUrlFilter(paging) {
 	var urlFilter = "";
 	var toSearchOn = "name";
@@ -909,11 +898,8 @@ function BuildUrlFilter(paging) {
 	return urlFilter;
 }
 
-/**
- * Fetch a resource from the controller's public client API (edge/client/v1) without a
- * session. Used for data the login page needs pre-authentication - e.g. external-jwt-signers,
- * so the IdP login buttons render in node-server deployments. See openziti/ziti-console#915.
- */
+// Fetch from the public client API (edge/client/v1) without a session, for pre-login data
+// like external-jwt-signers. See openziti/ziti-console#915.
 function GetClientItems(type, paging, request, response) {
 	var controllerBase = GetClientControllerBase(request);
 	if (controllerBase==null||controllerBase.trim().length==0) {
@@ -935,12 +921,8 @@ function GetClientItems(type, paging, request, response) {
 	});
 }
 
-/**
- * Resolve the controller base URL for a public client-API call. A controllerUrl supplied
- * by the browser is honored only when it matches a configured controller (guards against
- * the server being used to reach arbitrary hosts); otherwise fall back to the session /
- * global controller.
- */
+// Resolve controller base for a client-API call; honor a browser-supplied controllerUrl only
+// if it matches a configured controller (SSRF guard), else fall back to session/global.
 function GetClientControllerBase(request) {
 	if (request.body.controllerUrl) {
 		var requested = trimTrailingSlash(request.body.controllerUrl);

--- a/server.js
+++ b/server.js
@@ -359,9 +359,9 @@ for (var i=0; i<settings.edgeControllers.length; i++) {
 	}
 }
 
-// Prime the IdP CSP allowlist, then refresh periodically to pick up new signers.
+// Prime the IdP CSP allowlist at startup; thereafter it is refreshed opportunistically when
+// the login page fetches signers (see GetClientItems / mergeIdpOrigins).
 refreshIdpOrigins();
-setInterval(refreshIdpOrigins, 5 * 60 * 1000);
 
 var transporter;
 
@@ -877,6 +877,7 @@ function BuildUrlFilter(paging) {
 			if (paging.page!=-1) urlFilter = "?limit="+paging.total+"&offset="+((paging.page-1)*paging.total);
 		} else {
 			if (paging.rawFilter) {
+				// rawFilter is a complete filter expression (syntax, not a value) - do not encode it
 				urlFilter = "?filter=" + paging.filter.trim();
 				if (paging.total) {
 					urlFilter += "&limit="+paging.total;
@@ -885,12 +886,12 @@ function BuildUrlFilter(paging) {
 					urlFilter += "&offset="+((paging.page-1)*paging.total);
 				}
 				if (paging.sort) {
-					urlFilter += "&sort="+paging.sort+" "+paging.order;
+					urlFilter += "&sort="+encodeURIComponent(paging.sort)+" "+encodeURIComponent(paging.order);
 				}
-			} else if (paging.page!=-1) urlFilter = "?filter=("+toSearchOn+" contains \""+paging.filter+"\")&limit="+paging.total+"&offset="+((paging.page-1)*paging.total)+"&sort="+paging.sort+" "+paging.order;
+			} else if (paging.page!=-1) urlFilter = "?filter=("+encodeURIComponent(toSearchOn)+" contains \""+encodeURIComponent(paging.filter)+"\")&limit="+paging.total+"&offset="+((paging.page-1)*paging.total)+"&sort="+encodeURIComponent(paging.sort)+" "+encodeURIComponent(paging.order);
 			if (paging.params) {
 				for (var key in paging.params) {
-					urlFilter += ((urlFilter.length==0)?"?":"&")+key+"="+paging.params[key];
+					urlFilter += ((urlFilter.length==0)?"?":"&")+encodeURIComponent(key)+"="+encodeURIComponent(paging.params[key]);
 				}
 			}
 		}
@@ -898,9 +899,28 @@ function BuildUrlFilter(paging) {
 	return urlFilter;
 }
 
+// Entity types the unauthenticated client endpoint may fetch pre-login. Keep this tight -
+// it constrains the request path so it can't be steered to arbitrary controller endpoints.
+var CLIENT_ALLOWED_TYPES = ["external-jwt-signers"];
+
+// Add the IdP origins of the given signers to the CSP allowlist (add-only; full set is
+// (re)primed at startup by refreshIdpOrigins).
+function mergeIdpOrigins(signers) {
+	var set = new Set(idpConnectOrigins);
+	(signers || []).forEach(function(signer) {
+		var o = originOf(signer.externalAuthUrl);
+		if (o) set.add(o);
+	});
+	idpConnectOrigins = Array.from(set);
+}
+
 // Fetch from the public client API (edge/client/v1) without a session, for pre-login data
 // like external-jwt-signers. See openziti/ziti-console#915.
 function GetClientItems(type, paging, request, response) {
+	if (CLIENT_ALLOWED_TYPES.indexOf(type) === -1) {
+		response.json({data: [], error: "unsupported type"});
+		return;
+	}
 	var controllerBase = GetClientControllerBase(request);
 	if (controllerBase==null||controllerBase.trim().length==0) {
 		response.json({data: []});
@@ -914,6 +934,8 @@ function GetClientItems(type, paging, request, response) {
 			log("Server Error (client): "+JSON.stringify(err));
 			response.json({data: [], error: err});
 		} else if (body && body.data) {
+			// keep the CSP IdP allowlist current from the signers we just fetched
+			if (type === "external-jwt-signers") mergeIdpOrigins(body.data);
 			response.json(body);
 		} else {
 			response.json({data: []});
@@ -926,13 +948,15 @@ function GetClientItems(type, paging, request, response) {
 function GetClientControllerBase(request) {
 	if (request.body.controllerUrl) {
 		var requested = trimTrailingSlash(request.body.controllerUrl);
-		var known = false;
+		var match = "";
 		if (settings.edgeControllers) {
 			settings.edgeControllers.forEach(function(controller) {
-				if (trimTrailingSlash(controller.url) === requested) known = true;
+				// Return the configured (trusted) URL on match, never the request value, so the
+				// request target can't be influenced by user input.
+				if (trimTrailingSlash(controller.url) === requested) match = trimTrailingSlash(controller.url);
 			});
 		}
-		return known ? requested : "";
+		return match;
 	}
 	var fallback = request.session.baseUrl || baseUrl;
 	return fallback ? trimTrailingSlash(fallback) : "";

--- a/server.js
+++ b/server.js
@@ -105,7 +105,14 @@ const processControllerUrls = (urlString) => {
 // slash (see processControllerUrls), but the console can submit the URL with
 // one — an exact-match check then fails ("Invalid Edge Controller"), and a
 // trailing slash also produces a double slash when request paths are appended.
-const trimTrailingSlash = (url) => (typeof url === 'string' ? url.replace(/\/+$/, '') : url);
+const trimTrailingSlash = (url) => {
+	// Linear scan instead of /\/+$/ - the regex backtracks quadratically on long runs of '/'
+	// (CodeQL js/polynomial-redos). Strips all trailing slashes with no backtracking.
+	if (typeof url !== 'string') return url;
+	var end = url.length;
+	while (end > 0 && url.charCodeAt(end - 1) === 47 /* '/' */) end--;
+	return url.slice(0, end);
+};
 
 var ziti;
 const zitiServiceName = process.env.ZITI_SERVICE_NAME || 'zac';

--- a/server.js
+++ b/server.js
@@ -182,8 +182,7 @@ if (integration !== 'classic') {
 	helmetOptions.contentSecurityPolicy.directives.scriptSrcAttr.push("'unsafe-eval'");
 }
 
-// Dynamic CSP: allow connect/frame-src only to configured signers' IdP origins so the
-// browser OIDC flow works without a wildcard. Extra origins via ZAC_CSP_CONNECT_SRC.
+// Dynamic CSP: allow connect/frame-src only to configured signers' IdP origins (no wildcard). Extra via ZAC_CSP_CONNECT_SRC.
 let idpConnectOrigins = [];
 const extraCspConnect = (process.env.ZAC_CSP_CONNECT_SRC || '')
 	.split(',').map(function(s) { return s.trim(); }).filter(Boolean);
@@ -359,8 +358,7 @@ for (var i=0; i<settings.edgeControllers.length; i++) {
 	}
 }
 
-// Prime the IdP CSP allowlist at startup; thereafter it is refreshed opportunistically when
-// the login page fetches signers (see GetClientItems / mergeIdpOrigins).
+// Prime the CSP IdP allowlist at startup; refreshed later on the login page's signer fetch.
 refreshIdpOrigins();
 
 var transporter;
@@ -899,12 +897,10 @@ function BuildUrlFilter(paging) {
 	return urlFilter;
 }
 
-// Entity types the unauthenticated client endpoint may fetch pre-login. Keep this tight -
-// it constrains the request path so it can't be steered to arbitrary controller endpoints.
+// Entity types the unauthenticated client endpoint may fetch pre-login.
 var CLIENT_ALLOWED_TYPES = ["external-jwt-signers"];
 
-// Add the IdP origins of the given signers to the CSP allowlist (add-only; full set is
-// (re)primed at startup by refreshIdpOrigins).
+// Add the given signers' IdP origins to the CSP allowlist (add-only).
 function mergeIdpOrigins(signers) {
 	var set = new Set(idpConnectOrigins);
 	(signers || []).forEach(function(signer) {
@@ -914,20 +910,30 @@ function mergeIdpOrigins(signers) {
 	idpConnectOrigins = Array.from(set);
 }
 
-// Fetch from the public client API (edge/client/v1) without a session, for pre-login data
-// like external-jwt-signers. See openziti/ziti-console#915.
+// Minimal sanitized query for the client fetch: numeric limit/offset only, constant sort.
+function ClientPagingQuery(paging) {
+	var limit = parseInt((paging && paging.total) || 100, 10);
+	if (!(limit > 0)) limit = 100;
+	var page = parseInt((paging && paging.page) || 1, 10);
+	if (!(page > 0)) page = 1;
+	return "?limit=" + limit + "&offset=" + ((page - 1) * limit) + "&sort=name%20asc";
+}
+
+// Pre-login fetch (external-jwt-signers) from the public client API. The URL uses only trusted
+// values - configured controller, allowlisted type, numeric paging - so no user input. #915/#129
 function GetClientItems(type, paging, request, response) {
-	if (CLIENT_ALLOWED_TYPES.indexOf(type) === -1) {
+	var typeIdx = CLIENT_ALLOWED_TYPES.indexOf(type);
+	if (typeIdx === -1) {
 		response.json({data: [], error: "unsupported type"});
 		return;
 	}
+	var safeType = CLIENT_ALLOWED_TYPES[typeIdx]; // from our allowlist, never the request value
 	var controllerBase = GetClientControllerBase(request);
 	if (controllerBase==null||controllerBase.trim().length==0) {
 		response.json({data: []});
 		return;
 	}
-	var urlFilter = BuildUrlFilter(paging);
-	var clientUrl = controllerBase+"/edge/client/v1/"+type+urlFilter;
+	var clientUrl = controllerBase+"/edge/client/v1/"+safeType+ClientPagingQuery(paging);
 	log("Calling (client): "+clientUrl);
 	external.get(clientUrl, {json: {}, rejectUnauthorized: rejectUnauthorized}, function(err, res, body) {
 		if (err) {
@@ -935,7 +941,7 @@ function GetClientItems(type, paging, request, response) {
 			response.json({data: [], error: err});
 		} else if (body && body.data) {
 			// keep the CSP IdP allowlist current from the signers we just fetched
-			if (type === "external-jwt-signers") mergeIdpOrigins(body.data);
+			if (safeType === "external-jwt-signers") mergeIdpOrigins(body.data);
 			response.json(body);
 		} else {
 			response.json({data: []});
@@ -943,16 +949,15 @@ function GetClientItems(type, paging, request, response) {
 	});
 }
 
-// Resolve controller base for a client-API call; honor a browser-supplied controllerUrl only
-// if it matches a configured controller (SSRF guard), else fall back to session/global.
+// Resolve the client-API controller base; a browser controllerUrl is honored only if it matches
+// a configured controller (SSRF guard), else fall back to session/global.
 function GetClientControllerBase(request) {
 	if (request.body.controllerUrl) {
 		var requested = trimTrailingSlash(request.body.controllerUrl);
 		var match = "";
 		if (settings.edgeControllers) {
 			settings.edgeControllers.forEach(function(controller) {
-				// Return the configured (trusted) URL on match, never the request value, so the
-				// request target can't be influenced by user input.
+				// return the configured URL on match, never the request value
 				if (trimTrailingSlash(controller.url) === requested) match = trimTrailingSlash(controller.url);
 			});
 		}

--- a/server.js
+++ b/server.js
@@ -436,6 +436,9 @@ if (integration === 'edge-api') {
 
 app.post("/api/logout", function(request, response) {
     request.session.user = null;
+    // Also drop the stored IdP token, otherwise ReAuthenticate would silently renew the session
+    // on the next request and undo the logout. See #915.
+    request.session.extJwtToken = null;
     response.send({
         success: true,
         message: 'Logout Successful'
@@ -446,30 +449,52 @@ function Authenticate(request) {
 	return new Promise(function(resolve, reject) {
 		if (!baseUrl||baseUrl.trim().length==0&&request.session.baseUrl) baseUrl = request.session.baseUrl;
 		if (!serviceUrl||serviceUrl.trim().length==0&&request.session.serviceUrl) serviceUrl = request.session.serviceUrl;
-		let params = {
-			username: request.body.username,
-			password: request.body.password
-		};
-		log("Connecting to: "+serviceUrl+"/authenticate?method=password");
-		//if (request.session.creds != null) {
-			external.post(serviceUrl+"/authenticate?method=password", {json: params , rejectUnauthorized: rejectUnauthorized }, function(err, res, body) {
-				if (err) {
-					log(err);
-					var error = "Server Not Accessible";
-					if (err.code!="ECONNREFUSED") resolve( {error: err.code} );
-					resolve( {error: error} );
-				} else {
-					if (body.error) resolve( {error: body.error.message} );
-					else {
-						if (body.data&&body.data.token) {
-							request.session.user = body.data.token;
-							request.session.authorization = 100;
-							resolve( {success: "Logged In"} );
-						} else resolve( {error: "Invalid Account"} );
-					}
-				}				
+		// ext-jwt (IdP/OIDC) login: exchange the browser-supplied IdP token for a ziti session via
+		// the controller's ext-jwt authenticator. Otherwise fall back to username/password. See #915.
+		var extJwtToken = request.body.token;
+		var authUrl = serviceUrl + (extJwtToken ? "/authenticate?method=ext-jwt" : "/authenticate?method=password");
+		var options = extJwtToken
+			? {json: {}, rejectUnauthorized: rejectUnauthorized, headers: {authorization: "Bearer "+extJwtToken}}
+			: {json: {username: request.body.username, password: request.body.password}, rejectUnauthorized: rejectUnauthorized};
+		log("Connecting to: "+authUrl);
+		external.post(authUrl, options, function(err, res, body) {
+			if (err) {
+				log(err);
+				var error = "Server Not Accessible";
+				if (err.code!="ECONNREFUSED") resolve( {error: err.code} );
+				resolve( {error: error} );
+			} else {
+				if (body.error) resolve( {error: body.error.message} );
+				else {
+					if (body.data&&body.data.token) {
+						request.session.user = body.data.token;
+						request.session.authorization = 100;
+						// Keep the IdP token (valid well beyond the ziti session) so an expired ziti
+						// session can be renewed without a fresh IdP round-trip. See ReAuthenticate / #915.
+						request.session.extJwtToken = extJwtToken || null;
+						resolve( {success: "Logged In"} );
+					} else resolve( {error: "Invalid Account"} );
+				}
+			}
+		});
+	});
+}
+
+// Renew an expired ziti session from the stored ext-jwt (IdP) token. Returns true if a fresh
+// session token was obtained. Only ext-jwt sessions are renewable this way. See #915.
+function ReAuthenticate(request) {
+	return new Promise(function(resolve) {
+		var token = request.session.extJwtToken;
+		var url = request.session.serviceUrl || serviceUrl;
+		if (!token || !url) { resolve(false); return; }
+		external.post(url+"/authenticate?method=ext-jwt",
+			{json: {}, rejectUnauthorized: rejectUnauthorized, headers: {authorization: "Bearer "+token}},
+			function(err, res, body) {
+				if (!err && body && body.data && body.data.token) {
+					request.session.user = body.data.token;
+					resolve(true);
+				} else resolve(false);
 			});
-		//}
 	});
 }
 
@@ -809,13 +834,18 @@ function DoCall(url, json, request, isFirst=true) {
 				resolve({ error: err });
 			} else {
 				if (body.error) {
-					if (isFirst) {
-						log("Re-authenticate User");
-						//Authenticate(request).then((results) => {
-							DoCall(url, json, request, false).then((results) => {
-								resolve(results);
-							});
-						//});
+					if (isFirst && res && res.statusCode == 401) {
+						log("Session expired - attempting renewal");
+						// Renew the session from the stored ext-jwt token, then retry once. If renewal
+						// isn't possible (password session, or IdP token also expired), return the
+						// original error so the UI prompts for login. See #915.
+						ReAuthenticate(request).then((renewed) => {
+							if (renewed) {
+								DoCall(url, json, request, false).then((results) => {
+									resolve(results);
+								});
+							} else resolve(body);
+						});
 					} else resolve(body);
 				} else if (body.data) {
 					log("Items Returned: "+body.data.length);

--- a/server.js
+++ b/server.js
@@ -259,7 +259,16 @@ app.use(session({
 	// that a concurrent /api/login just wrote the user to. This fixes the ext-jwt "Session Expired"
 	// race, where bootstrap polls wiped the freshly-authenticated session.
 	resave: false,
-	saveUninitialized: false
+	saveUninitialized: false,
+	cookie: {
+		httpOnly: true,
+		// 'auto' sets the Secure attribute only over HTTPS, so the cookie stays usable on the
+		// plain-HTTP dev port yet is never sent in the clear over TLS (CodeQL js/clear-text-cookie).
+		secure: 'auto',
+		// SameSite=Lax keeps the session cookie off cross-site POSTs (CSRF protection) while still
+		// allowing the top-level GET redirect back from an IdP (CodeQL js/missing-token-validation).
+		sameSite: 'lax'
+	}
 }));
 app.use(function (req, res, next) {
 	res.setHeader('X-XSS-Protection', '1; mode=block');
@@ -413,6 +422,9 @@ app.post("/api/login", function(request, response) {
 		GetPath().then((prefix) => {
 			serviceUrl = urlToSet+prefix;
 			request.session.serviceUrl = serviceUrl;
+			// Store the API prefix (resolved from the controller's /version response, not the
+			// request) so the authenticate URL can be rebuilt from the allowlisted base. See #915.
+			request.session.apiPrefix = prefix;
 			//request.session.creds = {
 			//	username: request.body.username,
 			//	password: request.body.password
@@ -448,6 +460,16 @@ app.post("/api/logout", function(request, response) {
     });
 });
 
+// Rebuild the controller service URL from the CONFIGURED (allowlisted) controller base - never the
+// raw request/session value - so anything requested from it targets a trusted host. The prefix is
+// resolved server-side from the controller's /version response, so it isn't user-tainted either.
+// Returns "" when the controller isn't allowlisted. Addresses CodeQL js/request-forgery.
+function GetTrustedServiceUrl(request) {
+	var base = GetClientControllerBase(request);
+	if (!base) return "";
+	return base + (request.session.apiPrefix || "");
+}
+
 function Authenticate(request) {
 	return new Promise(function(resolve, reject) {
 		if (!baseUrl||baseUrl.trim().length==0&&request.session.baseUrl) baseUrl = request.session.baseUrl;
@@ -455,7 +477,9 @@ function Authenticate(request) {
 		// ext-jwt (IdP/OIDC) login: exchange the browser-supplied IdP token for a ziti session via
 		// the controller's ext-jwt authenticator. Otherwise fall back to username/password. See #915.
 		var extJwtToken = request.body.token;
-		var authUrl = serviceUrl + (extJwtToken ? "/authenticate?method=ext-jwt" : "/authenticate?method=password");
+		var trustedServiceUrl = GetTrustedServiceUrl(request);
+		if (!trustedServiceUrl) { resolve({error: errors.invalidServer}); return; }
+		var authUrl = trustedServiceUrl + (extJwtToken ? "/authenticate?method=ext-jwt" : "/authenticate?method=password");
 		var options = extJwtToken
 			? {json: {}, rejectUnauthorized: rejectUnauthorized, headers: {authorization: "Bearer "+extJwtToken}}
 			: {json: {username: request.body.username, password: request.body.password}, rejectUnauthorized: rejectUnauthorized};
@@ -488,7 +512,8 @@ function Authenticate(request) {
 function ReAuthenticate(request) {
 	return new Promise(function(resolve) {
 		var token = request.session.extJwtToken;
-		var url = request.session.serviceUrl || serviceUrl;
+		// Trusted, allowlisted base (see GetTrustedServiceUrl) rather than the raw session value.
+		var url = GetTrustedServiceUrl(request);
 		if (!token || !url) { resolve(false); return; }
 		external.post(url+"/authenticate?method=ext-jwt",
 			{json: {}, rejectUnauthorized: rejectUnauthorized, headers: {authorization: "Bearer "+token}},

--- a/server.js
+++ b/server.js
@@ -182,12 +182,71 @@ if (integration !== 'classic') {
 	helmetOptions.contentSecurityPolicy.directives.scriptSrcAttr.push("'unsafe-eval'");
 }
 
+// --- Dynamic CSP for external OIDC login ------------------------------------
+// OIDC login (discovery, JWKS, token exchange) is a browser fetch from the console
+// to the identity provider. Rather than weaken connect-src to a wildcard, allow only
+// the origins of External JWT Signers the controller admin has already configured as
+// trusted token issuers. The list is refreshed from the controller's public client API
+// (see refreshIdpOrigins) and applied per-request, so newly added signers take effect
+// without a restart. Operators can add extra origins via ZAC_CSP_CONNECT_SRC.
+let idpConnectOrigins = [];
+const extraCspConnect = (process.env.ZAC_CSP_CONNECT_SRC || '')
+	.split(',').map(function(s) { return s.trim(); }).filter(Boolean);
+
+function originOf(url) {
+	try { return new URL(url).origin; } catch (e) { return null; }
+}
+
+function buildHelmetOptions() {
+	var idp = idpConnectOrigins.concat(extraCspConnect);
+	var base = helmetOptions.contentSecurityPolicy.directives;
+	return {
+		contentSecurityPolicy: {
+			directives: Object.assign({}, base, {
+				// concat() returns new arrays, so the base directives are never mutated
+				connectSrc: base.connectSrc.concat(idp),
+				frameSrc: base.frameSrc.concat(idp),
+			}),
+		},
+		frameguard: helmetOptions.frameguard,
+		crossOriginEmbedderPolicy: helmetOptions.crossOriginEmbedderPolicy,
+	};
+}
+
+// Fetch the distinct externalAuthUrl origins of every enabled signer across all
+// configured controllers. Uses the public client API - no session required.
+function refreshIdpOrigins() {
+	var controllers = (settings.edgeControllers || [])
+		.map(function(c) { return trimTrailingSlash(c.url); }).filter(Boolean);
+	if (controllers.length === 0) return;
+	var origins = new Set();
+	var pending = controllers.length;
+	controllers.forEach(function(base) {
+		external.get(base + "/edge/client/v1/external-jwt-signers?limit=500", { rejectUnauthorized: rejectUnauthorized }, function(err, res, body) {
+			try {
+				if (!err && body) {
+					var parsed = (typeof body === 'string') ? JSON.parse(body) : body;
+					(parsed.data || []).forEach(function(signer) {
+						var o = originOf(signer.externalAuthUrl);
+						if (o) origins.add(o);
+					});
+				}
+			} catch (e) { /* ignore an unreachable/malformed controller */ }
+			if (--pending === 0) {
+				idpConnectOrigins = Array.from(origins);
+				log("CSP: IdP connect-src origins: " + (idpConnectOrigins.join(' ') || '(none)'));
+			}
+		});
+	});
+}
+
 app.use("/assets", express.static(__dirname + __assets , {
 	maxAge: '31536000000' 
 }));
 if (`${process.env.ALLOW_HTTP}`.toLowerCase() !== "true") {
 	app.use(cors(corsOptions));
-	app.use(helmet(helmetOptions));
+	// Rebuild options per-request so the CSP reflects the current IdP origin cache.
+	app.use(function(req, res, next) { helmet(buildHelmetOptions())(req, res, next); });
 } else {
 	console.log("ALLOW_HTTP - skipping cors/helmet");
 }
@@ -305,6 +364,11 @@ for (var i=0; i<settings.edgeControllers.length; i++) {
 		break;
 	}
 }
+
+// Prime the IdP CSP allowlist now that controllers/rejectUnauthorized are resolved,
+// then refresh periodically so signers added later are picked up without a restart.
+refreshIdpOrigins();
+setInterval(refreshIdpOrigins, 5 * 60 * 1000);
 
 var transporter;
 
@@ -729,7 +793,11 @@ app.post("/api/call", function(request, response) {
 app.post("/api/data", function(request, response) {
 	var type = request.body.type;
 	var paging = request.body.paging;
-	GetItems(type, paging, request, response);
+	if (request.body.useClient) {
+		GetClientItems(type, paging, request, response);
+	} else {
+		GetItems(type, paging, request, response);
+	}
 });
 
 /**
@@ -791,36 +859,7 @@ function GetItems(type, paging, request, response, cli, serviceCall) {
 	if (request.body.url) {
 		GetSubs(request.body.url.split("./").join(""), request.body.type, "", "", request, response);
 	} else {
-		var urlFilter = "";
-		var toSearchOn = "name";
-		var noSearch = false;
-		if (paging && paging.sort!=null) {
-			if (paging.searchOn) toSearchOn = paging.searchOn;
-			if (paging.noSearch) noSearch = true;
-			if (!paging.filter) paging.filter = "";
-			if (!paging.rawFilter) paging.filter = paging.filter.split('#').join('');
-			if (noSearch) {
-				if (paging.page!=-1) urlFilter = "?limit="+paging.total+"&offset="+((paging.page-1)*paging.total);
-			} else {
-				if (paging.rawFilter) {
-					urlFilter = "?filter=" + paging.filter.trim();
-					if (paging.total) {
-						urlFilter += "&limit="+paging.total;
-					}
-					if (paging.page) {
-						urlFilter += "&offset="+((paging.page-1)*paging.total);
-					}
-					if (paging.sort) {
-						urlFilter += "&sort="+paging.sort+" "+paging.order;
-					}
-				} else if (paging.page!=-1) urlFilter = "?filter=("+toSearchOn+" contains \""+paging.filter+"\")&limit="+paging.total+"&offset="+((paging.page-1)*paging.total)+"&sort="+paging.sort+" "+paging.order;
-				if (paging.params) {
-					for (var key in paging.params) {
-						urlFilter += ((urlFilter.length==0)?"?":"&")+key+"="+paging.params[key];
-					}
-				}
-			}
-		}
+		var urlFilter = BuildUrlFilter(paging);
 		if (serviceUrl==null||serviceUrl.trim().length==0) response.json({error:"loggedout"});
 		else {
 			DoCall(serviceUrl+"/"+type+urlFilter, {}, request, true).then((results) => {
@@ -829,6 +868,92 @@ function GetItems(type, paging, request, response, cli, serviceCall) {
 			});
 		}
 	}
+}
+
+/**
+ * Build the edge API query string (?filter=...&limit=...&offset=...&sort=...) from the
+ * paging parameters supplied by the browser. Shared by the authenticated management path
+ * (GetItems) and the public client path (GetClientItems) so both behave identically.
+ */
+function BuildUrlFilter(paging) {
+	var urlFilter = "";
+	var toSearchOn = "name";
+	var noSearch = false;
+	if (paging && paging.sort!=null) {
+		if (paging.searchOn) toSearchOn = paging.searchOn;
+		if (paging.noSearch) noSearch = true;
+		if (!paging.filter) paging.filter = "";
+		if (!paging.rawFilter) paging.filter = paging.filter.split('#').join('');
+		if (noSearch) {
+			if (paging.page!=-1) urlFilter = "?limit="+paging.total+"&offset="+((paging.page-1)*paging.total);
+		} else {
+			if (paging.rawFilter) {
+				urlFilter = "?filter=" + paging.filter.trim();
+				if (paging.total) {
+					urlFilter += "&limit="+paging.total;
+				}
+				if (paging.page) {
+					urlFilter += "&offset="+((paging.page-1)*paging.total);
+				}
+				if (paging.sort) {
+					urlFilter += "&sort="+paging.sort+" "+paging.order;
+				}
+			} else if (paging.page!=-1) urlFilter = "?filter=("+toSearchOn+" contains \""+paging.filter+"\")&limit="+paging.total+"&offset="+((paging.page-1)*paging.total)+"&sort="+paging.sort+" "+paging.order;
+			if (paging.params) {
+				for (var key in paging.params) {
+					urlFilter += ((urlFilter.length==0)?"?":"&")+key+"="+paging.params[key];
+				}
+			}
+		}
+	}
+	return urlFilter;
+}
+
+/**
+ * Fetch a resource from the controller's public client API (edge/client/v1) without a
+ * session. Used for data the login page needs pre-authentication - e.g. external-jwt-signers,
+ * so the IdP login buttons render in node-server deployments. See openziti/ziti-console#915.
+ */
+function GetClientItems(type, paging, request, response) {
+	var controllerBase = GetClientControllerBase(request);
+	if (controllerBase==null||controllerBase.trim().length==0) {
+		response.json({data: []});
+		return;
+	}
+	var urlFilter = BuildUrlFilter(paging);
+	var clientUrl = controllerBase+"/edge/client/v1/"+type+urlFilter;
+	log("Calling (client): "+clientUrl);
+	external.get(clientUrl, {json: {}, rejectUnauthorized: rejectUnauthorized}, function(err, res, body) {
+		if (err) {
+			log("Server Error (client): "+JSON.stringify(err));
+			response.json({data: [], error: err});
+		} else if (body && body.data) {
+			response.json(body);
+		} else {
+			response.json({data: []});
+		}
+	});
+}
+
+/**
+ * Resolve the controller base URL for a public client-API call. A controllerUrl supplied
+ * by the browser is honored only when it matches a configured controller (guards against
+ * the server being used to reach arbitrary hosts); otherwise fall back to the session /
+ * global controller.
+ */
+function GetClientControllerBase(request) {
+	if (request.body.controllerUrl) {
+		var requested = trimTrailingSlash(request.body.controllerUrl);
+		var known = false;
+		if (settings.edgeControllers) {
+			settings.edgeControllers.forEach(function(controller) {
+				if (trimTrailingSlash(controller.url) === requested) known = true;
+			});
+		}
+		return known ? requested : "";
+	}
+	var fallback = request.session.baseUrl || baseUrl;
+	return fallback ? trimTrailingSlash(fallback) : "";
 }
 
 /**


### PR DESCRIPTION
- server.js: add GetClientItems to fetch the public client API pre-login (controllerUrl validated against configured controllers), and allow configured signer IdP origins in CSP connect-src/frame-src
- login.component.ts / node-data.service.ts: stop gating IdP buttons on allowControllerAdd and route pre-login signer lookups through the client API
- controller-login.service.ts / session-refresh.service.ts: clear the full session on logout and skip the refresh monitor on /callback so a stale expired session can't preempt the login

closes #915 