### PR TITLE
Add max idle time field to service form and update model

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.html
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.component.html
@@ -198,6 +198,22 @@
               </div>
             </lib-form-field-container>
             <lib-form-field-container
+              [title]="'Max Idle Time'"
+              [label]="useStrictReadonlyForm ? '' : 'OPTIONAL'"
+              class="form-field-advanced"
+              >
+              <input
+                type="number"
+                class="form-field-input"
+                min="0"
+                step="1"
+                placeholder="0"
+                [(ngModel)]="formData.maxIdleTimeMillis"
+                [disabled]="useStrictReadonlyForm"
+                id="MaxIdleTimeMillis"
+                />
+            </lib-form-field-container>
+            <lib-form-field-container
               [title]="'Custom Tags'"
               [label]="'OPTIONAL'"
               class="form-field-advanced"

--- a/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
+++ b/projects/ziti-console-lib/src/lib/features/projectable-forms/service/service-form.service.ts
@@ -618,6 +618,7 @@ export class ServiceFormService {
             configs: this.formData?.configs || [],
             encryptionRequired: this.formData?.encryptionRequired,
             terminatorStrategy: this.formData?.terminatorStrategy || '',
+            maxIdleTimeMillis: this.formData?.maxIdleTimeMillis || 0,
             tags: this.formData?.tags || {}
         }
         return data;

--- a/projects/ziti-console-lib/src/lib/models/service.ts
+++ b/projects/ziti-console-lib/src/lib/models/service.ts
@@ -4,5 +4,6 @@ export class Service {
     terminatorStrategy = '';
     roleAttributes: any[] = [];
     tags: any = {};
-    configs: any[] = []
+    configs: any[] = [];
+    maxIdleTimeMillis = 0;
 };


### PR DESCRIPTION
- Introduced a new input field for 'Max Idle Time' in the service form component.
- Updated the service model to include 'maxIdleTimeMillis' with a default value of 0.
- Adjusted the service form service to handle the new 'maxIdleTimeMillis' property in form data.

fix #922 