### PR TITLE
Remove duplicate GET requests on every ziti entity list

### DIFF
--- a/projects/ziti-console-lib/src/lib/shared/list-page-component.class.ts
+++ b/projects/ziti-console-lib/src/lib/shared/list-page-component.class.ts
@@ -19,6 +19,7 @@ import {ListPageServiceClass} from "./list-page-service.class";
 import {inject, Injectable} from "@angular/core";
 import {ManagementPermissionsService} from "../services/management-permissions.service";
 import {Subscription} from "rxjs";
+import {skip} from "rxjs/operators";
 import {ConsoleEventsService} from "../services/console-events.service";
 import {ConfirmComponent} from "../features/confirm/confirm.component";
 import {MatDialog} from "@angular/material/dialog";
@@ -102,9 +103,11 @@ export abstract class ListPageComponent {
                 this.refreshData();
             })
         );
-        this.filterService.pageChanged.subscribe(page => {
-            this.refreshData();
-        });
+        this.subscription.add(
+            this.filterService.pageChanged.pipe(skip(1)).subscribe(page => {
+                this.refreshData();
+            })
+        );
         this.subscription.add(
             this.consoleEvents.closeSideModal.subscribe((event: any) => {
                 this.closeModal();


### PR DESCRIPTION
- Modified the subscription to the pageChanged observable to skip the first emitted value, preventing unnecessary data refresh on initial load.
fix #932 