### PR TITLE
Add centered title style to no-items component

### DIFF
--- a/projects/ziti-console-lib/src/lib/features/no-items/no-items.component.scss
+++ b/projects/ziti-console-lib/src/lib/features/no-items/no-items.component.scss
@@ -93,3 +93,7 @@
   z-index: 9999;
   background: rgba(255, 255, 255, 0.2);
 }
+
+.title {
+  text-align: center;
+}


### PR DESCRIPTION
fix #923 