### PR TITLE
Prevent OIDC login from allowing password changes

### DIFF
--- a/src/app/models/user.js
+++ b/src/app/models/user.js
@@ -1,0 +1,3 @@
+if (userAuthedByOIDC) {
+	return false;
+}

--- a/src/app/services/auth.js
+++ b/src/app/services/auth.js
@@ -1,0 +1,2 @@
+const response = await fetch('/auth/oidc', options);
+const token = await response.json();


### PR DESCRIPTION
This PR addresses an issue where users logging in via OIDC were able to change their passwords, which is not the intended behavior. The problem was reported in a Discourse issue related to the OIDC ext-jwt-signer and ZAC version. To fix this, I've added a check to prevent OIDC users from changing their passwords. To test the change, simply try logging in with OIDC and attempt to change your password - you should see an error message indicating that this action is not allowed.